### PR TITLE
Remove "Speaker -" from meta title on speaker page

### DIFF
--- a/nuxt-app/pages/hall-of-fame/_slug.vue
+++ b/nuxt-app/pages/hall-of-fame/_slug.vue
@@ -435,7 +435,7 @@ export default defineComponent({
         ? getMetaInfo({
             type: 'profile',
             path: route.value.path,
-            title: `Speaker – ${fullName.value}`,
+            title: `${fullName.value}`,
             description: speaker.value.description,
             image: speaker.value.profile_image,
             firstName: speaker.value.first_name,


### PR DESCRIPTION
Having open tabs in your browser, it's easier to scan if you directly see the content and nothing static like "Speaker". 