### PR TITLE
Added redirect for webfinger

### DIFF
--- a/nuxt-app/server/middleware/wellKnownWebfinger.ts
+++ b/nuxt-app/server/middleware/wellKnownWebfinger.ts
@@ -1,13 +1,13 @@
 export default eventHandler(function (context) {
-  const incomingUrl = context.path;
-  const toMatch = incomingUrl.substring(0, 22);
+  const incomingPath = context.path;
+  const toMatch = '/.well-known/webfinger';
 
-  if (toMatch !== '/.well-known/webfinger') {
+  if (!incomingPath.startsWith(toMatch)) {
     return;
   }
 
   const externalHost = 'https://social.programmier.bar';
-  const redirectUrl = `${externalHost}${incomingUrl}`;
+  const redirectUrl = `${externalHost}${incomingPath}`;
 
   // Set the response status and location header for redirection
   // And end the response to complete the redirection

--- a/nuxt-app/server/middleware/wellKnownWebfinger.ts
+++ b/nuxt-app/server/middleware/wellKnownWebfinger.ts
@@ -1,0 +1,18 @@
+export default eventHandler(function (context) {
+  const incomingUrl = context.path;
+  const toMatch = incomingUrl.substring(0, 22);
+
+  if (toMatch !== '/.well-known/webfinger') {
+    return;
+  }
+
+  const externalHost = 'https://social.programmier.bar';
+  const redirectUrl = `${externalHost}${incomingUrl}`;
+
+  // Set the response status and location header for redirection
+  // And end the response to complete the redirection
+  context.node.res.writeHead(302, {
+    Location: redirectUrl,
+  });
+  context.node.res.end();
+});


### PR DESCRIPTION
This PR adds support for [Webfinger (RFC 7033)](https://tools.ietf.org/html/rfc7033).

This is mandatory for our usage of `programmier.bar` as our Mastodon domain. But since this app is not handling Mastodon/Webfinger itself we need to have a redirect in place to forward to the respective service that is planned to be available at `social.programmier.bar`. ([See here](https://docs.joinmastodon.org/spec/webfinger/))

Please note that in order for Webfinger to work, we need to include any potential query parameters from the initial request. Hence the somewhat more complex redirect logic that appends the whole original `path` (including query parameters).