### PR TITLE
Added (temporary) raffle page

### DIFF
--- a/nuxt-app/pages/gewinnspiel.vue
+++ b/nuxt-app/pages/gewinnspiel.vue
@@ -29,9 +29,7 @@ const { data: rafflePage } = await useAsyncData(
   () => directus.singleton('raffle_page').read() as Promise<RafflePage>
 );
 
-console.log(rafflePage.value);
-
-if (rafflePage.value && rafflePage.value?.status !== 'published') {
+if (rafflePage.value && rafflePage.value.status !== 'published') {
   throw new Error('The page was not found.');
 }
 

--- a/nuxt-app/pages/gewinnspiel.vue
+++ b/nuxt-app/pages/gewinnspiel.vue
@@ -1,0 +1,50 @@
+<template>
+    <div v-if="rafflePage" class="relative">
+        <div class="container px-6 pb-20 pt-32 md:pb-32 md:pl-48 md:pt-40 lg:pb-52 lg:pr-8 lg:pt-56 2xl:pt-64 3xl:px-8">
+            <Breadcrumbs :breadcrumbs="breadcrumbs" />
+
+            <!-- Heading -->
+            <SectionHeading class="mt-8 md:mt-0" element="h1">
+                {{ rafflePage.heading }}
+            </SectionHeading>
+
+            <!-- Text -->
+            <InnerHtml
+                class="mt-8 space-y-8 break-words text-base font-light text-white md:mt-16 md:text-xl md:leading-normal lg:text-2xl lg:leading-normal"
+                :html="rafflePage.text"
+            />
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { useLoadingScreen } from '../composables';
+import { getMetaInfo } from '../helpers';
+import { directus } from '../services';
+import { RafflePage } from '../types';
+
+const breadcrumbs = [{ label: 'Teilnahmebedingungen und Datenschutz zum Gewinnspiel' }]
+// Query raffle page
+const { data: rafflePage } = await useAsyncData(
+  () => directus.singleton('raffle_page').read() as Promise<RafflePage>
+);
+
+console.log(rafflePage.value);
+
+if (rafflePage.value && rafflePage.value?.status !== 'published') {
+  throw new Error('The page was not found.');
+}
+
+// Set loading screen
+useLoadingScreen(rafflePage)
+
+// Set page meta data
+useHead(
+    getMetaInfo({
+        type: 'website',
+        path: '/gewinnspiel',
+        title: 'Teilnahmebedingungen und Datenschutz zum Gewinnspiel',
+        noIndex: true,
+    })
+)
+</script>

--- a/nuxt-app/types/pages.ts
+++ b/nuxt-app/types/pages.ts
@@ -69,6 +69,12 @@ export interface ImprintPage {
   text: string;
 }
 
+export interface RafflePage {
+  heading: string;
+  text: string;
+  status: string;
+}
+
 export interface PrivacyPage {
   heading: string;
   text: string;


### PR DESCRIPTION
Added a page to (temporarily) display terms and conditions as well as a privacy details for our upcoming raffle.

* All texts are stored in the CMS
* Visibility is controlled via page's status field in CMS