### PR TITLE
Add JSON-LD Support

### DIFF
--- a/nuxt-app/helpers/jsonLdGenerator.ts
+++ b/nuxt-app/helpers/jsonLdGenerator.ts
@@ -1,6 +1,6 @@
 import { JsonLD } from 'nuxt-jsonld/dist/types/index.d';
-import { Person, CreativeWorkSeries } from 'schema-dts';
-import { DIRECTUS_CMS_URL } from '~/config';
+import { Person, PodcastEpisode, PodcastSeries, WithContext } from 'schema-dts';
+import { DIRECTUS_CMS_URL, BUZZSPROUT_RSS_FEED_URL } from '~/config';
 import { FileItem, MemberItem, PodcastItem, SpeakerItem } from '~/types';
 import { getPodcastType } from 'shared-code';
 
@@ -13,8 +13,9 @@ function generatePodcastUrl(podcast: PodcastItem): string {
   return `${DIRECTUS_CMS_URL}/podcast/${podcast.slug}`;
 }
 
-function generatePersonFromSpeaker(speaker: SpeakerItem): Person {
+function generatePersonFromSpeaker(speaker: SpeakerItem): WithContext<Person> {
   return {
+    '@context': 'https://schema.org',
     '@type': 'Person',
     givenName: speaker.first_name,
     familyName: speaker.last_name,
@@ -31,8 +32,9 @@ function generatePersonFromSpeaker(speaker: SpeakerItem): Person {
   };
 }
 
-function generatePersonFromMember(member: MemberItem): Person {
+function generatePersonFromMember(member: MemberItem): WithContext<Person> {
   return {
+    '@context': 'https://schema.org',
     '@type': 'Person',
     givenName: member.first_name,
     familyName: member.last_name,
@@ -41,12 +43,14 @@ function generatePersonFromMember(member: MemberItem): Person {
   };
 }
 
-function generateCreativeWorkSeries(): CreativeWorkSeries {
+function generatePodcastSeries(): WithContext<PodcastSeries> {
   return {
-    '@type': 'CreativeWorkSeries',
+    '@context': 'https://schema.org',
+    '@type': 'PodcastSeries',
     name: 'programmier.bar',
     url: 'https://programmier.bar',
     mainEntityOfPage: 'https://programmier.bar',
+    webFeed: BUZZSPROUT_RSS_FEED_URL,
     sameAs: [
       'https://twitter.com/programmierbar',
       'https://www.linkedin.com/company/programmier-bar',
@@ -67,9 +71,9 @@ function generatePodcastEpisodeFromPodcast(
     ...(podcast.members ?? []).map(generatePersonFromMember),
   ];
 
-  const partOfSeries = generateCreativeWorkSeries();
+  const partOfSeries = generatePodcastSeries();
 
-  const podcastEpisode: JsonLD = {
+  const podcastEpisode: WithContext<PodcastEpisode> = {
     '@context': 'https://schema.org',
     '@type': 'PodcastEpisode',
     name: podcast.title,
@@ -88,5 +92,5 @@ function generatePodcastEpisodeFromPodcast(
 export {
   generatePersonFromSpeaker,
   generatePodcastEpisodeFromPodcast,
-  generateCreativeWorkSeries,
+  generatePodcastSeries,
 };

--- a/nuxt-app/helpers/jsonLdGenerator.ts
+++ b/nuxt-app/helpers/jsonLdGenerator.ts
@@ -1,97 +1,86 @@
 import { JsonLD } from 'nuxt-jsonld/dist/types/index.d';
+import { Person, CreativeWorkSeries } from 'schema-dts';
 import { DIRECTUS_CMS_URL } from '~/config';
 import { FileItem, MemberItem, PodcastItem, SpeakerItem } from '~/types';
 import { getPodcastType } from 'shared-code';
 
-function generateImageUrl(image?: FileItem): string{
-  if (!image) return "";
+function generateImageUrl(image?: FileItem): string {
+  if (!image) return '';
   return `${DIRECTUS_CMS_URL}/assets/${image.id}`;
 }
 
-function generatePodcastUrl(podcast: PodcastItem): string{
+function generatePodcastUrl(podcast: PodcastItem): string {
   return `${DIRECTUS_CMS_URL}/podcast/${podcast.slug}`;
 }
 
-function generatePersonFromSpeaker(speaker?: SpeakerItem): JsonLD|null {
-  if (!speaker) return null;
-
+function generatePersonFromSpeaker(speaker: SpeakerItem): Person {
   return {
-    '@context': 'https://schema.org',
     '@type': 'Person',
-    givenName	: speaker.first_name,
+    givenName: speaker.first_name,
     familyName: speaker.last_name,
-    jobTitle : speaker.occupation,
+    jobTitle: speaker.occupation,
     image: generateImageUrl(speaker.profile_image),
-    sameAs : [
+    sameAs: [
       speaker.twitter_url,
       speaker.linkedin_url,
       speaker.instagram_url,
       speaker.github_url,
       speaker.youtube_url,
       speaker.website_url,
-    ].filter((url) => (url && url.length > 0)),
+    ].filter((url) => url && url.length > 0) as string[],
   };
 }
 
-function generatePersonFromMember(member?: MemberItem): JsonLD|null {
-  if (!member) return null;
-
+function generatePersonFromMember(member: MemberItem): Person {
   return {
-    '@context': 'https://schema.org',
     '@type': 'Person',
-    givenName	: member.first_name,
+    givenName: member.first_name,
     familyName: member.last_name,
-    jobTitle : member.occupation,
+    jobTitle: member.occupation,
     image: generateImageUrl(member.normal_image),
   };
 }
 
-function generateCreativeWorkSeries(): JsonLD {
+function generateCreativeWorkSeries(): CreativeWorkSeries {
   return {
-    '@context': 'https://schema.org',
     '@type': 'CreativeWorkSeries',
-    name: "programmier.bar",
-    url: "https://programmier.bar",
-    mainEntityOfPage: "https://programmier.bar",
+    name: 'programmier.bar',
+    url: 'https://programmier.bar',
+    mainEntityOfPage: 'https://programmier.bar',
     sameAs: [
-      "https://twitter.com/programmierbar",
-      "https://www.linkedin.com/company/programmier-bar",
-      "https://www.instagram.com/programmier.bar/",
+      'https://twitter.com/programmierbar',
+      'https://www.linkedin.com/company/programmier-bar',
+      'https://www.instagram.com/programmier.bar/',
     ],
-  }
+  };
 }
 
-function generatePodcastEpisodeFromPodcast(podcast?: PodcastItem): JsonLD|null {
+function generatePodcastEpisodeFromPodcast(
+  podcast?: PodcastItem
+): JsonLD | null {
   if (!podcast) return null;
 
   const type = getPodcastType(podcast);
 
-  const podcastEpisode = {
+  const creator: Person[] = [
+    ...(podcast.speakers ?? []).map(generatePersonFromSpeaker),
+    ...(podcast.members ?? []).map(generatePersonFromMember),
+  ];
+
+  const partOfSeries = generateCreativeWorkSeries();
+
+  const podcastEpisode: JsonLD = {
     '@context': 'https://schema.org',
     '@type': 'PodcastEpisode',
     name: podcast.title,
-    partOfSeries: generateCreativeWorkSeries(),
+    partOfSeries: partOfSeries ?? undefined,
     image: generateImageUrl(podcast.cover_image),
     description: podcast.description,
     datePublished: podcast.published_on,
     episodeNumber: `${type} ${podcast.number}`,
     url: generatePodcastUrl(podcast),
-    creator: null,
+    ...(creator && { creator }),
   };
-
-
-  let creators = [];
-  if (podcast.speakers && podcast.speakers.length > 0) {
-    const speakers= podcast.speakers.map(generatePersonFromSpeaker);
-    creators = [...creators, ...speakers];
-  }
-  if (podcast.members && podcast.members.length > 0) {
-    const members= podcast.members.map(generatePersonFromMember);
-    creators = [...creators, ...members];
-  }
-  podcastEpisode.creator = creators;
-
-  console.log(podcast.members);
 
   return podcastEpisode;
 }
@@ -99,5 +88,5 @@ function generatePodcastEpisodeFromPodcast(podcast?: PodcastItem): JsonLD|null {
 export {
   generatePersonFromSpeaker,
   generatePodcastEpisodeFromPodcast,
-  generateCreativeWorkSeries
-}
+  generateCreativeWorkSeries,
+};

--- a/nuxt-app/helpers/jsonLdGenerator.ts
+++ b/nuxt-app/helpers/jsonLdGenerator.ts
@@ -1,0 +1,103 @@
+import { JsonLD } from 'nuxt-jsonld/dist/types/index.d';
+import { DIRECTUS_CMS_URL } from '~/config';
+import { FileItem, MemberItem, PodcastItem, SpeakerItem } from '~/types';
+import { getPodcastType } from 'shared-code';
+
+function generateImageUrl(image?: FileItem): string{
+  if (!image) return "";
+  return `${DIRECTUS_CMS_URL}/assets/${image.id}`;
+}
+
+function generatePodcastUrl(podcast: PodcastItem): string{
+  return `${DIRECTUS_CMS_URL}/podcast/${podcast.slug}`;
+}
+
+function generatePersonFromSpeaker(speaker?: SpeakerItem): JsonLD|null {
+  if (!speaker) return null;
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    givenName	: speaker.first_name,
+    familyName: speaker.last_name,
+    jobTitle : speaker.occupation,
+    image: generateImageUrl(speaker.profile_image),
+    sameAs : [
+      speaker.twitter_url,
+      speaker.linkedin_url,
+      speaker.instagram_url,
+      speaker.github_url,
+      speaker.youtube_url,
+      speaker.website_url,
+    ].filter((url) => (url && url.length > 0)),
+  };
+}
+
+function generatePersonFromMember(member?: MemberItem): JsonLD|null {
+  if (!member) return null;
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    givenName	: member.first_name,
+    familyName: member.last_name,
+    jobTitle : member.occupation,
+    image: generateImageUrl(member.normal_image),
+  };
+}
+
+function generateCreativeWorkSeries(): JsonLD {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'CreativeWorkSeries',
+    name: "programmier.bar",
+    url: "https://programmier.bar",
+    mainEntityOfPage: "https://programmier.bar",
+    sameAs: [
+      "https://twitter.com/programmierbar",
+      "https://www.linkedin.com/company/programmier-bar",
+      "https://www.instagram.com/programmier.bar/",
+    ],
+  }
+}
+
+function generatePodcastEpisodeFromPodcast(podcast?: PodcastItem): JsonLD|null {
+  if (!podcast) return null;
+
+  const type = getPodcastType(podcast);
+
+  const podcastEpisode = {
+    '@context': 'https://schema.org',
+    '@type': 'PodcastEpisode',
+    name: podcast.title,
+    partOfSeries: generateCreativeWorkSeries(),
+    image: generateImageUrl(podcast.cover_image),
+    description: podcast.description,
+    datePublished: podcast.published_on,
+    episodeNumber: `${type} ${podcast.number}`,
+    url: generatePodcastUrl(podcast),
+    creator: null,
+  };
+
+
+  let creators = [];
+  if (podcast.speakers && podcast.speakers.length > 0) {
+    const speakers= podcast.speakers.map(generatePersonFromSpeaker);
+    creators = [...creators, ...speakers];
+  }
+  if (podcast.members && podcast.members.length > 0) {
+    const members= podcast.members.map(generatePersonFromMember);
+    creators = [...creators, ...members];
+  }
+  podcastEpisode.creator = creators;
+
+  console.log(podcast.members);
+
+  return podcastEpisode;
+}
+
+export {
+  generatePersonFromSpeaker,
+  generatePodcastEpisodeFromPodcast,
+  generateCreativeWorkSeries
+}

--- a/nuxt-app/helpers/jsonLdGenerator.ts
+++ b/nuxt-app/helpers/jsonLdGenerator.ts
@@ -77,13 +77,13 @@ function generatePodcastEpisodeFromPodcast(
     '@context': 'https://schema.org',
     '@type': 'PodcastEpisode',
     name: podcast.title,
-    partOfSeries: partOfSeries ?? undefined,
+    partOfSeries,
     image: generateImageUrl(podcast.cover_image),
     description: podcast.description,
     datePublished: podcast.published_on,
     episodeNumber: `${type} ${podcast.number}`,
     url: generatePodcastUrl(podcast),
-    ...(creator && { creator }),
+    creator,
   };
 
   return podcastEpisode;

--- a/nuxt-app/nuxt.config.ts
+++ b/nuxt-app/nuxt.config.ts
@@ -40,6 +40,7 @@ export default defineNuxtConfig({
     '@nuxt/image-edge',
     // // Sitemap Module for Nuxt
     // '@nuxtjs/sitemap',
+    'nuxt-jsonld',
   ],
 
   // Router configuration: https://nuxtjs.org/docs/configuration-glossary/configuration-router

--- a/nuxt-app/package.json
+++ b/nuxt-app/package.json
@@ -19,6 +19,7 @@
     "core-js": "^3.19.3",
     "h3-zod": "^0.3.10",
     "nodemailer": "^6.9.2",
+    "nuxt-jsonld": "^2.0.8",
     "smoothscroll-polyfill": "^0.4.4",
     "vite-svg-loader": "^4.0.0",
     "zod": "^3.20.6"

--- a/nuxt-app/pages/hall-of-fame/[slug].vue
+++ b/nuxt-app/pages/hall-of-fame/[slug].vue
@@ -239,6 +239,7 @@ import {
   OPEN_SPEAKER_TWITTER_EVENT_ID,
   OPEN_SPEAKER_WEBSITE_EVENT_ID,
   OPEN_SPEAKER_YOUTUBE_EVENT_ID,
+  DIRECTUS_CMS_URL,
 } from '~/config';
 
 import { useLoadingScreen, useLocaleString } from '~/composables';
@@ -392,6 +393,30 @@ const color = computed(
 const fullName = computed(
   () => speaker.value && getFullSpeakerName(speaker.value)
 );
+
+// TODO: Why is this giving linting errors?
+useJsonld(() => {
+  if (!speaker.value) {
+    return null;
+  }
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    givenName	: speaker.value.first_name,
+    familyName: speaker.value.last_name,
+    jobTitle : speaker.value.occupation,
+    image: `${DIRECTUS_CMS_URL}/assets/${speaker.value.profile_image.id}`,
+    sameAs : [
+      speaker.value?.twitter_url,
+      speaker.value?.linkedin_url,
+      speaker.value?.instagram_url,
+      speaker.value?.github_url,
+      speaker.value?.youtube_url,
+      speaker.value?.website_url,
+    ].filter((url) => (url && url.length > 0)),
+  };
+});
 
 // Set page meta data
 useHead(() =>

--- a/nuxt-app/pages/hall-of-fame/[slug].vue
+++ b/nuxt-app/pages/hall-of-fame/[slug].vue
@@ -239,13 +239,13 @@ import {
   OPEN_SPEAKER_TWITTER_EVENT_ID,
   OPEN_SPEAKER_WEBSITE_EVENT_ID,
   OPEN_SPEAKER_YOUTUBE_EVENT_ID,
-  DIRECTUS_CMS_URL,
 } from '~/config';
 
 import { useLoadingScreen, useLocaleString } from '~/composables';
 import { getMetaInfo, trackGoal } from '~/helpers';
 import { directus } from '~/services';
 import { SpeakerItem, PodcastItem, TagItem, PickOfTheDayItem } from '~/types';
+import { generatePersonFromSpeaker } from '~/helpers/jsonLdGenerator';
 
 // Add route and router
 const route = useRoute();
@@ -394,29 +394,7 @@ const fullName = computed(
   () => speaker.value && getFullSpeakerName(speaker.value)
 );
 
-// TODO: Why is this giving linting errors?
-useJsonld(() => {
-  if (!speaker.value) {
-    return null;
-  }
-
-  return {
-    '@context': 'https://schema.org',
-    '@type': 'Person',
-    givenName	: speaker.value.first_name,
-    familyName: speaker.value.last_name,
-    jobTitle : speaker.value.occupation,
-    image: `${DIRECTUS_CMS_URL}/assets/${speaker.value.profile_image.id}`,
-    sameAs : [
-      speaker.value?.twitter_url,
-      speaker.value?.linkedin_url,
-      speaker.value?.instagram_url,
-      speaker.value?.github_url,
-      speaker.value?.youtube_url,
-      speaker.value?.website_url,
-    ].filter((url) => (url && url.length > 0)),
-  };
-});
+useJsonld(generatePersonFromSpeaker(speaker.value));
 
 // Set page meta data
 useHead(() =>

--- a/nuxt-app/pages/hall-of-fame/[slug].vue
+++ b/nuxt-app/pages/hall-of-fame/[slug].vue
@@ -394,7 +394,9 @@ const fullName = computed(
   () => speaker.value && getFullSpeakerName(speaker.value)
 );
 
-useJsonld(generatePersonFromSpeaker(speaker.value));
+if (speaker.value) {
+  useJsonld(generatePersonFromSpeaker(speaker.value));
+}
 
 // Set page meta data
 useHead(() =>

--- a/nuxt-app/pages/index.vue
+++ b/nuxt-app/pages/index.vue
@@ -88,7 +88,7 @@ import { DIRECTUS_CMS_URL } from '../config';
 import { useLoadingScreen, usePageMeta } from '../composables';
 import { directus } from '../services';
 import { HomePage, PodcastItem } from '../types';
-import { generateCreativeWorkSeries, generatePodcastEpisodeFromPodcast } from '~/helpers/jsonLdGenerator';
+import { generatePodcastSeries } from '~/helpers/jsonLdGenerator';
 
 const breadcrumbs = [{ label: 'Home' }];
 
@@ -159,7 +159,7 @@ useLoadingScreen(homePage);
 // Set page meta data
 usePageMeta(homePage);
 
-useJsonld(generateCreativeWorkSeries());
+useJsonld(generatePodcastSeries());
 
 // Create Video URL
 const videoUrl = computed(

--- a/nuxt-app/pages/index.vue
+++ b/nuxt-app/pages/index.vue
@@ -88,6 +88,7 @@ import { DIRECTUS_CMS_URL } from '../config';
 import { useLoadingScreen, usePageMeta } from '../composables';
 import { directus } from '../services';
 import { HomePage, PodcastItem } from '../types';
+import { generateCreativeWorkSeries, generatePodcastEpisodeFromPodcast } from '~/helpers/jsonLdGenerator';
 
 const breadcrumbs = [{ label: 'Home' }];
 
@@ -157,6 +158,8 @@ useLoadingScreen(homePage);
 
 // Set page meta data
 usePageMeta(homePage);
+
+useJsonld(generateCreativeWorkSeries());
 
 // Create Video URL
 const videoUrl = computed(

--- a/nuxt-app/tsconfig.json
+++ b/nuxt-app/tsconfig.json
@@ -1,5 +1,7 @@
 {
   // https://nuxt.com/docs/guide/concepts/typescript
   "extends": "./.nuxt/tsconfig.json",
-
+  "compilerOptions": {
+    "allowArbitraryExtensions": true,
+  }
 }

--- a/nuxt-app/yarn.lock
+++ b/nuxt-app/yarn.lock
@@ -3911,6 +3911,14 @@ nuxi@3.5.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
+nuxt-jsonld@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/nuxt-jsonld/-/nuxt-jsonld-2.0.8.tgz#88381c2cbe683192dbd3b772ba5e2b7c56a01a35"
+  integrity sha512-EnrEdh8q5TKqrY1ZaIU9xe9iqHc0bj/QR5b8BEO2ckWXIR6rHV+XxWMfdHMgGbo6fzrZTLTtlWUG2q0L7q45HQ==
+  dependencies:
+    pathe "^1.1.0"
+    schema-dts "^1.1.2"
+
 nuxt@^3.1.2:
   version "3.5.0"
   resolved "https://registry.npmjs.org/nuxt/-/nuxt-3.5.0.tgz"
@@ -4858,6 +4866,11 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "2.1.2"
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+schema-dts@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/schema-dts/-/schema-dts-1.1.2.tgz#82ccf71b5dcb80065a1cc5941888507a4ce1e44b"
+  integrity sha512-MpNwH0dZJHinVxk9bT8XUdjKTxMYrA5bLtrrGmFA6PTLwlOKnhi67XoRd6/ty+Djt6ZC0slR57qFhZDNMI6DhQ==
 
 schema-utils@^3.0.0:
   version "3.1.2"


### PR DESCRIPTION
Adresses #19 

This PR adds JSON-LD support (conforming to schema.org) for the following pages:

* `/` now includes JSON-LD markup for the general podcast series (according to https://schema.org/CreativeWorkSeries)
* `/podcast/*` now includes JSON-LD markup for the specific podcast episode (according to https://schema.org/PodcastEpisode)
* `/hall-of-fame/*` now includes JSON-LD markup for the specific person (according to https://schema.org/Person)

Given that each of these schemas is rather complex, there certainly are possibilities to include even more detailed information. But this seems like a solid first take.

All pages have been verified via schema.org (see attached screenshots)



<img width="1157" alt="Bildschirmfoto 2023-11-09 um 17 29 04" src="https://github.com/programmierbar/website/assets/1663330/2a958256-ec24-4dad-8dc1-db293fd66bfe">
<img width="1151" alt="Bildschirmfoto 2023-11-09 um 17 29 35" src="https://github.com/programmierbar/website/assets/1663330/22d40d45-8ae9-4e71-a33d-2f57564679fe">
<img width="1162" alt="Bildschirmfoto 2023-11-09 um 17 29 58" src="https://github.com/programmierbar/website/assets/1663330/9d21f7b9-9000-4f3d-892c-d10f726f7d7f">

PS: While the code is functional, some TypeScript warnings have been thrown that I was not able to resolve. Hints are welcome, especially for this file `nuxt-app/helpers/jsonLdGenerator.ts`
