### PR TITLE
WIP: Staging

### DIFF
--- a/directus-cms/extensions/hooks/buzzsproutApi/index.js
+++ b/directus-cms/extensions/hooks/buzzsproutApi/index.js
@@ -174,6 +174,12 @@ module.exports = (
       buzzsproutData.artist = 'programmier.bar';
     }
 
+    if (!env.BUZZSPROUT_API_TOKEN) {
+      logger.warning(`${HOOK_NAME} hook: Buzzsprout Hook aborted early, because no API token was set.`);
+      logger.info(`${HOOK_NAME} hook: Would have sent this data: ${JSON.stringify(buzzsproutData)}`);
+      return;
+    }
+
     try {
       // Create or update podcast episode at Buzzsprout
       const buzzsproutResponse = await axios({
@@ -375,6 +381,13 @@ module.exports = (
         payload,
         context,
       });
+
+      if (!buzzsproutData) {
+        logger.info(
+          `${HOOK_NAME} hook: Aborting hook, because no Buzzsprout data was received.`
+        );
+        return;
+      }
 
       // Create update data object
       const updateData = {};


### PR DESCRIPTION
## Staging 
> The `staging` branch is used to build the `programmierbar/cms:staging` docker image which is then used to deploy the staging environment at Digital Ocean.

## Changes

* Added failsafe behavior to buzzsprout hook so that episodes are not unintentionally published twice (once from production and once from staging). Just clear the `BUZZSPROUT_API_TOKEN` environment variable and the hook will fail gracefully, yet log all the data that would have been transmitted (for review/debugging).