### PR TITLE
Fix for Publishable Interface

### DIFF
--- a/directus-cms/extensions-src/publishable/src/presentation-publishable.vue
+++ b/directus-cms/extensions-src/publishable/src/presentation-publishable.vue
@@ -21,14 +21,16 @@ function loadFields(collection: string) {
 }
 
 onMounted(async () => {
-  const [itemResponse, fieldResponse] = await Promise.all([
-    loadItem(props.collection, props.primaryKey),
-    loadFields(props.collection),
-  ]);
-  const itemData = itemResponse.data.data;
-  const fieldData = fieldResponse.data.data;
+  if (props.primaryKey !== '+') {
+    const [itemResponse, fieldResponse] = await Promise.all([
+      loadItem(props.collection, props.primaryKey),
+      loadFields(props.collection),
+    ]);
+    const itemData = itemResponse.data.data;
+    const fieldData = fieldResponse.data.data;
 
-  publishable.value = isPublishable(itemData, fieldData);
+    publishable.value = isPublishable(itemData, fieldData);
+  }
 });
 </script>
 


### PR DESCRIPTION
This PR adds condition to check for an existing ID before validating the publishable state.
Newly created items do not have a proper ID yet (it's simply "+", due to routing) and thus the check would fail in an error.

So now, we only start checking the publishable state if an ID !== "+" is present.