### PR TITLE
Updated the schema file for directus

### DIFF
--- a/directus-cms/schema.json
+++ b/directus-cms/schema.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "directus": "10.2.0",
+  "directus": "10.12.1",
   "vendor": "postgres",
   "collections": [
     {
@@ -19,11 +19,13 @@
         "icon": "folder_copy",
         "item_duplication_fields": null,
         "note": null,
+        "preview_url": null,
         "singleton": false,
         "sort": 1,
         "sort_field": null,
         "translations": null,
-        "unarchive_value": null
+        "unarchive_value": null,
+        "versioning": false
       }
     },
     {
@@ -42,11 +44,13 @@
         "icon": "article",
         "item_duplication_fields": null,
         "note": null,
+        "preview_url": null,
         "singleton": false,
         "sort": 2,
         "sort_field": null,
         "translations": null,
-        "unarchive_value": null
+        "unarchive_value": null,
+        "versioning": false
       }
     },
     {
@@ -65,11 +69,38 @@
         "icon": "share",
         "item_duplication_fields": null,
         "note": null,
+        "preview_url": null,
+        "singleton": false,
+        "sort": 4,
+        "sort_field": null,
+        "translations": null,
+        "unarchive_value": null,
+        "versioning": false
+      }
+    },
+    {
+      "collection": "WIP",
+      "meta": {
+        "accountability": "all",
+        "archive_app_filter": true,
+        "archive_field": null,
+        "archive_value": null,
+        "collapse": "open",
+        "collection": "WIP",
+        "color": null,
+        "display_template": null,
+        "group": null,
+        "hidden": false,
+        "icon": "tools_power_drill",
+        "item_duplication_fields": null,
+        "note": null,
+        "preview_url": null,
         "singleton": false,
         "sort": 3,
         "sort_field": null,
         "translations": null,
-        "unarchive_value": null
+        "unarchive_value": null,
+        "versioning": false
       }
     },
     {
@@ -88,14 +119,77 @@
         "icon": "sticky_note_2",
         "item_duplication_fields": null,
         "note": null,
+        "preview_url": null,
         "singleton": true,
         "sort": 6,
         "sort_field": null,
         "translations": null,
-        "unarchive_value": "draft"
+        "unarchive_value": "draft",
+        "versioning": false
       },
       "schema": {
         "name": "about_page"
+      }
+    },
+    {
+      "collection": "badges",
+      "meta": {
+        "accountability": "all",
+        "archive_app_filter": true,
+        "archive_field": "status",
+        "archive_value": "archived",
+        "collapse": "open",
+        "collection": "badges",
+        "color": null,
+        "display_template": null,
+        "group": "WIP",
+        "hidden": false,
+        "icon": "badge",
+        "item_duplication_fields": null,
+        "note": null,
+        "preview_url": null,
+        "singleton": false,
+        "sort": 1,
+        "sort_field": null,
+        "translations": null,
+        "unarchive_value": "draft",
+        "versioning": false
+      },
+      "schema": {
+        "name": "badges"
+      }
+    },
+    {
+      "collection": "coc_page",
+      "meta": {
+        "accountability": "all",
+        "archive_app_filter": true,
+        "archive_field": "status",
+        "archive_value": "archived",
+        "collapse": "open",
+        "collection": "coc_page",
+        "color": null,
+        "display_template": null,
+        "group": "Pages",
+        "hidden": false,
+        "icon": "shield_with_heart",
+        "item_duplication_fields": null,
+        "note": null,
+        "preview_url": null,
+        "singleton": true,
+        "sort": 10,
+        "sort_field": null,
+        "translations": [
+          {
+            "language": "en-US",
+            "translation": "CoC Page"
+          }
+        ],
+        "unarchive_value": "draft",
+        "versioning": false
+      },
+      "schema": {
+        "name": "coc_page"
       }
     },
     {
@@ -114,14 +208,44 @@
         "icon": "mail",
         "item_duplication_fields": null,
         "note": null,
+        "preview_url": null,
         "singleton": true,
         "sort": 7,
         "sort_field": null,
         "translations": null,
-        "unarchive_value": "draft"
+        "unarchive_value": "draft",
+        "versioning": false
       },
       "schema": {
         "name": "contact_page"
+      }
+    },
+    {
+      "collection": "emojis",
+      "meta": {
+        "accountability": "all",
+        "archive_app_filter": true,
+        "archive_field": "status",
+        "archive_value": "archived",
+        "collapse": "open",
+        "collection": "emojis",
+        "color": null,
+        "display_template": null,
+        "group": "Collections",
+        "hidden": false,
+        "icon": "face_2",
+        "item_duplication_fields": null,
+        "note": null,
+        "preview_url": null,
+        "singleton": false,
+        "sort": 7,
+        "sort_field": "sort",
+        "translations": null,
+        "unarchive_value": "draft",
+        "versioning": false
+      },
+      "schema": {
+        "name": "emojis"
       }
     },
     {
@@ -140,11 +264,13 @@
         "icon": "star_outline",
         "item_duplication_fields": null,
         "note": null,
+        "preview_url": null,
         "singleton": true,
         "sort": 4,
         "sort_field": null,
         "translations": null,
-        "unarchive_value": "draft"
+        "unarchive_value": "draft",
+        "versioning": false
       },
       "schema": {
         "name": "hall_of_fame_page"
@@ -166,11 +292,13 @@
         "icon": "home",
         "item_duplication_fields": null,
         "note": null,
+        "preview_url": null,
         "singleton": true,
         "sort": 1,
         "sort_field": null,
         "translations": null,
-        "unarchive_value": "draft"
+        "unarchive_value": "draft",
+        "versioning": false
       },
       "schema": {
         "name": "home_page"
@@ -192,11 +320,13 @@
         "icon": "import_export",
         "item_duplication_fields": null,
         "note": null,
+        "preview_url": null,
         "singleton": false,
-        "sort": 11,
-        "sort_field": null,
+        "sort": 3,
+        "sort_field": "sort",
         "translations": null,
-        "unarchive_value": null
+        "unarchive_value": null,
+        "versioning": false
       },
       "schema": {
         "name": "home_page_podcasts"
@@ -218,14 +348,72 @@
         "icon": "fingerprint",
         "item_duplication_fields": null,
         "note": null,
+        "preview_url": null,
         "singleton": true,
         "sort": 8,
         "sort_field": null,
         "translations": null,
-        "unarchive_value": "draft"
+        "unarchive_value": "draft",
+        "versioning": false
       },
       "schema": {
         "name": "imprint_page"
+      }
+    },
+    {
+      "collection": "junction_directus_users_profiles",
+      "meta": {
+        "accountability": "all",
+        "archive_app_filter": true,
+        "archive_field": null,
+        "archive_value": null,
+        "collapse": "open",
+        "collection": "junction_directus_users_profiles",
+        "color": null,
+        "display_template": null,
+        "group": null,
+        "hidden": true,
+        "icon": "import_export",
+        "item_duplication_fields": null,
+        "note": null,
+        "preview_url": null,
+        "singleton": false,
+        "sort": null,
+        "sort_field": null,
+        "translations": null,
+        "unarchive_value": null,
+        "versioning": false
+      },
+      "schema": {
+        "name": "junction_directus_users_profiles"
+      }
+    },
+    {
+      "collection": "login_page",
+      "meta": {
+        "accountability": "all",
+        "archive_app_filter": true,
+        "archive_field": "status",
+        "archive_value": "archived",
+        "collapse": "open",
+        "collection": "login_page",
+        "color": null,
+        "display_template": null,
+        "group": "Pages",
+        "hidden": false,
+        "icon": "login",
+        "item_duplication_fields": null,
+        "note": null,
+        "preview_url": null,
+        "singleton": true,
+        "sort": 11,
+        "sort_field": null,
+        "translations": null,
+        "unarchive_value": "draft",
+        "versioning": false
+      },
+      "schema": {
+        "name": "login_page"
       }
     },
     {
@@ -244,11 +432,13 @@
         "icon": "import_export",
         "item_duplication_fields": null,
         "note": null,
+        "preview_url": null,
         "singleton": false,
-        "sort": 1,
-        "sort_field": null,
+        "sort": 4,
+        "sort_field": "sort",
         "translations": null,
-        "unarchive_value": null
+        "unarchive_value": null,
+        "versioning": false
       },
       "schema": {
         "name": "meetup_gallery_images"
@@ -270,11 +460,13 @@
         "icon": "import_export",
         "item_duplication_fields": null,
         "note": null,
+        "preview_url": null,
         "singleton": false,
-        "sort": 2,
-        "sort_field": null,
+        "sort": 5,
+        "sort_field": "sort",
         "translations": null,
-        "unarchive_value": null
+        "unarchive_value": null,
+        "versioning": false
       },
       "schema": {
         "name": "meetup_members"
@@ -296,11 +488,13 @@
         "icon": "event",
         "item_duplication_fields": null,
         "note": null,
+        "preview_url": null,
         "singleton": true,
         "sort": 3,
         "sort_field": null,
         "translations": null,
-        "unarchive_value": "draft"
+        "unarchive_value": "draft",
+        "versioning": false
       },
       "schema": {
         "name": "meetup_page"
@@ -322,11 +516,13 @@
         "icon": "import_export",
         "item_duplication_fields": null,
         "note": null,
+        "preview_url": null,
         "singleton": false,
-        "sort": 3,
-        "sort_field": null,
+        "sort": 6,
+        "sort_field": "sort",
         "translations": null,
-        "unarchive_value": null
+        "unarchive_value": null,
+        "versioning": false
       },
       "schema": {
         "name": "meetup_speakers"
@@ -348,11 +544,13 @@
         "icon": "import_export",
         "item_duplication_fields": null,
         "note": null,
+        "preview_url": null,
         "singleton": false,
-        "sort": 4,
-        "sort_field": null,
+        "sort": 7,
+        "sort_field": "sort",
         "translations": null,
-        "unarchive_value": null
+        "unarchive_value": null,
+        "versioning": false
       },
       "schema": {
         "name": "meetup_tags"
@@ -374,11 +572,13 @@
         "icon": "event",
         "item_duplication_fields": null,
         "note": "Hier findest du all unsere Meetups",
+        "preview_url": null,
         "singleton": false,
-        "sort": 4,
+        "sort": 2,
         "sort_field": "sort",
         "translations": null,
-        "unarchive_value": "draft"
+        "unarchive_value": "draft",
+        "versioning": false
       },
       "schema": {
         "name": "meetups"
@@ -400,11 +600,13 @@
         "icon": "import_export",
         "item_duplication_fields": null,
         "note": null,
+        "preview_url": null,
         "singleton": false,
-        "sort": 5,
-        "sort_field": null,
+        "sort": 8,
+        "sort_field": "sort",
         "translations": null,
-        "unarchive_value": null
+        "unarchive_value": null,
+        "versioning": false
       },
       "schema": {
         "name": "member_tags"
@@ -426,11 +628,13 @@
         "icon": "portrait",
         "item_duplication_fields": null,
         "note": "Hier findest du das programmier.bar Team",
+        "preview_url": null,
         "singleton": false,
-        "sort": 1,
+        "sort": 3,
         "sort_field": "sort",
         "translations": null,
-        "unarchive_value": "draft"
+        "unarchive_value": "draft",
+        "versioning": false
       },
       "schema": {
         "name": "members"
@@ -452,11 +656,13 @@
         "icon": "thumb_up",
         "item_duplication_fields": null,
         "note": null,
+        "preview_url": null,
         "singleton": true,
         "sort": 5,
         "sort_field": null,
         "translations": null,
-        "unarchive_value": "draft"
+        "unarchive_value": "draft",
+        "versioning": false
       },
       "schema": {
         "name": "pick_of_the_day_page"
@@ -478,11 +684,13 @@
         "icon": "import_export",
         "item_duplication_fields": null,
         "note": null,
+        "preview_url": null,
         "singleton": false,
-        "sort": 6,
-        "sort_field": null,
+        "sort": 9,
+        "sort_field": "sort",
         "translations": null,
-        "unarchive_value": null
+        "unarchive_value": null,
+        "versioning": false
       },
       "schema": {
         "name": "pick_of_the_day_tags"
@@ -504,11 +712,13 @@
         "icon": "thumb_up",
         "item_duplication_fields": null,
         "note": "Hier findest du die Picks of the Day aus den Deep Dive Folgen",
+        "preview_url": null,
         "singleton": false,
         "sort": 5,
         "sort_field": "sort",
         "translations": null,
-        "unarchive_value": "draft"
+        "unarchive_value": "draft",
+        "versioning": false
       },
       "schema": {
         "name": "picks_of_the_day"
@@ -530,11 +740,13 @@
         "icon": "import_export",
         "item_duplication_fields": null,
         "note": null,
+        "preview_url": null,
         "singleton": false,
-        "sort": 7,
-        "sort_field": null,
+        "sort": 10,
+        "sort_field": "sort",
         "translations": null,
-        "unarchive_value": null
+        "unarchive_value": null,
+        "versioning": false
       },
       "schema": {
         "name": "podcast_members"
@@ -556,11 +768,13 @@
         "icon": "mic_none",
         "item_duplication_fields": null,
         "note": null,
+        "preview_url": null,
         "singleton": true,
         "sort": 2,
         "sort_field": null,
         "translations": null,
-        "unarchive_value": "draft"
+        "unarchive_value": "draft",
+        "versioning": false
       },
       "schema": {
         "name": "podcast_page"
@@ -582,11 +796,13 @@
         "icon": "import_export",
         "item_duplication_fields": null,
         "note": null,
+        "preview_url": null,
         "singleton": false,
-        "sort": 8,
-        "sort_field": null,
+        "sort": 11,
+        "sort_field": "sort",
         "translations": null,
-        "unarchive_value": null
+        "unarchive_value": null,
+        "versioning": false
       },
       "schema": {
         "name": "podcast_speakers"
@@ -608,11 +824,13 @@
         "icon": "import_export",
         "item_duplication_fields": null,
         "note": null,
+        "preview_url": null,
         "singleton": false,
-        "sort": 9,
-        "sort_field": null,
+        "sort": 12,
+        "sort_field": "sort",
         "translations": null,
-        "unarchive_value": null
+        "unarchive_value": null,
+        "versioning": false
       },
       "schema": {
         "name": "podcast_tags"
@@ -634,11 +852,13 @@
         "icon": "mic_none",
         "item_duplication_fields": null,
         "note": "Hier findest du die einzelnen Podcastfolgen",
+        "preview_url": null,
         "singleton": false,
-        "sort": 3,
+        "sort": 1,
         "sort_field": "sort",
         "translations": null,
-        "unarchive_value": "draft"
+        "unarchive_value": "draft",
+        "versioning": false
       },
       "schema": {
         "name": "podcasts"
@@ -660,14 +880,156 @@
         "icon": "shield",
         "item_duplication_fields": null,
         "note": null,
+        "preview_url": null,
         "singleton": true,
         "sort": 9,
         "sort_field": null,
         "translations": null,
-        "unarchive_value": "draft"
+        "unarchive_value": "draft",
+        "versioning": false
       },
       "schema": {
         "name": "privacy_page"
+      }
+    },
+    {
+      "collection": "profile_creation_page",
+      "meta": {
+        "accountability": "all",
+        "archive_app_filter": true,
+        "archive_field": "status",
+        "archive_value": "archived",
+        "collapse": "open",
+        "collection": "profile_creation_page",
+        "color": null,
+        "display_template": null,
+        "group": "Pages",
+        "hidden": false,
+        "icon": null,
+        "item_duplication_fields": null,
+        "note": null,
+        "preview_url": null,
+        "singleton": true,
+        "sort": 12,
+        "sort_field": null,
+        "translations": null,
+        "unarchive_value": "draft",
+        "versioning": false
+      },
+      "schema": {
+        "name": "profile_creation_page"
+      }
+    },
+    {
+      "collection": "profiles",
+      "meta": {
+        "accountability": "all",
+        "archive_app_filter": true,
+        "archive_field": "status",
+        "archive_value": "archived",
+        "collapse": "open",
+        "collection": "profiles",
+        "color": null,
+        "display_template": null,
+        "group": "Collections",
+        "hidden": false,
+        "icon": "problem",
+        "item_duplication_fields": null,
+        "note": null,
+        "preview_url": null,
+        "singleton": false,
+        "sort": 6,
+        "sort_field": "sort",
+        "translations": null,
+        "unarchive_value": "draft",
+        "versioning": false
+      },
+      "schema": {
+        "name": "profiles"
+      }
+    },
+    {
+      "collection": "profiles_emojis",
+      "meta": {
+        "accountability": "all",
+        "archive_app_filter": true,
+        "archive_field": null,
+        "archive_value": null,
+        "collapse": "open",
+        "collection": "profiles_emojis",
+        "color": null,
+        "display_template": null,
+        "group": "Relations",
+        "hidden": true,
+        "icon": "import_export",
+        "item_duplication_fields": null,
+        "note": null,
+        "preview_url": null,
+        "singleton": false,
+        "sort": 1,
+        "sort_field": null,
+        "translations": null,
+        "unarchive_value": null,
+        "versioning": false
+      },
+      "schema": {
+        "name": "profiles_emojis"
+      }
+    },
+    {
+      "collection": "profiles_tags",
+      "meta": {
+        "accountability": "all",
+        "archive_app_filter": true,
+        "archive_field": null,
+        "archive_value": null,
+        "collapse": "open",
+        "collection": "profiles_tags",
+        "color": null,
+        "display_template": null,
+        "group": "Relations",
+        "hidden": true,
+        "icon": "import_export",
+        "item_duplication_fields": null,
+        "note": null,
+        "preview_url": null,
+        "singleton": false,
+        "sort": 2,
+        "sort_field": null,
+        "translations": null,
+        "unarchive_value": null,
+        "versioning": false
+      },
+      "schema": {
+        "name": "profiles_tags"
+      }
+    },
+    {
+      "collection": "raffle_page",
+      "meta": {
+        "accountability": "all",
+        "archive_app_filter": true,
+        "archive_field": null,
+        "archive_value": null,
+        "collapse": "open",
+        "collection": "raffle_page",
+        "color": null,
+        "display_template": null,
+        "group": "Pages",
+        "hidden": false,
+        "icon": "local_activity",
+        "item_duplication_fields": [],
+        "note": null,
+        "preview_url": null,
+        "singleton": true,
+        "sort": 13,
+        "sort_field": null,
+        "translations": null,
+        "unarchive_value": null,
+        "versioning": false
+      },
+      "schema": {
+        "name": "raffle_page"
       }
     },
     {
@@ -686,11 +1048,13 @@
         "icon": "import_export",
         "item_duplication_fields": null,
         "note": null,
+        "preview_url": null,
         "singleton": false,
-        "sort": 10,
-        "sort_field": null,
+        "sort": 13,
+        "sort_field": "sort",
         "translations": null,
-        "unarchive_value": null
+        "unarchive_value": null,
+        "versioning": false
       },
       "schema": {
         "name": "speaker_tags"
@@ -712,11 +1076,13 @@
         "icon": "record_voice_over",
         "item_duplication_fields": null,
         "note": "Hier findest du die Gäste der programmier.bar",
+        "preview_url": null,
         "singleton": false,
-        "sort": 2,
+        "sort": 4,
         "sort_field": "sort",
         "translations": null,
-        "unarchive_value": "draft"
+        "unarchive_value": "draft",
+        "versioning": false
       },
       "schema": {
         "name": "speakers"
@@ -738,11 +1104,13 @@
         "icon": "local_offer",
         "item_duplication_fields": null,
         "note": "Hier findest du die Tags, mit denen die anderen Inhalte kategorisiert werden",
+        "preview_url": null,
         "singleton": false,
-        "sort": 6,
+        "sort": 8,
         "sort_field": "sort",
         "translations": null,
-        "unarchive_value": "draft"
+        "unarchive_value": "draft",
+        "versioning": false
       },
       "schema": {
         "name": "tags"
@@ -752,39 +1120,41 @@
   "fields": [
     {
       "collection": "about_page",
-      "field": "behind_the_scenes_heading",
-      "type": "string",
+      "field": "id",
+      "type": "uuid",
       "meta": {
         "collection": "about_page",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "behind_the_scenes_heading",
+        "field": "id",
         "group": null,
-        "hidden": false,
+        "hidden": true,
         "interface": "input",
         "note": null,
         "options": null,
-        "readonly": false,
-        "required": true,
-        "sort": 10,
-        "special": null,
+        "readonly": true,
+        "required": false,
+        "sort": 12,
+        "special": [
+          "uuid"
+        ],
         "translations": null,
         "validation": null,
         "validation_message": null,
-        "width": "half"
+        "width": "full"
       },
       "schema": {
-        "name": "behind_the_scenes_heading",
+        "name": "id",
         "table": "about_page",
-        "data_type": "character varying",
+        "data_type": "uuid",
         "default_value": null,
-        "max_length": 255,
+        "max_length": null,
         "numeric_precision": null,
         "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
+        "is_nullable": false,
+        "is_unique": true,
+        "is_primary_key": true,
         "is_generated": false,
         "generation_expression": null,
         "has_auto_increment": false,
@@ -794,46 +1164,75 @@
     },
     {
       "collection": "about_page",
-      "field": "cover_image",
-      "type": "uuid",
+      "field": "status",
+      "type": "string",
       "meta": {
         "collection": "about_page",
         "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "cover_image",
+        "display": "labels",
+        "display_options": {
+          "choices": [
+            {
+              "background": "#00C897",
+              "value": "published"
+            },
+            {
+              "background": "#D3DAE4",
+              "value": "draft"
+            },
+            {
+              "background": "#F7971C",
+              "value": "archived"
+            }
+          ],
+          "showAsDot": true
+        },
+        "field": "status",
         "group": null,
         "hidden": false,
-        "interface": "file-image",
+        "interface": "select-dropdown",
         "note": null,
-        "options": null,
+        "options": {
+          "choices": [
+            {
+              "text": "$t:published",
+              "value": "published"
+            },
+            {
+              "text": "$t:draft",
+              "value": "draft"
+            },
+            {
+              "text": "$t:archived",
+              "value": "archived"
+            }
+          ]
+        },
         "readonly": false,
-        "required": true,
-        "sort": 7,
-        "special": [
-          "file"
-        ],
+        "required": false,
+        "sort": 2,
+        "special": null,
         "translations": null,
         "validation": null,
         "validation_message": null,
         "width": "full"
       },
       "schema": {
-        "name": "cover_image",
+        "name": "status",
         "table": "about_page",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
+        "data_type": "character varying",
+        "default_value": "draft",
+        "max_length": 255,
         "numeric_precision": null,
         "numeric_scale": null,
-        "is_nullable": true,
+        "is_nullable": false,
         "is_unique": false,
         "is_primary_key": false,
         "is_generated": false,
         "generation_expression": null,
         "has_auto_increment": false,
-        "foreign_key_table": "directus_files",
-        "foreign_key_column": "id"
+        "foreign_key_table": null,
+        "foreign_key_column": null
       }
     },
     {
@@ -919,425 +1318,6 @@
         "numeric_precision": null,
         "numeric_scale": null,
         "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "about_page",
-      "field": "divider-content",
-      "type": "alias",
-      "meta": {
-        "collection": "about_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-content",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": {
-          "title": "Content"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 6,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "about_page",
-      "field": "divider-hidden",
-      "type": "alias",
-      "meta": {
-        "collection": "about_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-hidden",
-        "group": null,
-        "hidden": true,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 11,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "about_page",
-      "field": "divider-metadata",
-      "type": "alias",
-      "meta": {
-        "collection": "about_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-metadata",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": {
-          "title": "Metadata"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 1,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "about_page",
-      "field": "id",
-      "type": "uuid",
-      "meta": {
-        "collection": "about_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "id",
-        "group": null,
-        "hidden": true,
-        "interface": "input",
-        "note": null,
-        "options": null,
-        "readonly": true,
-        "required": false,
-        "sort": 12,
-        "special": [
-          "uuid"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "id",
-        "table": "about_page",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": false,
-        "is_unique": true,
-        "is_primary_key": true,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "about_page",
-      "field": "intro_text",
-      "type": "text",
-      "meta": {
-        "collection": "about_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "intro_text",
-        "group": null,
-        "hidden": false,
-        "interface": "input-rich-text-html",
-        "note": null,
-        "options": {
-          "toolbar": [
-            "bold",
-            "code",
-            "customLink",
-            "fullscreen",
-            "italic",
-            "removeformat",
-            "underline"
-          ]
-        },
-        "readonly": false,
-        "required": true,
-        "sort": 8,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "intro_text",
-        "table": "about_page",
-        "data_type": "text",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "about_page",
-      "field": "meta_description",
-      "type": "text",
-      "meta": {
-        "collection": "about_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "meta_description",
-        "group": null,
-        "hidden": false,
-        "interface": "input-multiline",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": true,
-        "sort": 5,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "meta_description",
-        "table": "about_page",
-        "data_type": "text",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "about_page",
-      "field": "meta_title",
-      "type": "string",
-      "meta": {
-        "collection": "about_page",
-        "conditions": null,
-        "display": null,
-        "display_options": {
-          "conditionalFormatting": null
-        },
-        "field": "meta_title",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": true,
-        "sort": 4,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "meta_title",
-        "table": "about_page",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "about_page",
-      "field": "notice-meta",
-      "type": "alias",
-      "meta": {
-        "collection": "about_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "notice-meta",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-notice",
-        "note": null,
-        "options": {
-          "text": "Nach Möglichkeit sollte der Meta-Titel nicht länger als 42 Zeichen lang sein und die Meta-Beschreibung nicht länger als 160 Zeichen."
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 3,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "about_page",
-      "field": "podcast_crew_heading",
-      "type": "string",
-      "meta": {
-        "collection": "about_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "podcast_crew_heading",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": true,
-        "sort": 9,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "podcast_crew_heading",
-        "table": "about_page",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "about_page",
-      "field": "status",
-      "type": "string",
-      "meta": {
-        "collection": "about_page",
-        "conditions": null,
-        "display": "labels",
-        "display_options": {
-          "choices": [
-            {
-              "background": "#00C897",
-              "value": "published"
-            },
-            {
-              "background": "#D3DAE4",
-              "value": "draft"
-            },
-            {
-              "background": "#F7971C",
-              "value": "archived"
-            }
-          ],
-          "showAsDot": true
-        },
-        "field": "status",
-        "group": null,
-        "hidden": false,
-        "interface": "select-dropdown",
-        "note": null,
-        "options": {
-          "choices": [
-            {
-              "text": "$t:published",
-              "value": "published"
-            },
-            {
-              "text": "$t:draft",
-              "value": "draft"
-            },
-            {
-              "text": "$t:archived",
-              "value": "archived"
-            }
-          ]
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 2,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "status",
-        "table": "about_page",
-        "data_type": "character varying",
-        "default_value": "draft",
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": false,
         "is_unique": false,
         "is_primary_key": false,
         "is_generated": false,
@@ -1440,6 +1420,1393 @@
       }
     },
     {
+      "collection": "about_page",
+      "field": "divider-hidden",
+      "type": "alias",
+      "meta": {
+        "collection": "about_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-hidden",
+        "group": null,
+        "hidden": true,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 11,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "about_page",
+      "field": "meta_title",
+      "type": "string",
+      "meta": {
+        "collection": "about_page",
+        "conditions": null,
+        "display": null,
+        "display_options": {
+          "conditionalFormatting": null
+        },
+        "field": "meta_title",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": true,
+        "sort": 4,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "meta_title",
+        "table": "about_page",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "about_page",
+      "field": "meta_description",
+      "type": "text",
+      "meta": {
+        "collection": "about_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "meta_description",
+        "group": null,
+        "hidden": false,
+        "interface": "input-multiline",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": true,
+        "sort": 5,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "meta_description",
+        "table": "about_page",
+        "data_type": "text",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "about_page",
+      "field": "divider-metadata",
+      "type": "alias",
+      "meta": {
+        "collection": "about_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-metadata",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": {
+          "title": "Metadata"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 1,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "about_page",
+      "field": "divider-content",
+      "type": "alias",
+      "meta": {
+        "collection": "about_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-content",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": {
+          "title": "Content"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 6,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "about_page",
+      "field": "intro_text",
+      "type": "text",
+      "meta": {
+        "collection": "about_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "intro_text",
+        "group": null,
+        "hidden": false,
+        "interface": "input-rich-text-html",
+        "note": null,
+        "options": {
+          "toolbar": [
+            "bold",
+            "code",
+            "customLink",
+            "fullscreen",
+            "italic",
+            "removeformat",
+            "underline"
+          ]
+        },
+        "readonly": false,
+        "required": true,
+        "sort": 8,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "intro_text",
+        "table": "about_page",
+        "data_type": "text",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "about_page",
+      "field": "podcast_crew_heading",
+      "type": "string",
+      "meta": {
+        "collection": "about_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "podcast_crew_heading",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": true,
+        "sort": 9,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "podcast_crew_heading",
+        "table": "about_page",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "about_page",
+      "field": "behind_the_scenes_heading",
+      "type": "string",
+      "meta": {
+        "collection": "about_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "behind_the_scenes_heading",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": true,
+        "sort": 10,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "behind_the_scenes_heading",
+        "table": "about_page",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "about_page",
+      "field": "cover_image",
+      "type": "uuid",
+      "meta": {
+        "collection": "about_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "cover_image",
+        "group": null,
+        "hidden": false,
+        "interface": "file-image",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": true,
+        "sort": 7,
+        "special": [
+          "file"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "cover_image",
+        "table": "about_page",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_files",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "about_page",
+      "field": "notice-meta",
+      "type": "alias",
+      "meta": {
+        "collection": "about_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "notice-meta",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-notice",
+        "note": null,
+        "options": {
+          "text": "Nach Möglichkeit sollte der Meta-Titel nicht länger als 42 Zeichen lang sein und die Meta-Beschreibung nicht länger als 160 Zeichen."
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 3,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "badges",
+      "field": "id",
+      "type": "integer",
+      "meta": {
+        "collection": "badges",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "id",
+        "group": null,
+        "hidden": true,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": null,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "id",
+        "table": "badges",
+        "data_type": "integer",
+        "default_value": "nextval('badges_id_seq'::regclass)",
+        "max_length": null,
+        "numeric_precision": 32,
+        "numeric_scale": 0,
+        "is_nullable": false,
+        "is_unique": true,
+        "is_primary_key": true,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": true,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "badges",
+      "field": "status",
+      "type": "string",
+      "meta": {
+        "collection": "badges",
+        "conditions": null,
+        "display": "labels",
+        "display_options": {
+          "choices": [
+            {
+              "text": "$t:published",
+              "value": "published",
+              "foreground": "#FFFFFF",
+              "background": "var(--primary)"
+            },
+            {
+              "text": "$t:draft",
+              "value": "draft",
+              "foreground": "#18222F",
+              "background": "#D3DAE4"
+            },
+            {
+              "text": "$t:archived",
+              "value": "archived",
+              "foreground": "#FFFFFF",
+              "background": "var(--warning)"
+            }
+          ],
+          "showAsDot": true
+        },
+        "field": "status",
+        "group": null,
+        "hidden": true,
+        "interface": "select-dropdown",
+        "note": null,
+        "options": {
+          "choices": [
+            {
+              "text": "$t:published",
+              "value": "published"
+            },
+            {
+              "text": "$t:draft",
+              "value": "draft"
+            },
+            {
+              "text": "$t:archived",
+              "value": "archived"
+            }
+          ]
+        },
+        "readonly": false,
+        "required": false,
+        "sort": null,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "status",
+        "table": "badges",
+        "data_type": "character varying",
+        "default_value": "draft",
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": false,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "badges",
+      "field": "user_created",
+      "type": "uuid",
+      "meta": {
+        "collection": "badges",
+        "conditions": null,
+        "display": "user",
+        "display_options": null,
+        "field": "user_created",
+        "group": null,
+        "hidden": true,
+        "interface": "select-dropdown-m2o",
+        "note": null,
+        "options": {
+          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+        },
+        "readonly": true,
+        "required": false,
+        "sort": null,
+        "special": [
+          "user-created"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "user_created",
+        "table": "badges",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "badges",
+      "field": "date_created",
+      "type": "timestamp",
+      "meta": {
+        "collection": "badges",
+        "conditions": null,
+        "display": "datetime",
+        "display_options": {
+          "relative": true
+        },
+        "field": "date_created",
+        "group": null,
+        "hidden": true,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": null,
+        "special": [
+          "date-created"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "date_created",
+        "table": "badges",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "badges",
+      "field": "user_updated",
+      "type": "uuid",
+      "meta": {
+        "collection": "badges",
+        "conditions": null,
+        "display": "user",
+        "display_options": null,
+        "field": "user_updated",
+        "group": null,
+        "hidden": true,
+        "interface": "select-dropdown-m2o",
+        "note": null,
+        "options": {
+          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+        },
+        "readonly": true,
+        "required": false,
+        "sort": null,
+        "special": [
+          "user-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "user_updated",
+        "table": "badges",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "badges",
+      "field": "date_updated",
+      "type": "timestamp",
+      "meta": {
+        "collection": "badges",
+        "conditions": null,
+        "display": "datetime",
+        "display_options": {
+          "relative": true
+        },
+        "field": "date_updated",
+        "group": null,
+        "hidden": true,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": null,
+        "special": [
+          "date-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "date_updated",
+        "table": "badges",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "badges",
+      "field": "name",
+      "type": "string",
+      "meta": {
+        "collection": "badges",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "name",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": null,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "name",
+        "table": "badges",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "badges",
+      "field": "role",
+      "type": "string",
+      "meta": {
+        "collection": "badges",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "role",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": null,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "role",
+        "table": "badges",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "badges",
+      "field": "company",
+      "type": "string",
+      "meta": {
+        "collection": "badges",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "company",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": null,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "company",
+        "table": "badges",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "badges",
+      "field": "url",
+      "type": "string",
+      "meta": {
+        "collection": "badges",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "url",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": null,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "url",
+        "table": "badges",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "badges",
+      "field": "linked_badge",
+      "type": "string",
+      "meta": {
+        "collection": "badges",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "linked_badge",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": null,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "linked_badge",
+        "table": "badges",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "coc_page",
+      "field": "id",
+      "type": "integer",
+      "meta": {
+        "collection": "coc_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "id",
+        "group": null,
+        "hidden": true,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 1,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "id",
+        "table": "coc_page",
+        "data_type": "integer",
+        "default_value": "nextval('coc_page_id_seq'::regclass)",
+        "max_length": null,
+        "numeric_precision": 32,
+        "numeric_scale": 0,
+        "is_nullable": false,
+        "is_unique": true,
+        "is_primary_key": true,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": true,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "coc_page",
+      "field": "user_created",
+      "type": "uuid",
+      "meta": {
+        "collection": "coc_page",
+        "conditions": null,
+        "display": "user",
+        "display_options": null,
+        "field": "user_created",
+        "group": null,
+        "hidden": true,
+        "interface": "select-dropdown-m2o",
+        "note": null,
+        "options": {
+          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+        },
+        "readonly": true,
+        "required": false,
+        "sort": 5,
+        "special": [
+          "user-created"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "user_created",
+        "table": "coc_page",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "coc_page",
+      "field": "date_created",
+      "type": "timestamp",
+      "meta": {
+        "collection": "coc_page",
+        "conditions": null,
+        "display": "datetime",
+        "display_options": {
+          "relative": true
+        },
+        "field": "date_created",
+        "group": null,
+        "hidden": true,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 6,
+        "special": [
+          "date-created"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "date_created",
+        "table": "coc_page",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "coc_page",
+      "field": "user_updated",
+      "type": "uuid",
+      "meta": {
+        "collection": "coc_page",
+        "conditions": null,
+        "display": "user",
+        "display_options": null,
+        "field": "user_updated",
+        "group": null,
+        "hidden": true,
+        "interface": "select-dropdown-m2o",
+        "note": null,
+        "options": {
+          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+        },
+        "readonly": true,
+        "required": false,
+        "sort": 7,
+        "special": [
+          "user-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "user_updated",
+        "table": "coc_page",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "coc_page",
+      "field": "date_updated",
+      "type": "timestamp",
+      "meta": {
+        "collection": "coc_page",
+        "conditions": null,
+        "display": "datetime",
+        "display_options": {
+          "relative": true
+        },
+        "field": "date_updated",
+        "group": null,
+        "hidden": true,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 8,
+        "special": [
+          "date-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "date_updated",
+        "table": "coc_page",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "coc_page",
+      "field": "status",
+      "type": "string",
+      "meta": {
+        "collection": "coc_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "status",
+        "group": null,
+        "hidden": false,
+        "interface": "select-dropdown",
+        "note": null,
+        "options": {
+          "choices": [
+            {
+              "text": "published",
+              "value": "published"
+            },
+            {
+              "text": "draft",
+              "value": "draft"
+            },
+            {
+              "text": "archived",
+              "value": "archived"
+            }
+          ]
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 2,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "status",
+        "table": "coc_page",
+        "data_type": "character varying",
+        "default_value": "draft",
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "coc_page",
+      "field": "heading",
+      "type": "string",
+      "meta": {
+        "collection": "coc_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "heading",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 3,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "heading",
+        "table": "coc_page",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "coc_page",
+      "field": "text",
+      "type": "text",
+      "meta": {
+        "collection": "coc_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "text",
+        "group": null,
+        "hidden": false,
+        "interface": "input-rich-text-html",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 4,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "text",
+        "table": "coc_page",
+        "data_type": "text",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "contact_page",
+      "field": "id",
+      "type": "uuid",
+      "meta": {
+        "collection": "contact_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "id",
+        "group": null,
+        "hidden": true,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 11,
+        "special": [
+          "uuid"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "id",
+        "table": "contact_page",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": false,
+        "is_unique": true,
+        "is_primary_key": true,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "contact_page",
+      "field": "status",
+      "type": "string",
+      "meta": {
+        "collection": "contact_page",
+        "conditions": null,
+        "display": "labels",
+        "display_options": {
+          "choices": [
+            {
+              "background": "#00C897",
+              "value": "published"
+            },
+            {
+              "background": "#D3DAE4",
+              "value": "draft"
+            },
+            {
+              "background": "#F7971C",
+              "value": "archived"
+            }
+          ],
+          "showAsDot": true
+        },
+        "field": "status",
+        "group": null,
+        "hidden": false,
+        "interface": "select-dropdown",
+        "note": null,
+        "options": {
+          "choices": [
+            {
+              "text": "$t:published",
+              "value": "published"
+            },
+            {
+              "text": "$t:draft",
+              "value": "draft"
+            },
+            {
+              "text": "$t:archived",
+              "value": "archived"
+            }
+          ]
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 2,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "status",
+        "table": "contact_page",
+        "data_type": "character varying",
+        "default_value": "draft",
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": false,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
       "collection": "contact_page",
       "field": "created_by",
       "type": "uuid",
@@ -1517,6 +2884,358 @@
         "name": "created_on",
         "table": "contact_page",
         "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "contact_page",
+      "field": "updated_by",
+      "type": "uuid",
+      "meta": {
+        "collection": "contact_page",
+        "conditions": null,
+        "display": "user",
+        "display_options": null,
+        "field": "updated_by",
+        "group": null,
+        "hidden": true,
+        "interface": "select-dropdown-m2o",
+        "note": null,
+        "options": {
+          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+        },
+        "readonly": true,
+        "required": false,
+        "sort": 14,
+        "special": [
+          "user-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "updated_by",
+        "table": "contact_page",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "contact_page",
+      "field": "updated_on",
+      "type": "timestamp",
+      "meta": {
+        "collection": "contact_page",
+        "conditions": null,
+        "display": "datetime",
+        "display_options": {
+          "relative": true
+        },
+        "field": "updated_on",
+        "group": null,
+        "hidden": true,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 15,
+        "special": [
+          "date-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "updated_on",
+        "table": "contact_page",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "contact_page",
+      "field": "divider-hidden",
+      "type": "alias",
+      "meta": {
+        "collection": "contact_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-hidden",
+        "group": null,
+        "hidden": true,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 10,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "contact_page",
+      "field": "divider-metadata",
+      "type": "alias",
+      "meta": {
+        "collection": "contact_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-metadata",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": {
+          "title": "Metadata"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 1,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "contact_page",
+      "field": "meta_title",
+      "type": "string",
+      "meta": {
+        "collection": "contact_page",
+        "conditions": null,
+        "display": null,
+        "display_options": {
+          "conditionalFormatting": null
+        },
+        "field": "meta_title",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": true,
+        "sort": 4,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "meta_title",
+        "table": "contact_page",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "contact_page",
+      "field": "meta_description",
+      "type": "text",
+      "meta": {
+        "collection": "contact_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "meta_description",
+        "group": null,
+        "hidden": false,
+        "interface": "input-multiline",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": true,
+        "sort": 5,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "meta_description",
+        "table": "contact_page",
+        "data_type": "text",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "contact_page",
+      "field": "notice-meta",
+      "type": "alias",
+      "meta": {
+        "collection": "contact_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "notice-meta",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-notice",
+        "note": null,
+        "options": {
+          "text": "Nach Möglichkeit sollte der Meta-Titel nicht länger als 42 Zeichen lang sein und die Meta-Beschreibung nicht länger als 160 Zeichen."
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 3,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "contact_page",
+      "field": "divider-content",
+      "type": "alias",
+      "meta": {
+        "collection": "contact_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-content",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": {
+          "title": "Content"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 6,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "contact_page",
+      "field": "intro_text",
+      "type": "text",
+      "meta": {
+        "collection": "contact_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "intro_text",
+        "group": null,
+        "hidden": false,
+        "interface": "input-rich-text-html",
+        "note": null,
+        "options": {
+          "toolbar": [
+            "bold",
+            "code",
+            "customLink",
+            "fullscreen",
+            "italic",
+            "removeformat",
+            "underline"
+          ]
+        },
+        "readonly": false,
+        "required": true,
+        "sort": 8,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "intro_text",
+        "table": "contact_page",
+        "data_type": "text",
         "default_value": null,
         "max_length": null,
         "numeric_precision": null,
@@ -1585,138 +3304,6 @@
     },
     {
       "collection": "contact_page",
-      "field": "divider-content",
-      "type": "alias",
-      "meta": {
-        "collection": "contact_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-content",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": {
-          "title": "Content"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 6,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "contact_page",
-      "field": "divider-hidden",
-      "type": "alias",
-      "meta": {
-        "collection": "contact_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-hidden",
-        "group": null,
-        "hidden": true,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 10,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "contact_page",
-      "field": "divider-metadata",
-      "type": "alias",
-      "meta": {
-        "collection": "contact_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-metadata",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": {
-          "title": "Metadata"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 1,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "contact_page",
-      "field": "id",
-      "type": "uuid",
-      "meta": {
-        "collection": "contact_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "id",
-        "group": null,
-        "hidden": true,
-        "interface": "input",
-        "note": null,
-        "options": null,
-        "readonly": true,
-        "required": false,
-        "sort": 11,
-        "special": [
-          "uuid"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "id",
-        "table": "contact_page",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": false,
-        "is_unique": true,
-        "is_primary_key": true,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "contact_page",
       "field": "intro_heading",
       "type": "string",
       "meta": {
@@ -1760,1460 +3347,25 @@
       }
     },
     {
-      "collection": "contact_page",
-      "field": "intro_text",
-      "type": "text",
-      "meta": {
-        "collection": "contact_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "intro_text",
-        "group": null,
-        "hidden": false,
-        "interface": "input-rich-text-html",
-        "note": null,
-        "options": {
-          "toolbar": [
-            "bold",
-            "code",
-            "customLink",
-            "fullscreen",
-            "italic",
-            "removeformat",
-            "underline"
-          ]
-        },
-        "readonly": false,
-        "required": true,
-        "sort": 8,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "intro_text",
-        "table": "contact_page",
-        "data_type": "text",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "contact_page",
-      "field": "meta_description",
-      "type": "text",
-      "meta": {
-        "collection": "contact_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "meta_description",
-        "group": null,
-        "hidden": false,
-        "interface": "input-multiline",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": true,
-        "sort": 5,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "meta_description",
-        "table": "contact_page",
-        "data_type": "text",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "contact_page",
-      "field": "meta_title",
-      "type": "string",
-      "meta": {
-        "collection": "contact_page",
-        "conditions": null,
-        "display": null,
-        "display_options": {
-          "conditionalFormatting": null
-        },
-        "field": "meta_title",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": true,
-        "sort": 4,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "meta_title",
-        "table": "contact_page",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "contact_page",
-      "field": "notice-meta",
+      "collection": "directus_users",
+      "field": "profiles",
       "type": "alias",
       "meta": {
-        "collection": "contact_page",
+        "collection": "directus_users",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "notice-meta",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-notice",
-        "note": null,
-        "options": {
-          "text": "Nach Möglichkeit sollte der Meta-Titel nicht länger als 42 Zeichen lang sein und die Meta-Beschreibung nicht länger als 160 Zeichen."
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 3,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "contact_page",
-      "field": "status",
-      "type": "string",
-      "meta": {
-        "collection": "contact_page",
-        "conditions": null,
-        "display": "labels",
-        "display_options": {
-          "choices": [
-            {
-              "background": "#00C897",
-              "value": "published"
-            },
-            {
-              "background": "#D3DAE4",
-              "value": "draft"
-            },
-            {
-              "background": "#F7971C",
-              "value": "archived"
-            }
-          ],
-          "showAsDot": true
-        },
-        "field": "status",
-        "group": null,
-        "hidden": false,
-        "interface": "select-dropdown",
-        "note": null,
-        "options": {
-          "choices": [
-            {
-              "text": "$t:published",
-              "value": "published"
-            },
-            {
-              "text": "$t:draft",
-              "value": "draft"
-            },
-            {
-              "text": "$t:archived",
-              "value": "archived"
-            }
-          ]
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 2,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "status",
-        "table": "contact_page",
-        "data_type": "character varying",
-        "default_value": "draft",
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": false,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "contact_page",
-      "field": "updated_by",
-      "type": "uuid",
-      "meta": {
-        "collection": "contact_page",
-        "conditions": null,
-        "display": "user",
-        "display_options": null,
-        "field": "updated_by",
-        "group": null,
-        "hidden": true,
-        "interface": "select-dropdown-m2o",
-        "note": null,
-        "options": {
-          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
-        },
-        "readonly": true,
-        "required": false,
-        "sort": 14,
-        "special": [
-          "user-updated"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "updated_by",
-        "table": "contact_page",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "directus_users",
-        "foreign_key_column": "id"
-      }
-    },
-    {
-      "collection": "contact_page",
-      "field": "updated_on",
-      "type": "timestamp",
-      "meta": {
-        "collection": "contact_page",
-        "conditions": null,
-        "display": "datetime",
-        "display_options": {
-          "relative": true
-        },
-        "field": "updated_on",
-        "group": null,
-        "hidden": true,
-        "interface": "datetime",
-        "note": null,
-        "options": null,
-        "readonly": true,
-        "required": false,
-        "sort": 15,
-        "special": [
-          "date-updated"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "updated_on",
-        "table": "contact_page",
-        "data_type": "timestamp with time zone",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "hall_of_fame_page",
-      "field": "created_by",
-      "type": "uuid",
-      "meta": {
-        "collection": "hall_of_fame_page",
-        "conditions": null,
-        "display": "user",
-        "display_options": null,
-        "field": "created_by",
-        "group": null,
-        "hidden": true,
-        "interface": "select-dropdown-m2o",
-        "note": null,
-        "options": {
-          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
-        },
-        "readonly": true,
-        "required": false,
-        "sort": 11,
-        "special": [
-          "user-created"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "created_by",
-        "table": "hall_of_fame_page",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "directus_users",
-        "foreign_key_column": "id"
-      }
-    },
-    {
-      "collection": "hall_of_fame_page",
-      "field": "created_on",
-      "type": "timestamp",
-      "meta": {
-        "collection": "hall_of_fame_page",
-        "conditions": null,
-        "display": "datetime",
-        "display_options": {
-          "relative": true
-        },
-        "field": "created_on",
-        "group": null,
-        "hidden": true,
-        "interface": "datetime",
-        "note": null,
-        "options": null,
-        "readonly": true,
-        "required": false,
-        "sort": 12,
-        "special": [
-          "date-created"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "created_on",
-        "table": "hall_of_fame_page",
-        "data_type": "timestamp with time zone",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "hall_of_fame_page",
-      "field": "divider-content",
-      "type": "alias",
-      "meta": {
-        "collection": "hall_of_fame_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-content",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": {
-          "title": "Content"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 6,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "hall_of_fame_page",
-      "field": "divider-hidden",
-      "type": "alias",
-      "meta": {
-        "collection": "hall_of_fame_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-hidden",
-        "group": null,
-        "hidden": true,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 9,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "hall_of_fame_page",
-      "field": "divider-metadata",
-      "type": "alias",
-      "meta": {
-        "collection": "hall_of_fame_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-metadata",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": {
-          "title": "Metadata"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 1,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "hall_of_fame_page",
-      "field": "id",
-      "type": "uuid",
-      "meta": {
-        "collection": "hall_of_fame_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "id",
-        "group": null,
-        "hidden": true,
-        "interface": "input",
-        "note": null,
-        "options": null,
-        "readonly": true,
-        "required": false,
-        "sort": 10,
-        "special": [
-          "uuid"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "id",
-        "table": "hall_of_fame_page",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": false,
-        "is_unique": true,
-        "is_primary_key": true,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "hall_of_fame_page",
-      "field": "intro_heading",
-      "type": "string",
-      "meta": {
-        "collection": "hall_of_fame_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "intro_heading",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": true,
-        "sort": 7,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "intro_heading",
-        "table": "hall_of_fame_page",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "hall_of_fame_page",
-      "field": "intro_text",
-      "type": "text",
-      "meta": {
-        "collection": "hall_of_fame_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "intro_text",
-        "group": null,
-        "hidden": false,
-        "interface": "input-rich-text-html",
-        "note": null,
-        "options": {
-          "toolbar": [
-            "bold",
-            "code",
-            "customLink",
-            "fullscreen",
-            "italic",
-            "removeformat",
-            "underline"
-          ]
-        },
-        "readonly": false,
-        "required": true,
-        "sort": 8,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "intro_text",
-        "table": "hall_of_fame_page",
-        "data_type": "text",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "hall_of_fame_page",
-      "field": "meta_description",
-      "type": "text",
-      "meta": {
-        "collection": "hall_of_fame_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "meta_description",
-        "group": null,
-        "hidden": false,
-        "interface": "input-multiline",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": true,
-        "sort": 5,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "meta_description",
-        "table": "hall_of_fame_page",
-        "data_type": "text",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "hall_of_fame_page",
-      "field": "meta_title",
-      "type": "string",
-      "meta": {
-        "collection": "hall_of_fame_page",
-        "conditions": null,
-        "display": null,
-        "display_options": {
-          "conditionalFormatting": null
-        },
-        "field": "meta_title",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": true,
-        "sort": 4,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "meta_title",
-        "table": "hall_of_fame_page",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "hall_of_fame_page",
-      "field": "notice-meta",
-      "type": "alias",
-      "meta": {
-        "collection": "hall_of_fame_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "notice-meta",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-notice",
-        "note": null,
-        "options": {
-          "text": "Nach Möglichkeit sollte der Meta-Titel nicht länger als 42 Zeichen lang sein und die Meta-Beschreibung nicht länger als 160 Zeichen."
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 3,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "hall_of_fame_page",
-      "field": "status",
-      "type": "string",
-      "meta": {
-        "collection": "hall_of_fame_page",
-        "conditions": null,
-        "display": "labels",
-        "display_options": {
-          "choices": [
-            {
-              "background": "#00C897",
-              "value": "published"
-            },
-            {
-              "background": "#D3DAE4",
-              "value": "draft"
-            },
-            {
-              "background": "#F7971C",
-              "value": "archived"
-            }
-          ],
-          "showAsDot": true
-        },
-        "field": "status",
-        "group": null,
-        "hidden": false,
-        "interface": "select-dropdown",
-        "note": null,
-        "options": {
-          "choices": [
-            {
-              "text": "$t:published",
-              "value": "published"
-            },
-            {
-              "text": "$t:draft",
-              "value": "draft"
-            },
-            {
-              "text": "$t:archived",
-              "value": "archived"
-            }
-          ]
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 2,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "status",
-        "table": "hall_of_fame_page",
-        "data_type": "character varying",
-        "default_value": "draft",
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": false,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "hall_of_fame_page",
-      "field": "updated_by",
-      "type": "uuid",
-      "meta": {
-        "collection": "hall_of_fame_page",
-        "conditions": null,
-        "display": "user",
-        "display_options": null,
-        "field": "updated_by",
-        "group": null,
-        "hidden": true,
-        "interface": "select-dropdown-m2o",
-        "note": null,
-        "options": {
-          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
-        },
-        "readonly": true,
-        "required": false,
-        "sort": 13,
-        "special": [
-          "user-updated"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "updated_by",
-        "table": "hall_of_fame_page",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "directus_users",
-        "foreign_key_column": "id"
-      }
-    },
-    {
-      "collection": "hall_of_fame_page",
-      "field": "updated_on",
-      "type": "timestamp",
-      "meta": {
-        "collection": "hall_of_fame_page",
-        "conditions": null,
-        "display": "datetime",
-        "display_options": {
-          "relative": true
-        },
-        "field": "updated_on",
-        "group": null,
-        "hidden": true,
-        "interface": "datetime",
-        "note": null,
-        "options": null,
-        "readonly": true,
-        "required": false,
-        "sort": 14,
-        "special": [
-          "date-updated"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "updated_on",
-        "table": "hall_of_fame_page",
-        "data_type": "timestamp with time zone",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "home_page",
-      "field": "created_by",
-      "type": "uuid",
-      "meta": {
-        "collection": "home_page",
-        "conditions": null,
-        "display": "user",
-        "display_options": null,
-        "field": "created_by",
-        "group": null,
-        "hidden": true,
-        "interface": "select-dropdown-m2o",
-        "note": null,
-        "options": {
-          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
-        },
-        "readonly": true,
-        "required": false,
-        "sort": 14,
-        "special": [
-          "user-created"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "created_by",
-        "table": "home_page",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "directus_users",
-        "foreign_key_column": "id"
-      }
-    },
-    {
-      "collection": "home_page",
-      "field": "created_on",
-      "type": "timestamp",
-      "meta": {
-        "collection": "home_page",
-        "conditions": null,
-        "display": "datetime",
-        "display_options": {
-          "relative": true
-        },
-        "field": "created_on",
-        "group": null,
-        "hidden": true,
-        "interface": "datetime",
-        "note": null,
-        "options": null,
-        "readonly": true,
-        "required": false,
-        "sort": 15,
-        "special": [
-          "date-created"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "created_on",
-        "table": "home_page",
-        "data_type": "timestamp with time zone",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "home_page",
-      "field": "divider-content",
-      "type": "alias",
-      "meta": {
-        "collection": "home_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-content",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": {
-          "title": "Content"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 6,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "home_page",
-      "field": "divider-hidden",
-      "type": "alias",
-      "meta": {
-        "collection": "home_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-hidden",
-        "group": null,
-        "hidden": true,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 12,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "home_page",
-      "field": "divider-metadata",
-      "type": "alias",
-      "meta": {
-        "collection": "home_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-metadata",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": {
-          "title": "Metadata"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 1,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "home_page",
-      "field": "id",
-      "type": "uuid",
-      "meta": {
-        "collection": "home_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "id",
-        "group": null,
-        "hidden": true,
-        "interface": "input",
-        "note": null,
-        "options": null,
-        "readonly": true,
-        "required": false,
-        "sort": 13,
-        "special": [
-          "uuid"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "id",
-        "table": "home_page",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": false,
-        "is_unique": true,
-        "is_primary_key": true,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "home_page",
-      "field": "intro_heading",
-      "type": "string",
-      "meta": {
-        "collection": "home_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "intro_heading",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": true,
-        "sort": 7,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "intro_heading",
-        "table": "home_page",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "home_page",
-      "field": "meta_description",
-      "type": "text",
-      "meta": {
-        "collection": "home_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "meta_description",
-        "group": null,
-        "hidden": false,
-        "interface": "input-multiline",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": true,
-        "sort": 5,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "meta_description",
-        "table": "home_page",
-        "data_type": "text",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "home_page",
-      "field": "meta_title",
-      "type": "string",
-      "meta": {
-        "collection": "home_page",
-        "conditions": null,
-        "display": null,
-        "display_options": {
-          "conditionalFormatting": null
-        },
-        "field": "meta_title",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": true,
-        "sort": 4,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "meta_title",
-        "table": "home_page",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "home_page",
-      "field": "news",
-      "type": "json",
-      "meta": {
-        "collection": "home_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "news",
-        "group": null,
-        "hidden": false,
-        "interface": "list",
-        "note": null,
-        "options": {
-          "addLabel": "Add news",
-          "fields": [
-            {
-              "field": "text",
-              "name": "text",
-              "type": "string",
-              "meta": {
-                "field": "text",
-                "width": "full",
-                "type": "string",
-                "interface": "input",
-                "options": {
-                  "trim": true
-                }
-              }
-            }
-          ]
-        },
-        "readonly": false,
-        "required": true,
-        "sort": 9,
-        "special": [
-          "cast-json"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "news",
-        "table": "home_page",
-        "data_type": "json",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "home_page",
-      "field": "notice-meta",
-      "type": "alias",
-      "meta": {
-        "collection": "home_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "notice-meta",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-notice",
-        "note": null,
-        "options": {
-          "text": "Nach Möglichkeit sollte der Meta-Titel nicht länger als 60 Zeichen lang sein und die Meta-Beschreibung nicht länger als 160 Zeichen."
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 3,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "home_page",
-      "field": "podcast_heading",
-      "type": "string",
-      "meta": {
-        "collection": "home_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "podcast_heading",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": true,
-        "sort": 10,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "podcast_heading",
-        "table": "home_page",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "home_page",
-      "field": "podcasts",
-      "type": "alias",
-      "meta": {
-        "collection": "home_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "podcasts",
+        "field": "profiles",
         "group": null,
         "hidden": false,
         "interface": "list-m2m",
         "note": null,
         "options": {
-          "enableCreate": false,
-          "template": "{{podcast_id.title}}"
+          "template": "{{profiles_id.slug}}"
         },
         "readonly": false,
-        "required": true,
-        "sort": 11,
+        "required": false,
+        "sort": 1,
         "special": [
           "m2m"
         ],
@@ -3224,6 +3376,1094 @@
       }
     },
     {
+      "collection": "emojis",
+      "field": "id",
+      "type": "uuid",
+      "meta": {
+        "collection": "emojis",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "id",
+        "group": null,
+        "hidden": true,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 1,
+        "special": [
+          "uuid"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "id",
+        "table": "emojis",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": false,
+        "is_unique": true,
+        "is_primary_key": true,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "emojis",
+      "field": "status",
+      "type": "string",
+      "meta": {
+        "collection": "emojis",
+        "conditions": null,
+        "display": "labels",
+        "display_options": {
+          "choices": [
+            {
+              "text": "$t:published",
+              "value": "published",
+              "color": "var(--theme--primary)",
+              "foreground": "var(--theme--primary)",
+              "background": "var(--theme--primary-background)"
+            },
+            {
+              "text": "$t:draft",
+              "value": "draft",
+              "color": "var(--theme--foreground)",
+              "foreground": "var(--theme--foreground)",
+              "background": "var(--theme--background-normal)"
+            },
+            {
+              "text": "$t:archived",
+              "value": "archived",
+              "color": "var(--theme--warning)",
+              "foreground": "var(--theme--warning)",
+              "background": "var(--theme--warning-background)"
+            }
+          ],
+          "showAsDot": true
+        },
+        "field": "status",
+        "group": null,
+        "hidden": false,
+        "interface": "select-dropdown",
+        "note": null,
+        "options": {
+          "choices": [
+            {
+              "text": "$t:published",
+              "value": "published",
+              "color": "var(--theme--primary)"
+            },
+            {
+              "text": "$t:draft",
+              "value": "draft",
+              "color": "var(--theme--foreground)"
+            },
+            {
+              "text": "$t:archived",
+              "value": "archived",
+              "color": "var(--theme--warning)"
+            }
+          ]
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 2,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "status",
+        "table": "emojis",
+        "data_type": "character varying",
+        "default_value": "draft",
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": false,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "emojis",
+      "field": "sort",
+      "type": "integer",
+      "meta": {
+        "collection": "emojis",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "sort",
+        "group": null,
+        "hidden": true,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 3,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "sort",
+        "table": "emojis",
+        "data_type": "integer",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": 32,
+        "numeric_scale": 0,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "emojis",
+      "field": "user_created",
+      "type": "uuid",
+      "meta": {
+        "collection": "emojis",
+        "conditions": null,
+        "display": "user",
+        "display_options": null,
+        "field": "user_created",
+        "group": null,
+        "hidden": true,
+        "interface": "select-dropdown-m2o",
+        "note": null,
+        "options": {
+          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+        },
+        "readonly": true,
+        "required": false,
+        "sort": 4,
+        "special": [
+          "user-created"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "user_created",
+        "table": "emojis",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "emojis",
+      "field": "date_created",
+      "type": "timestamp",
+      "meta": {
+        "collection": "emojis",
+        "conditions": null,
+        "display": "datetime",
+        "display_options": {
+          "relative": true
+        },
+        "field": "date_created",
+        "group": null,
+        "hidden": true,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 5,
+        "special": [
+          "date-created"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "date_created",
+        "table": "emojis",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "emojis",
+      "field": "user_updated",
+      "type": "uuid",
+      "meta": {
+        "collection": "emojis",
+        "conditions": null,
+        "display": "user",
+        "display_options": null,
+        "field": "user_updated",
+        "group": null,
+        "hidden": true,
+        "interface": "select-dropdown-m2o",
+        "note": null,
+        "options": {
+          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+        },
+        "readonly": true,
+        "required": false,
+        "sort": 6,
+        "special": [
+          "user-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "user_updated",
+        "table": "emojis",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "emojis",
+      "field": "date_updated",
+      "type": "timestamp",
+      "meta": {
+        "collection": "emojis",
+        "conditions": null,
+        "display": "datetime",
+        "display_options": {
+          "relative": true
+        },
+        "field": "date_updated",
+        "group": null,
+        "hidden": true,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 7,
+        "special": [
+          "date-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "date_updated",
+        "table": "emojis",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "emojis",
+      "field": "title",
+      "type": "string",
+      "meta": {
+        "collection": "emojis",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "title",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 8,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "title",
+        "table": "emojis",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "emojis",
+      "field": "display_emoji",
+      "type": "string",
+      "meta": {
+        "collection": "emojis",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "display_emoji",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 9,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "display_emoji",
+        "table": "emojis",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "hall_of_fame_page",
+      "field": "id",
+      "type": "uuid",
+      "meta": {
+        "collection": "hall_of_fame_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "id",
+        "group": null,
+        "hidden": true,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 10,
+        "special": [
+          "uuid"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "id",
+        "table": "hall_of_fame_page",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": false,
+        "is_unique": true,
+        "is_primary_key": true,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "hall_of_fame_page",
+      "field": "status",
+      "type": "string",
+      "meta": {
+        "collection": "hall_of_fame_page",
+        "conditions": null,
+        "display": "labels",
+        "display_options": {
+          "choices": [
+            {
+              "background": "#00C897",
+              "value": "published"
+            },
+            {
+              "background": "#D3DAE4",
+              "value": "draft"
+            },
+            {
+              "background": "#F7971C",
+              "value": "archived"
+            }
+          ],
+          "showAsDot": true
+        },
+        "field": "status",
+        "group": null,
+        "hidden": false,
+        "interface": "select-dropdown",
+        "note": null,
+        "options": {
+          "choices": [
+            {
+              "text": "$t:published",
+              "value": "published"
+            },
+            {
+              "text": "$t:draft",
+              "value": "draft"
+            },
+            {
+              "text": "$t:archived",
+              "value": "archived"
+            }
+          ]
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 2,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "status",
+        "table": "hall_of_fame_page",
+        "data_type": "character varying",
+        "default_value": "draft",
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": false,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "hall_of_fame_page",
+      "field": "created_by",
+      "type": "uuid",
+      "meta": {
+        "collection": "hall_of_fame_page",
+        "conditions": null,
+        "display": "user",
+        "display_options": null,
+        "field": "created_by",
+        "group": null,
+        "hidden": true,
+        "interface": "select-dropdown-m2o",
+        "note": null,
+        "options": {
+          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+        },
+        "readonly": true,
+        "required": false,
+        "sort": 11,
+        "special": [
+          "user-created"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "created_by",
+        "table": "hall_of_fame_page",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "hall_of_fame_page",
+      "field": "created_on",
+      "type": "timestamp",
+      "meta": {
+        "collection": "hall_of_fame_page",
+        "conditions": null,
+        "display": "datetime",
+        "display_options": {
+          "relative": true
+        },
+        "field": "created_on",
+        "group": null,
+        "hidden": true,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 12,
+        "special": [
+          "date-created"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "created_on",
+        "table": "hall_of_fame_page",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "hall_of_fame_page",
+      "field": "updated_by",
+      "type": "uuid",
+      "meta": {
+        "collection": "hall_of_fame_page",
+        "conditions": null,
+        "display": "user",
+        "display_options": null,
+        "field": "updated_by",
+        "group": null,
+        "hidden": true,
+        "interface": "select-dropdown-m2o",
+        "note": null,
+        "options": {
+          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+        },
+        "readonly": true,
+        "required": false,
+        "sort": 13,
+        "special": [
+          "user-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "updated_by",
+        "table": "hall_of_fame_page",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "hall_of_fame_page",
+      "field": "updated_on",
+      "type": "timestamp",
+      "meta": {
+        "collection": "hall_of_fame_page",
+        "conditions": null,
+        "display": "datetime",
+        "display_options": {
+          "relative": true
+        },
+        "field": "updated_on",
+        "group": null,
+        "hidden": true,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 14,
+        "special": [
+          "date-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "updated_on",
+        "table": "hall_of_fame_page",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "hall_of_fame_page",
+      "field": "divider-hidden",
+      "type": "alias",
+      "meta": {
+        "collection": "hall_of_fame_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-hidden",
+        "group": null,
+        "hidden": true,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 9,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "hall_of_fame_page",
+      "field": "divider-metadata",
+      "type": "alias",
+      "meta": {
+        "collection": "hall_of_fame_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-metadata",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": {
+          "title": "Metadata"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 1,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "hall_of_fame_page",
+      "field": "meta_title",
+      "type": "string",
+      "meta": {
+        "collection": "hall_of_fame_page",
+        "conditions": null,
+        "display": null,
+        "display_options": {
+          "conditionalFormatting": null
+        },
+        "field": "meta_title",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": true,
+        "sort": 4,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "meta_title",
+        "table": "hall_of_fame_page",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "hall_of_fame_page",
+      "field": "meta_description",
+      "type": "text",
+      "meta": {
+        "collection": "hall_of_fame_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "meta_description",
+        "group": null,
+        "hidden": false,
+        "interface": "input-multiline",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": true,
+        "sort": 5,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "meta_description",
+        "table": "hall_of_fame_page",
+        "data_type": "text",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "hall_of_fame_page",
+      "field": "intro_heading",
+      "type": "string",
+      "meta": {
+        "collection": "hall_of_fame_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "intro_heading",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": true,
+        "sort": 7,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "intro_heading",
+        "table": "hall_of_fame_page",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "hall_of_fame_page",
+      "field": "intro_text",
+      "type": "text",
+      "meta": {
+        "collection": "hall_of_fame_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "intro_text",
+        "group": null,
+        "hidden": false,
+        "interface": "input-rich-text-html",
+        "note": null,
+        "options": {
+          "toolbar": [
+            "bold",
+            "code",
+            "customLink",
+            "fullscreen",
+            "italic",
+            "removeformat",
+            "underline"
+          ]
+        },
+        "readonly": false,
+        "required": true,
+        "sort": 8,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "intro_text",
+        "table": "hall_of_fame_page",
+        "data_type": "text",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "hall_of_fame_page",
+      "field": "notice-meta",
+      "type": "alias",
+      "meta": {
+        "collection": "hall_of_fame_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "notice-meta",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-notice",
+        "note": null,
+        "options": {
+          "text": "Nach Möglichkeit sollte der Meta-Titel nicht länger als 42 Zeichen lang sein und die Meta-Beschreibung nicht länger als 160 Zeichen."
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 3,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "hall_of_fame_page",
+      "field": "divider-content",
+      "type": "alias",
+      "meta": {
+        "collection": "hall_of_fame_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-content",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": {
+          "title": "Content"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 6,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "home_page",
+      "field": "id",
+      "type": "uuid",
+      "meta": {
+        "collection": "home_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "id",
+        "group": null,
+        "hidden": true,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 13,
+        "special": [
+          "uuid"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "id",
+        "table": "home_page",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": false,
+        "is_unique": true,
+        "is_primary_key": true,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
       "collection": "home_page",
       "field": "status",
       "type": "string",
@@ -3287,6 +4527,98 @@
         "numeric_precision": null,
         "numeric_scale": null,
         "is_nullable": false,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "home_page",
+      "field": "created_by",
+      "type": "uuid",
+      "meta": {
+        "collection": "home_page",
+        "conditions": null,
+        "display": "user",
+        "display_options": null,
+        "field": "created_by",
+        "group": null,
+        "hidden": true,
+        "interface": "select-dropdown-m2o",
+        "note": null,
+        "options": {
+          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+        },
+        "readonly": true,
+        "required": false,
+        "sort": 14,
+        "special": [
+          "user-created"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "created_by",
+        "table": "home_page",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "home_page",
+      "field": "created_on",
+      "type": "timestamp",
+      "meta": {
+        "collection": "home_page",
+        "conditions": null,
+        "display": "datetime",
+        "display_options": {
+          "relative": true
+        },
+        "field": "created_on",
+        "group": null,
+        "hidden": true,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 15,
+        "special": [
+          "date-created"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "created_on",
+        "table": "home_page",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
         "is_unique": false,
         "is_primary_key": false,
         "is_generated": false,
@@ -3390,6 +4722,258 @@
     },
     {
       "collection": "home_page",
+      "field": "divider-hidden",
+      "type": "alias",
+      "meta": {
+        "collection": "home_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-hidden",
+        "group": null,
+        "hidden": true,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 12,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "home_page",
+      "field": "divider-metadata",
+      "type": "alias",
+      "meta": {
+        "collection": "home_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-metadata",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": {
+          "title": "Metadata"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 1,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "home_page",
+      "field": "notice-meta",
+      "type": "alias",
+      "meta": {
+        "collection": "home_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "notice-meta",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-notice",
+        "note": null,
+        "options": {
+          "text": "Nach Möglichkeit sollte der Meta-Titel nicht länger als 60 Zeichen lang sein und die Meta-Beschreibung nicht länger als 160 Zeichen."
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 3,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "home_page",
+      "field": "meta_title",
+      "type": "string",
+      "meta": {
+        "collection": "home_page",
+        "conditions": null,
+        "display": null,
+        "display_options": {
+          "conditionalFormatting": null
+        },
+        "field": "meta_title",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": true,
+        "sort": 4,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "meta_title",
+        "table": "home_page",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "home_page",
+      "field": "meta_description",
+      "type": "text",
+      "meta": {
+        "collection": "home_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "meta_description",
+        "group": null,
+        "hidden": false,
+        "interface": "input-multiline",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": true,
+        "sort": 5,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "meta_description",
+        "table": "home_page",
+        "data_type": "text",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "home_page",
+      "field": "podcast_heading",
+      "type": "string",
+      "meta": {
+        "collection": "home_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "podcast_heading",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": true,
+        "sort": 11,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "podcast_heading",
+        "table": "home_page",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "home_page",
+      "field": "divider-content",
+      "type": "alias",
+      "meta": {
+        "collection": "home_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-content",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": {
+          "title": "Content"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 6,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "home_page",
       "field": "video",
       "type": "uuid",
       "meta": {
@@ -3433,33 +5017,53 @@
       }
     },
     {
-      "collection": "home_page_podcasts",
-      "field": "home_page_id",
-      "type": "uuid",
+      "collection": "home_page",
+      "field": "news",
+      "type": "json",
       "meta": {
-        "collection": "home_page_podcasts",
+        "collection": "home_page",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "home_page_id",
+        "field": "news",
         "group": null,
-        "hidden": true,
-        "interface": null,
+        "hidden": false,
+        "interface": "list",
         "note": null,
-        "options": null,
+        "options": {
+          "addLabel": "Add news",
+          "fields": [
+            {
+              "field": "text",
+              "name": "text",
+              "type": "string",
+              "meta": {
+                "field": "text",
+                "width": "full",
+                "type": "string",
+                "interface": "input",
+                "options": {
+                  "trim": true
+                }
+              }
+            }
+          ]
+        },
         "readonly": false,
-        "required": false,
-        "sort": null,
-        "special": null,
+        "required": true,
+        "sort": 9,
+        "special": [
+          "cast-json"
+        ],
         "translations": null,
         "validation": null,
         "validation_message": null,
         "width": "full"
       },
       "schema": {
-        "name": "home_page_id",
-        "table": "home_page_podcasts",
-        "data_type": "uuid",
+        "name": "news",
+        "table": "home_page",
+        "data_type": "json",
         "default_value": null,
         "max_length": null,
         "numeric_precision": null,
@@ -3470,8 +5074,50 @@
         "is_generated": false,
         "generation_expression": null,
         "has_auto_increment": false,
-        "foreign_key_table": "home_page",
-        "foreign_key_column": "id"
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "home_page",
+      "field": "intro_heading",
+      "type": "string",
+      "meta": {
+        "collection": "home_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "intro_heading",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": true,
+        "sort": 7,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "intro_heading",
+        "table": "home_page",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
       }
     },
     {
@@ -3518,14 +5164,14 @@
     },
     {
       "collection": "home_page_podcasts",
-      "field": "podcast_id",
+      "field": "home_page",
       "type": "uuid",
       "meta": {
         "collection": "home_page_podcasts",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "podcast_id",
+        "field": "home_page",
         "group": null,
         "hidden": true,
         "interface": null,
@@ -3541,7 +5187,49 @@
         "width": "full"
       },
       "schema": {
-        "name": "podcast_id",
+        "name": "home_page",
+        "table": "home_page_podcasts",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "home_page",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "home_page_podcasts",
+      "field": "podcast",
+      "type": "uuid",
+      "meta": {
+        "collection": "home_page_podcasts",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "podcast",
+        "group": null,
+        "hidden": true,
+        "interface": null,
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": null,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "podcast",
         "table": "home_page_podcasts",
         "data_type": "uuid",
         "default_value": null,
@@ -3590,168 +5278,6 @@
         "max_length": null,
         "numeric_precision": 32,
         "numeric_scale": 0,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "imprint_page",
-      "field": "created_by",
-      "type": "uuid",
-      "meta": {
-        "collection": "imprint_page",
-        "conditions": null,
-        "display": "user",
-        "display_options": null,
-        "field": "created_by",
-        "group": null,
-        "hidden": true,
-        "interface": "select-dropdown-m2o",
-        "note": null,
-        "options": {
-          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
-        },
-        "readonly": true,
-        "required": false,
-        "sort": 6,
-        "special": [
-          "user-created"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "created_by",
-        "table": "imprint_page",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "directus_users",
-        "foreign_key_column": "id"
-      }
-    },
-    {
-      "collection": "imprint_page",
-      "field": "created_on",
-      "type": "timestamp",
-      "meta": {
-        "collection": "imprint_page",
-        "conditions": null,
-        "display": "datetime",
-        "display_options": {
-          "relative": true
-        },
-        "field": "created_on",
-        "group": null,
-        "hidden": true,
-        "interface": "datetime",
-        "note": null,
-        "options": null,
-        "readonly": true,
-        "required": false,
-        "sort": 7,
-        "special": [
-          "date-created"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "created_on",
-        "table": "imprint_page",
-        "data_type": "timestamp with time zone",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "imprint_page",
-      "field": "divider-hidden",
-      "type": "alias",
-      "meta": {
-        "collection": "imprint_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-hidden",
-        "group": null,
-        "hidden": true,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 4,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "imprint_page",
-      "field": "heading",
-      "type": "string",
-      "meta": {
-        "collection": "imprint_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "heading",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": true,
-        "sort": 2,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "heading",
-        "table": "imprint_page",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
         "is_nullable": true,
         "is_unique": false,
         "is_primary_key": false,
@@ -3881,48 +5407,82 @@
     },
     {
       "collection": "imprint_page",
-      "field": "text",
-      "type": "text",
+      "field": "created_by",
+      "type": "uuid",
       "meta": {
         "collection": "imprint_page",
         "conditions": null,
-        "display": null,
+        "display": "user",
         "display_options": null,
-        "field": "text",
+        "field": "created_by",
         "group": null,
-        "hidden": false,
-        "interface": "input-rich-text-html",
+        "hidden": true,
+        "interface": "select-dropdown-m2o",
         "note": null,
         "options": {
-          "toolbar": [
-            "blockquote",
-            "bold",
-            "bullist",
-            "code",
-            "customLink",
-            "fullscreen",
-            "h2",
-            "h3",
-            "h4",
-            "italic",
-            "numlist",
-            "removeformat",
-            "underline"
-          ]
+          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
         },
-        "readonly": false,
-        "required": true,
-        "sort": 3,
-        "special": null,
+        "readonly": true,
+        "required": false,
+        "sort": 6,
+        "special": [
+          "user-created"
+        ],
         "translations": null,
         "validation": null,
         "validation_message": null,
-        "width": "full"
+        "width": "half"
       },
       "schema": {
-        "name": "text",
+        "name": "created_by",
         "table": "imprint_page",
-        "data_type": "text",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "imprint_page",
+      "field": "created_on",
+      "type": "timestamp",
+      "meta": {
+        "collection": "imprint_page",
+        "conditions": null,
+        "display": "datetime",
+        "display_options": {
+          "relative": true
+        },
+        "field": "created_on",
+        "group": null,
+        "hidden": true,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 7,
+        "special": [
+          "date-created"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "created_on",
+        "table": "imprint_page",
+        "data_type": "timestamp with time zone",
         "default_value": null,
         "max_length": null,
         "numeric_precision": null,
@@ -4030,18 +5590,619 @@
       }
     },
     {
-      "collection": "meetup_gallery_images",
-      "field": "directus_file_id",
-      "type": "uuid",
+      "collection": "imprint_page",
+      "field": "divider-hidden",
+      "type": "alias",
       "meta": {
-        "collection": "meetup_gallery_images",
+        "collection": "imprint_page",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "directus_file_id",
+        "field": "divider-hidden",
+        "group": null,
+        "hidden": true,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 4,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "imprint_page",
+      "field": "text",
+      "type": "text",
+      "meta": {
+        "collection": "imprint_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "text",
+        "group": null,
+        "hidden": false,
+        "interface": "input-rich-text-html",
+        "note": null,
+        "options": {
+          "toolbar": [
+            "blockquote",
+            "bold",
+            "bullist",
+            "code",
+            "customLink",
+            "fullscreen",
+            "h2",
+            "h3",
+            "h4",
+            "italic",
+            "numlist",
+            "removeformat",
+            "underline"
+          ]
+        },
+        "readonly": false,
+        "required": true,
+        "sort": 3,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "text",
+        "table": "imprint_page",
+        "data_type": "text",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "imprint_page",
+      "field": "heading",
+      "type": "string",
+      "meta": {
+        "collection": "imprint_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "heading",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": true,
+        "sort": 2,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "heading",
+        "table": "imprint_page",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "junction_directus_users_profiles",
+      "field": "id",
+      "type": "integer",
+      "meta": {
+        "collection": "junction_directus_users_profiles",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "id",
         "group": null,
         "hidden": true,
         "interface": null,
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 1,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "id",
+        "table": "junction_directus_users_profiles",
+        "data_type": "integer",
+        "default_value": "nextval('junction_directus_users_profiles_id_seq'::regclass)",
+        "max_length": null,
+        "numeric_precision": 32,
+        "numeric_scale": 0,
+        "is_nullable": false,
+        "is_unique": true,
+        "is_primary_key": true,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": true,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "junction_directus_users_profiles",
+      "field": "directus_users_id",
+      "type": "uuid",
+      "meta": {
+        "collection": "junction_directus_users_profiles",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "directus_users_id",
+        "group": null,
+        "hidden": true,
+        "interface": null,
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 2,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "directus_users_id",
+        "table": "junction_directus_users_profiles",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "junction_directus_users_profiles",
+      "field": "profiles_id",
+      "type": "uuid",
+      "meta": {
+        "collection": "junction_directus_users_profiles",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "profiles_id",
+        "group": null,
+        "hidden": true,
+        "interface": null,
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 3,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "profiles_id",
+        "table": "junction_directus_users_profiles",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "profiles",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "login_page",
+      "field": "id",
+      "type": "integer",
+      "meta": {
+        "collection": "login_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "id",
+        "group": null,
+        "hidden": true,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": null,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "id",
+        "table": "login_page",
+        "data_type": "integer",
+        "default_value": "nextval('login_page_id_seq'::regclass)",
+        "max_length": null,
+        "numeric_precision": 32,
+        "numeric_scale": 0,
+        "is_nullable": false,
+        "is_unique": true,
+        "is_primary_key": true,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": true,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "login_page",
+      "field": "status",
+      "type": "string",
+      "meta": {
+        "collection": "login_page",
+        "conditions": null,
+        "display": "labels",
+        "display_options": {
+          "choices": [
+            {
+              "text": "$t:published",
+              "value": "published",
+              "foreground": "#FFFFFF",
+              "background": "var(--primary)"
+            },
+            {
+              "text": "$t:draft",
+              "value": "draft",
+              "foreground": "#18222F",
+              "background": "#D3DAE4"
+            },
+            {
+              "text": "$t:archived",
+              "value": "archived",
+              "foreground": "#FFFFFF",
+              "background": "var(--warning)"
+            }
+          ],
+          "showAsDot": true
+        },
+        "field": "status",
+        "group": null,
+        "hidden": false,
+        "interface": "select-dropdown",
+        "note": null,
+        "options": {
+          "choices": [
+            {
+              "text": "$t:published",
+              "value": "published"
+            },
+            {
+              "text": "$t:draft",
+              "value": "draft"
+            },
+            {
+              "text": "$t:archived",
+              "value": "archived"
+            }
+          ]
+        },
+        "readonly": false,
+        "required": false,
+        "sort": null,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "status",
+        "table": "login_page",
+        "data_type": "character varying",
+        "default_value": "draft",
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": false,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "login_page",
+      "field": "user_created",
+      "type": "uuid",
+      "meta": {
+        "collection": "login_page",
+        "conditions": null,
+        "display": "user",
+        "display_options": null,
+        "field": "user_created",
+        "group": null,
+        "hidden": true,
+        "interface": "select-dropdown-m2o",
+        "note": null,
+        "options": {
+          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+        },
+        "readonly": true,
+        "required": false,
+        "sort": null,
+        "special": [
+          "user-created"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "user_created",
+        "table": "login_page",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "login_page",
+      "field": "date_created",
+      "type": "timestamp",
+      "meta": {
+        "collection": "login_page",
+        "conditions": null,
+        "display": "datetime",
+        "display_options": {
+          "relative": true
+        },
+        "field": "date_created",
+        "group": null,
+        "hidden": true,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": null,
+        "special": [
+          "date-created"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "date_created",
+        "table": "login_page",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "login_page",
+      "field": "user_updated",
+      "type": "uuid",
+      "meta": {
+        "collection": "login_page",
+        "conditions": null,
+        "display": "user",
+        "display_options": null,
+        "field": "user_updated",
+        "group": null,
+        "hidden": true,
+        "interface": "select-dropdown-m2o",
+        "note": null,
+        "options": {
+          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+        },
+        "readonly": true,
+        "required": false,
+        "sort": null,
+        "special": [
+          "user-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "user_updated",
+        "table": "login_page",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "login_page",
+      "field": "date_updated",
+      "type": "timestamp",
+      "meta": {
+        "collection": "login_page",
+        "conditions": null,
+        "display": "datetime",
+        "display_options": {
+          "relative": true
+        },
+        "field": "date_updated",
+        "group": null,
+        "hidden": true,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": null,
+        "special": [
+          "date-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "date_updated",
+        "table": "login_page",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "login_page",
+      "field": "heading",
+      "type": "string",
+      "meta": {
+        "collection": "login_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "heading",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": true,
+        "sort": null,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "heading",
+        "table": "login_page",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "login_page",
+      "field": "text",
+      "type": "text",
+      "meta": {
+        "collection": "login_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "text",
+        "group": null,
+        "hidden": false,
+        "interface": "input-rich-text-html",
         "note": null,
         "options": null,
         "readonly": false,
@@ -4054,9 +6215,9 @@
         "width": "full"
       },
       "schema": {
-        "name": "directus_file_id",
-        "table": "meetup_gallery_images",
-        "data_type": "uuid",
+        "name": "text",
+        "table": "login_page",
+        "data_type": "text",
         "default_value": null,
         "max_length": null,
         "numeric_precision": null,
@@ -4067,8 +6228,8 @@
         "is_generated": false,
         "generation_expression": null,
         "has_auto_increment": false,
-        "foreign_key_table": "directus_files",
-        "foreign_key_column": "id"
+        "foreign_key_table": null,
+        "foreign_key_column": null
       }
     },
     {
@@ -4115,14 +6276,14 @@
     },
     {
       "collection": "meetup_gallery_images",
-      "field": "meetup_id",
+      "field": "meetup",
       "type": "uuid",
       "meta": {
         "collection": "meetup_gallery_images",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "meetup_id",
+        "field": "meetup",
         "group": null,
         "hidden": true,
         "interface": null,
@@ -4138,7 +6299,7 @@
         "width": "full"
       },
       "schema": {
-        "name": "meetup_id",
+        "name": "meetup",
         "table": "meetup_gallery_images",
         "data_type": "uuid",
         "default_value": null,
@@ -4152,6 +6313,48 @@
         "generation_expression": null,
         "has_auto_increment": false,
         "foreign_key_table": "meetups",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "meetup_gallery_images",
+      "field": "image",
+      "type": "uuid",
+      "meta": {
+        "collection": "meetup_gallery_images",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "image",
+        "group": null,
+        "hidden": true,
+        "interface": null,
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": null,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "image",
+        "table": "meetup_gallery_images",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_files",
         "foreign_key_column": "id"
       }
     },
@@ -4241,14 +6444,14 @@
     },
     {
       "collection": "meetup_members",
-      "field": "meetup_id",
+      "field": "meetup",
       "type": "uuid",
       "meta": {
         "collection": "meetup_members",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "meetup_id",
+        "field": "meetup",
         "group": null,
         "hidden": true,
         "interface": null,
@@ -4264,7 +6467,7 @@
         "width": "full"
       },
       "schema": {
-        "name": "meetup_id",
+        "name": "meetup",
         "table": "meetup_members",
         "data_type": "uuid",
         "default_value": null,
@@ -4283,14 +6486,14 @@
     },
     {
       "collection": "meetup_members",
-      "field": "member_id",
+      "field": "member",
       "type": "uuid",
       "meta": {
         "collection": "meetup_members",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "member_id",
+        "field": "member",
         "group": null,
         "hidden": true,
         "interface": null,
@@ -4306,7 +6509,7 @@
         "width": "full"
       },
       "schema": {
-        "name": "member_id",
+        "name": "member",
         "table": "meetup_members",
         "data_type": "uuid",
         "default_value": null,
@@ -4367,49 +6570,41 @@
     },
     {
       "collection": "meetup_page",
-      "field": "corona_text",
-      "type": "text",
+      "field": "id",
+      "type": "uuid",
       "meta": {
         "collection": "meetup_page",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "corona_text",
+        "field": "id",
         "group": null,
-        "hidden": false,
-        "interface": "input-rich-text-html",
+        "hidden": true,
+        "interface": "input",
         "note": null,
-        "options": {
-          "toolbar": [
-            "bold",
-            "code",
-            "customLink",
-            "fullscreen",
-            "italic",
-            "removeformat",
-            "underline"
-          ]
-        },
-        "readonly": false,
-        "required": true,
-        "sort": 11,
-        "special": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 14,
+        "special": [
+          "uuid"
+        ],
         "translations": null,
         "validation": null,
         "validation_message": null,
         "width": "full"
       },
       "schema": {
-        "name": "corona_text",
+        "name": "id",
         "table": "meetup_page",
-        "data_type": "text",
+        "data_type": "uuid",
         "default_value": null,
         "max_length": null,
         "numeric_precision": null,
         "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
+        "is_nullable": false,
+        "is_unique": true,
+        "is_primary_key": true,
         "is_generated": false,
         "generation_expression": null,
         "has_auto_increment": false,
@@ -4419,46 +6614,75 @@
     },
     {
       "collection": "meetup_page",
-      "field": "cover_image",
-      "type": "uuid",
+      "field": "status",
+      "type": "string",
       "meta": {
         "collection": "meetup_page",
         "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "cover_image",
+        "display": "labels",
+        "display_options": {
+          "choices": [
+            {
+              "background": "#00C897",
+              "value": "published"
+            },
+            {
+              "background": "#D3DAE4",
+              "value": "draft"
+            },
+            {
+              "background": "#F7971C",
+              "value": "archived"
+            }
+          ],
+          "showAsDot": true
+        },
+        "field": "status",
         "group": null,
         "hidden": false,
-        "interface": "file-image",
+        "interface": "select-dropdown",
         "note": null,
-        "options": null,
+        "options": {
+          "choices": [
+            {
+              "text": "$t:published",
+              "value": "published"
+            },
+            {
+              "text": "$t:draft",
+              "value": "draft"
+            },
+            {
+              "text": "$t:archived",
+              "value": "archived"
+            }
+          ]
+        },
         "readonly": false,
-        "required": true,
-        "sort": 7,
-        "special": [
-          "file"
-        ],
+        "required": false,
+        "sort": 2,
+        "special": null,
         "translations": null,
         "validation": null,
         "validation_message": null,
         "width": "full"
       },
       "schema": {
-        "name": "cover_image",
+        "name": "status",
         "table": "meetup_page",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
+        "data_type": "character varying",
+        "default_value": "draft",
+        "max_length": 255,
         "numeric_precision": null,
         "numeric_scale": null,
-        "is_nullable": true,
+        "is_nullable": false,
         "is_unique": false,
         "is_primary_key": false,
         "is_generated": false,
         "generation_expression": null,
         "has_auto_increment": false,
-        "foreign_key_table": "directus_files",
-        "foreign_key_column": "id"
+        "foreign_key_table": null,
+        "foreign_key_column": null
       }
     },
     {
@@ -4555,32 +6779,94 @@
     },
     {
       "collection": "meetup_page",
-      "field": "divider-content",
-      "type": "alias",
+      "field": "updated_by",
+      "type": "uuid",
       "meta": {
         "collection": "meetup_page",
         "conditions": null,
-        "display": null,
+        "display": "user",
         "display_options": null,
-        "field": "divider-content",
+        "field": "updated_by",
         "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
+        "hidden": true,
+        "interface": "select-dropdown-m2o",
         "note": null,
         "options": {
-          "title": "Content"
+          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
         },
-        "readonly": false,
+        "readonly": true,
         "required": false,
-        "sort": 6,
+        "sort": 17,
         "special": [
-          "alias",
-          "no-data"
+          "user-updated"
         ],
         "translations": null,
         "validation": null,
         "validation_message": null,
-        "width": "full"
+        "width": "half"
+      },
+      "schema": {
+        "name": "updated_by",
+        "table": "meetup_page",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "meetup_page",
+      "field": "updated_on",
+      "type": "timestamp",
+      "meta": {
+        "collection": "meetup_page",
+        "conditions": null,
+        "display": "datetime",
+        "display_options": {
+          "relative": true
+        },
+        "field": "updated_on",
+        "group": null,
+        "hidden": true,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 18,
+        "special": [
+          "date-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "updated_on",
+        "table": "meetup_page",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
       }
     },
     {
@@ -4643,41 +6929,147 @@
     },
     {
       "collection": "meetup_page",
-      "field": "id",
-      "type": "uuid",
+      "field": "divider-content",
+      "type": "alias",
       "meta": {
         "collection": "meetup_page",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "id",
+        "field": "divider-content",
         "group": null,
-        "hidden": true,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": {
+          "title": "Content"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 6,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "meetup_page",
+      "field": "notice-meta",
+      "type": "alias",
+      "meta": {
+        "collection": "meetup_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "notice-meta",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-notice",
+        "note": null,
+        "options": {
+          "text": "Nach Möglichkeit sollte der Meta-Titel nicht länger als 42 Zeichen lang sein und die Meta-Beschreibung nicht länger als 160 Zeichen."
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 3,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "meetup_page",
+      "field": "meta_title",
+      "type": "string",
+      "meta": {
+        "collection": "meetup_page",
+        "conditions": null,
+        "display": null,
+        "display_options": {
+          "conditionalFormatting": null
+        },
+        "field": "meta_title",
+        "group": null,
+        "hidden": false,
         "interface": "input",
         "note": null,
-        "options": null,
-        "readonly": true,
-        "required": false,
-        "sort": 14,
-        "special": [
-          "uuid"
-        ],
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": true,
+        "sort": 4,
+        "special": null,
         "translations": null,
         "validation": null,
         "validation_message": null,
         "width": "full"
       },
       "schema": {
-        "name": "id",
+        "name": "meta_title",
         "table": "meetup_page",
-        "data_type": "uuid",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "meetup_page",
+      "field": "meta_description",
+      "type": "text",
+      "meta": {
+        "collection": "meetup_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "meta_description",
+        "group": null,
+        "hidden": false,
+        "interface": "input-multiline",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": true,
+        "sort": 5,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "meta_description",
+        "table": "meetup_page",
+        "data_type": "text",
         "default_value": null,
         "max_length": null,
         "numeric_precision": null,
         "numeric_scale": null,
-        "is_nullable": false,
-        "is_unique": true,
-        "is_primary_key": true,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
         "is_generated": false,
         "generation_expression": null,
         "has_auto_increment": false,
@@ -4852,7 +7244,7 @@
         },
         "readonly": false,
         "required": true,
-        "sort": 12,
+        "sort": 11,
         "special": null,
         "translations": null,
         "validation": null,
@@ -4879,227 +7271,32 @@
     },
     {
       "collection": "meetup_page",
-      "field": "meta_description",
-      "type": "text",
-      "meta": {
-        "collection": "meetup_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "meta_description",
-        "group": null,
-        "hidden": false,
-        "interface": "input-multiline",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": true,
-        "sort": 5,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "meta_description",
-        "table": "meetup_page",
-        "data_type": "text",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "meetup_page",
-      "field": "meta_title",
-      "type": "string",
-      "meta": {
-        "collection": "meetup_page",
-        "conditions": null,
-        "display": null,
-        "display_options": {
-          "conditionalFormatting": null
-        },
-        "field": "meta_title",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": true,
-        "sort": 4,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "meta_title",
-        "table": "meetup_page",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "meetup_page",
-      "field": "notice-meta",
-      "type": "alias",
-      "meta": {
-        "collection": "meetup_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "notice-meta",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-notice",
-        "note": null,
-        "options": {
-          "text": "Nach Möglichkeit sollte der Meta-Titel nicht länger als 42 Zeichen lang sein und die Meta-Beschreibung nicht länger als 160 Zeichen."
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 3,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "meetup_page",
-      "field": "status",
-      "type": "string",
-      "meta": {
-        "collection": "meetup_page",
-        "conditions": null,
-        "display": "labels",
-        "display_options": {
-          "choices": [
-            {
-              "background": "#00C897",
-              "value": "published"
-            },
-            {
-              "background": "#D3DAE4",
-              "value": "draft"
-            },
-            {
-              "background": "#F7971C",
-              "value": "archived"
-            }
-          ],
-          "showAsDot": true
-        },
-        "field": "status",
-        "group": null,
-        "hidden": false,
-        "interface": "select-dropdown",
-        "note": null,
-        "options": {
-          "choices": [
-            {
-              "text": "$t:published",
-              "value": "published"
-            },
-            {
-              "text": "$t:draft",
-              "value": "draft"
-            },
-            {
-              "text": "$t:archived",
-              "value": "archived"
-            }
-          ]
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 2,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "status",
-        "table": "meetup_page",
-        "data_type": "character varying",
-        "default_value": "draft",
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": false,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "meetup_page",
-      "field": "updated_by",
+      "field": "cover_image",
       "type": "uuid",
       "meta": {
         "collection": "meetup_page",
         "conditions": null,
-        "display": "user",
+        "display": null,
         "display_options": null,
-        "field": "updated_by",
+        "field": "cover_image",
         "group": null,
-        "hidden": true,
-        "interface": "select-dropdown-m2o",
+        "hidden": false,
+        "interface": "file-image",
         "note": null,
-        "options": {
-          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
-        },
-        "readonly": true,
-        "required": false,
-        "sort": 17,
+        "options": null,
+        "readonly": false,
+        "required": true,
+        "sort": 7,
         "special": [
-          "user-updated"
+          "file"
         ],
         "translations": null,
         "validation": null,
         "validation_message": null,
-        "width": "half"
+        "width": "full"
       },
       "schema": {
-        "name": "updated_by",
+        "name": "cover_image",
         "table": "meetup_page",
         "data_type": "uuid",
         "default_value": null,
@@ -5112,44 +7309,42 @@
         "is_generated": false,
         "generation_expression": null,
         "has_auto_increment": false,
-        "foreign_key_table": "directus_users",
+        "foreign_key_table": "directus_files",
         "foreign_key_column": "id"
       }
     },
     {
       "collection": "meetup_page",
-      "field": "updated_on",
-      "type": "timestamp",
+      "field": "meetup_heading_past",
+      "type": "string",
       "meta": {
         "collection": "meetup_page",
         "conditions": null,
-        "display": "datetime",
-        "display_options": {
-          "relative": true
-        },
-        "field": "updated_on",
+        "display": null,
+        "display_options": null,
+        "field": "meetup_heading_past",
         "group": null,
-        "hidden": true,
-        "interface": "datetime",
+        "hidden": false,
+        "interface": "input",
         "note": null,
-        "options": null,
-        "readonly": true,
-        "required": false,
-        "sort": 18,
-        "special": [
-          "date-updated"
-        ],
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": true,
+        "sort": 12,
+        "special": null,
         "translations": null,
         "validation": null,
         "validation_message": null,
-        "width": "half"
+        "width": "full"
       },
       "schema": {
-        "name": "updated_on",
+        "name": "meetup_heading_past",
         "table": "meetup_page",
-        "data_type": "timestamp with time zone",
+        "data_type": "character varying",
         "default_value": null,
-        "max_length": null,
+        "max_length": 255,
         "numeric_precision": null,
         "numeric_scale": null,
         "is_nullable": true,
@@ -5206,14 +7401,14 @@
     },
     {
       "collection": "meetup_speakers",
-      "field": "meetup_id",
+      "field": "meetup",
       "type": "uuid",
       "meta": {
         "collection": "meetup_speakers",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "meetup_id",
+        "field": "meetup",
         "group": null,
         "hidden": true,
         "interface": null,
@@ -5229,7 +7424,7 @@
         "width": "full"
       },
       "schema": {
-        "name": "meetup_id",
+        "name": "meetup",
         "table": "meetup_speakers",
         "data_type": "uuid",
         "default_value": null,
@@ -5243,6 +7438,48 @@
         "generation_expression": null,
         "has_auto_increment": false,
         "foreign_key_table": "meetups",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "meetup_speakers",
+      "field": "speaker",
+      "type": "uuid",
+      "meta": {
+        "collection": "meetup_speakers",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "speaker",
+        "group": null,
+        "hidden": true,
+        "interface": null,
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": null,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "speaker",
+        "table": "meetup_speakers",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "speakers",
         "foreign_key_column": "id"
       }
     },
@@ -5286,48 +7523,6 @@
         "has_auto_increment": false,
         "foreign_key_table": null,
         "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "meetup_speakers",
-      "field": "speaker_id",
-      "type": "uuid",
-      "meta": {
-        "collection": "meetup_speakers",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "speaker_id",
-        "group": null,
-        "hidden": true,
-        "interface": null,
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": null,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "speaker_id",
-        "table": "meetup_speakers",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "speakers",
-        "foreign_key_column": "id"
       }
     },
     {
@@ -5374,14 +7569,14 @@
     },
     {
       "collection": "meetup_tags",
-      "field": "meetup_id",
+      "field": "meetup",
       "type": "uuid",
       "meta": {
         "collection": "meetup_tags",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "meetup_id",
+        "field": "meetup",
         "group": null,
         "hidden": true,
         "interface": null,
@@ -5397,7 +7592,7 @@
         "width": "full"
       },
       "schema": {
-        "name": "meetup_id",
+        "name": "meetup",
         "table": "meetup_tags",
         "data_type": "uuid",
         "default_value": null,
@@ -5411,6 +7606,48 @@
         "generation_expression": null,
         "has_auto_increment": false,
         "foreign_key_table": "meetups",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "meetup_tags",
+      "field": "tag",
+      "type": "uuid",
+      "meta": {
+        "collection": "meetup_tags",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "tag",
+        "group": null,
+        "hidden": true,
+        "interface": null,
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": null,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "tag",
+        "table": "meetup_tags",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "tags",
         "foreign_key_column": "id"
       }
     },
@@ -5457,99 +7694,162 @@
       }
     },
     {
-      "collection": "meetup_tags",
-      "field": "tag_id",
-      "type": "uuid",
-      "meta": {
-        "collection": "meetup_tags",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "tag_id",
-        "group": null,
-        "hidden": true,
-        "interface": null,
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": null,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "tag_id",
-        "table": "meetup_tags",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "tags",
-        "foreign_key_column": "id"
-      }
-    },
-    {
       "collection": "meetups",
-      "field": "cover_image",
+      "field": "id",
       "type": "uuid",
       "meta": {
         "collection": "meetups",
-        "conditions": [
-          {
-            "name": "If published",
-            "rule": {
-              "status": {
-                "_eq": "published"
-              }
-            },
-            "required": true
-          }
-        ],
+        "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "cover_image",
+        "field": "id",
         "group": null,
-        "hidden": false,
-        "interface": "file-image",
+        "hidden": true,
+        "interface": "input",
         "note": null,
         "options": null,
-        "readonly": false,
+        "readonly": true,
         "required": false,
-        "sort": 8,
+        "sort": 19,
         "special": [
-          "file"
+          "uuid"
         ],
         "translations": null,
         "validation": null,
         "validation_message": null,
-        "width": "full"
+        "width": "half"
       },
       "schema": {
-        "name": "cover_image",
+        "name": "id",
         "table": "meetups",
         "data_type": "uuid",
         "default_value": null,
         "max_length": null,
         "numeric_precision": null,
         "numeric_scale": null,
+        "is_nullable": false,
+        "is_unique": true,
+        "is_primary_key": true,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "meetups",
+      "field": "status",
+      "type": "string",
+      "meta": {
+        "collection": "meetups",
+        "conditions": null,
+        "display": "labels",
+        "display_options": {
+          "choices": [
+            {
+              "background": "#00C897",
+              "value": "published"
+            },
+            {
+              "background": "#D3DAE4",
+              "value": "draft"
+            },
+            {
+              "background": "#F7971C",
+              "value": "archived"
+            }
+          ],
+          "showAsDot": true
+        },
+        "field": "status",
+        "group": null,
+        "hidden": false,
+        "interface": "select-dropdown",
+        "note": null,
+        "options": {
+          "choices": [
+            {
+              "text": "$t:published",
+              "value": "published"
+            },
+            {
+              "text": "$t:draft",
+              "value": "draft"
+            },
+            {
+              "text": "$t:archived",
+              "value": "archived"
+            }
+          ]
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 3,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "status",
+        "table": "meetups",
+        "data_type": "character varying",
+        "default_value": "draft",
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": false,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "meetups",
+      "field": "sort",
+      "type": "integer",
+      "meta": {
+        "collection": "meetups",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "sort",
+        "group": null,
+        "hidden": true,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 20,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "sort",
+        "table": "meetups",
+        "data_type": "integer",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": 32,
+        "numeric_scale": 0,
         "is_nullable": true,
         "is_unique": false,
         "is_primary_key": false,
         "is_generated": false,
         "generation_expression": null,
         "has_auto_increment": false,
-        "foreign_key_table": "directus_files",
-        "foreign_key_column": "id"
+        "foreign_key_table": null,
+        "foreign_key_column": null
       }
     },
     {
@@ -5632,6 +7932,396 @@
         "data_type": "timestamp with time zone",
         "default_value": null,
         "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "meetups",
+      "field": "updated_by",
+      "type": "uuid",
+      "meta": {
+        "collection": "meetups",
+        "conditions": null,
+        "display": "user",
+        "display_options": null,
+        "field": "updated_by",
+        "group": null,
+        "hidden": true,
+        "interface": "select-dropdown-m2o",
+        "note": null,
+        "options": {
+          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+        },
+        "readonly": true,
+        "required": false,
+        "sort": 23,
+        "special": [
+          "user-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "updated_by",
+        "table": "meetups",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "meetups",
+      "field": "updated_on",
+      "type": "timestamp",
+      "meta": {
+        "collection": "meetups",
+        "conditions": null,
+        "display": "datetime",
+        "display_options": {
+          "relative": true
+        },
+        "field": "updated_on",
+        "group": null,
+        "hidden": true,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 24,
+        "special": [
+          "date-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "updated_on",
+        "table": "meetups",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "meetups",
+      "field": "published_on",
+      "type": "timestamp",
+      "meta": {
+        "collection": "meetups",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "published_on",
+        "group": null,
+        "hidden": false,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 4,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "published_on",
+        "table": "meetups",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "meetups",
+      "field": "slug",
+      "type": "string",
+      "meta": {
+        "collection": "meetups",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "slug",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "slug": true
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 25,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "slug",
+        "table": "meetups",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "meetups",
+      "field": "start_on",
+      "type": "timestamp",
+      "meta": {
+        "collection": "meetups",
+        "conditions": [
+          {
+            "name": "If published",
+            "rule": {
+              "status": {
+                "_eq": "published"
+              }
+            },
+            "required": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "start_on",
+        "group": null,
+        "hidden": false,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 6,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "start_on",
+        "table": "meetups",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "meetups",
+      "field": "end_on",
+      "type": "timestamp",
+      "meta": {
+        "collection": "meetups",
+        "conditions": [
+          {
+            "name": "If published",
+            "rule": {
+              "status": {
+                "_eq": "published"
+              }
+            },
+            "required": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "end_on",
+        "group": null,
+        "hidden": false,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 7,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "end_on",
+        "table": "meetups",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "meetups",
+      "field": "cover_image",
+      "type": "uuid",
+      "meta": {
+        "collection": "meetups",
+        "conditions": [
+          {
+            "name": "If published",
+            "rule": {
+              "status": {
+                "_eq": "published"
+              }
+            },
+            "required": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "cover_image",
+        "group": null,
+        "hidden": false,
+        "interface": "file-image",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 8,
+        "special": [
+          "file"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "cover_image",
+        "table": "meetups",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_files",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "meetups",
+      "field": "title",
+      "type": "string",
+      "meta": {
+        "collection": "meetups",
+        "conditions": [
+          {
+            "name": "If published",
+            "rule": {
+              "status": {
+                "_eq": "published"
+              }
+            },
+            "required": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "title",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 9,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "title",
+        "table": "meetups",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
         "numeric_precision": null,
         "numeric_scale": null,
         "is_nullable": true,
@@ -5725,151 +8415,24 @@
     },
     {
       "collection": "meetups",
-      "field": "divider-hidden",
-      "type": "alias",
+      "field": "youtube_url",
+      "type": "string",
       "meta": {
         "collection": "meetups",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "divider-hidden",
-        "group": null,
-        "hidden": true,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 18,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "meetups",
-      "field": "divider-meetup",
-      "type": "alias",
-      "meta": {
-        "collection": "meetups",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-meetup",
+        "field": "youtube_url",
         "group": null,
         "hidden": false,
-        "interface": "presentation-divider",
+        "interface": "input",
         "note": null,
         "options": {
-          "title": "Meetup"
+          "trim": true
         },
         "readonly": false,
         "required": false,
-        "sort": 5,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "meetups",
-      "field": "divider-metadata",
-      "type": "alias",
-      "meta": {
-        "collection": "meetups",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-metadata",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": {
-          "title": "Metadata"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 1,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "meetups",
-      "field": "divider-relations",
-      "type": "alias",
-      "meta": {
-        "collection": "meetups",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-relations",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": {
-          "icon": null,
-          "title": "Relations"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 14,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "meetups",
-      "field": "end_on",
-      "type": "timestamp",
-      "meta": {
-        "collection": "meetups",
-        "conditions": [
-          {
-            "name": "If published",
-            "rule": {
-              "status": {
-                "_eq": "published"
-              }
-            },
-            "required": true
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "end_on",
-        "group": null,
-        "hidden": false,
-        "interface": "datetime",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 7,
+        "sort": 12,
         "special": null,
         "translations": null,
         "validation": null,
@@ -5877,87 +8440,16 @@
         "width": "half"
       },
       "schema": {
-        "name": "end_on",
+        "name": "youtube_url",
         "table": "meetups",
-        "data_type": "timestamp with time zone",
+        "data_type": "character varying",
         "default_value": null,
-        "max_length": null,
+        "max_length": 255,
         "numeric_precision": null,
         "numeric_scale": null,
         "is_nullable": true,
         "is_unique": false,
         "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "meetups",
-      "field": "gallery_images",
-      "type": "alias",
-      "meta": {
-        "collection": "meetups",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "gallery_images",
-        "group": null,
-        "hidden": false,
-        "interface": "files",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 13,
-        "special": [
-          "files"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "meetups",
-      "field": "id",
-      "type": "uuid",
-      "meta": {
-        "collection": "meetups",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "id",
-        "group": null,
-        "hidden": true,
-        "interface": "input",
-        "note": null,
-        "options": null,
-        "readonly": true,
-        "required": false,
-        "sort": 19,
-        "special": [
-          "uuid"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "id",
-        "table": "meetups",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": false,
-        "is_unique": true,
-        "is_primary_key": true,
         "is_generated": false,
         "generation_expression": null,
         "has_auto_increment": false,
@@ -6021,26 +8513,116 @@
     },
     {
       "collection": "meetups",
-      "field": "members",
+      "field": "divider-relations",
       "type": "alias",
       "meta": {
         "collection": "meetups",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "members",
+        "field": "divider-relations",
         "group": null,
         "hidden": false,
-        "interface": "list-m2m",
+        "interface": "presentation-divider",
         "note": null,
         "options": {
-          "template": "{{member_id.first_name}} {{member_id.last_name}}"
+          "icon": null,
+          "title": "Relations"
         },
         "readonly": false,
         "required": false,
-        "sort": 15,
+        "sort": 14,
         "special": [
-          "m2m"
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "meetups",
+      "field": "divider-metadata",
+      "type": "alias",
+      "meta": {
+        "collection": "meetups",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-metadata",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": {
+          "title": "Metadata"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 1,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "meetups",
+      "field": "divider-hidden",
+      "type": "alias",
+      "meta": {
+        "collection": "meetups",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-hidden",
+        "group": null,
+        "hidden": true,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 18,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "meetups",
+      "field": "divider-meetup",
+      "type": "alias",
+      "meta": {
+        "collection": "meetups",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-meetup",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": {
+          "title": "Meetup"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 5,
+        "special": [
+          "alias",
+          "no-data"
         ],
         "translations": null,
         "validation": null,
@@ -6093,130 +8675,58 @@
     },
     {
       "collection": "meetups",
-      "field": "published_on",
-      "type": "timestamp",
+      "field": "gallery_images",
+      "type": "alias",
       "meta": {
         "collection": "meetups",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "published_on",
+        "field": "gallery_images",
         "group": null,
         "hidden": false,
-        "interface": "datetime",
+        "interface": "files",
         "note": null,
         "options": null,
         "readonly": false,
         "required": false,
-        "sort": 4,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "published_on",
-        "table": "meetups",
-        "data_type": "timestamp with time zone",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "meetups",
-      "field": "slug",
-      "type": "string",
-      "meta": {
-        "collection": "meetups",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "slug",
-        "group": null,
-        "hidden": true,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "slug": true
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 25,
-        "special": null,
+        "sort": 13,
+        "special": [
+          "files"
+        ],
         "translations": null,
         "validation": null,
         "validation_message": null,
         "width": "full"
-      },
-      "schema": {
-        "name": "slug",
-        "table": "meetups",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
       }
     },
     {
       "collection": "meetups",
-      "field": "sort",
-      "type": "integer",
+      "field": "members",
+      "type": "alias",
       "meta": {
         "collection": "meetups",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "sort",
+        "field": "members",
         "group": null,
-        "hidden": true,
-        "interface": "input",
+        "hidden": false,
+        "interface": "list-m2m",
         "note": null,
-        "options": null,
+        "options": {
+          "template": "{{member.first_name}} {{member.last_name}}"
+        },
         "readonly": false,
         "required": false,
-        "sort": 20,
-        "special": null,
+        "sort": 15,
+        "special": [
+          "m2m"
+        ],
         "translations": null,
         "validation": null,
         "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "sort",
-        "table": "meetups",
-        "data_type": "integer",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": 32,
-        "numeric_scale": 0,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
+        "width": "full"
       }
     },
     {
@@ -6234,7 +8744,7 @@
         "interface": "list-m2m",
         "note": null,
         "options": {
-          "template": "{{speaker_id.first_name}} {{speaker_id.last_name}}"
+          "template": "{{speaker.first_name}} {{speaker.last_name}}"
         },
         "readonly": false,
         "required": false,
@@ -6250,46 +8760,191 @@
     },
     {
       "collection": "meetups",
-      "field": "start_on",
-      "type": "timestamp",
+      "field": "tags",
+      "type": "alias",
       "meta": {
         "collection": "meetups",
-        "conditions": [
-          {
-            "name": "If published",
-            "rule": {
-              "status": {
-                "_eq": "published"
-              }
-            },
-            "required": true
-          }
-        ],
+        "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "start_on",
+        "field": "tags",
         "group": null,
         "hidden": false,
-        "interface": "datetime",
+        "interface": "list-m2m",
+        "note": null,
+        "options": {
+          "template": "{{tag.name}}"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 17,
+        "special": [
+          "m2m"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "member_tags",
+      "field": "id",
+      "type": "integer",
+      "meta": {
+        "collection": "member_tags",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "id",
+        "group": null,
+        "hidden": true,
+        "interface": null,
         "note": null,
         "options": null,
         "readonly": false,
         "required": false,
-        "sort": 6,
+        "sort": null,
         "special": null,
         "translations": null,
         "validation": null,
         "validation_message": null,
-        "width": "half"
+        "width": "full"
       },
       "schema": {
-        "name": "start_on",
-        "table": "meetups",
-        "data_type": "timestamp with time zone",
+        "name": "id",
+        "table": "member_tags",
+        "data_type": "integer",
+        "default_value": "nextval('member_tags_id_seq'::regclass)",
+        "max_length": null,
+        "numeric_precision": 32,
+        "numeric_scale": 0,
+        "is_nullable": false,
+        "is_unique": true,
+        "is_primary_key": true,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": true,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "member_tags",
+      "field": "member",
+      "type": "uuid",
+      "meta": {
+        "collection": "member_tags",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "member",
+        "group": null,
+        "hidden": true,
+        "interface": null,
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": null,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "member",
+        "table": "member_tags",
+        "data_type": "uuid",
         "default_value": null,
         "max_length": null,
         "numeric_precision": null,
         "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "members",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "member_tags",
+      "field": "tag",
+      "type": "uuid",
+      "meta": {
+        "collection": "member_tags",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "tag",
+        "group": null,
+        "hidden": true,
+        "interface": null,
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": null,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "tag",
+        "table": "member_tags",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "tags",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "member_tags",
+      "field": "sort",
+      "type": "integer",
+      "meta": {
+        "collection": "member_tags",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "sort",
+        "group": null,
+        "hidden": false,
+        "interface": null,
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": null,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "sort",
+        "table": "member_tags",
+        "data_type": "integer",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": 32,
+        "numeric_scale": 0,
         "is_nullable": true,
         "is_unique": false,
         "is_primary_key": false,
@@ -6301,11 +8956,55 @@
       }
     },
     {
-      "collection": "meetups",
+      "collection": "members",
+      "field": "id",
+      "type": "uuid",
+      "meta": {
+        "collection": "members",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "id",
+        "group": null,
+        "hidden": true,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 20,
+        "special": [
+          "uuid"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "id",
+        "table": "members",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": false,
+        "is_unique": true,
+        "is_primary_key": true,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "members",
       "field": "status",
       "type": "string",
       "meta": {
-        "collection": "meetups",
+        "collection": "members",
         "conditions": null,
         "display": "labels",
         "display_options": {
@@ -6357,7 +9056,7 @@
       },
       "schema": {
         "name": "status",
-        "table": "meetups",
+        "table": "members",
         "data_type": "character varying",
         "default_value": "draft",
         "max_length": 255,
@@ -6374,326 +9073,23 @@
       }
     },
     {
-      "collection": "meetups",
-      "field": "tags",
-      "type": "alias",
-      "meta": {
-        "collection": "meetups",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "tags",
-        "group": null,
-        "hidden": false,
-        "interface": "list-m2m",
-        "note": null,
-        "options": {
-          "template": "{{tag_id.name}}"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 17,
-        "special": [
-          "m2m"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "meetups",
-      "field": "title",
-      "type": "string",
-      "meta": {
-        "collection": "meetups",
-        "conditions": [
-          {
-            "name": "If published",
-            "rule": {
-              "status": {
-                "_eq": "published"
-              }
-            },
-            "required": true
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "title",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 9,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "title",
-        "table": "meetups",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "meetups",
-      "field": "updated_by",
-      "type": "uuid",
-      "meta": {
-        "collection": "meetups",
-        "conditions": null,
-        "display": "user",
-        "display_options": null,
-        "field": "updated_by",
-        "group": null,
-        "hidden": true,
-        "interface": "select-dropdown-m2o",
-        "note": null,
-        "options": {
-          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
-        },
-        "readonly": true,
-        "required": false,
-        "sort": 23,
-        "special": [
-          "user-updated"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "updated_by",
-        "table": "meetups",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "directus_users",
-        "foreign_key_column": "id"
-      }
-    },
-    {
-      "collection": "meetups",
-      "field": "updated_on",
-      "type": "timestamp",
-      "meta": {
-        "collection": "meetups",
-        "conditions": null,
-        "display": "datetime",
-        "display_options": {
-          "relative": true
-        },
-        "field": "updated_on",
-        "group": null,
-        "hidden": true,
-        "interface": "datetime",
-        "note": null,
-        "options": null,
-        "readonly": true,
-        "required": false,
-        "sort": 24,
-        "special": [
-          "date-updated"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "updated_on",
-        "table": "meetups",
-        "data_type": "timestamp with time zone",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "meetups",
-      "field": "youtube_url",
-      "type": "string",
-      "meta": {
-        "collection": "meetups",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "youtube_url",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 12,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "youtube_url",
-        "table": "meetups",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "member_tags",
-      "field": "id",
-      "type": "integer",
-      "meta": {
-        "collection": "member_tags",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "id",
-        "group": null,
-        "hidden": true,
-        "interface": null,
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": null,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "id",
-        "table": "member_tags",
-        "data_type": "integer",
-        "default_value": "nextval('member_tags_id_seq'::regclass)",
-        "max_length": null,
-        "numeric_precision": 32,
-        "numeric_scale": 0,
-        "is_nullable": false,
-        "is_unique": true,
-        "is_primary_key": true,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": true,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "member_tags",
-      "field": "member_id",
-      "type": "uuid",
-      "meta": {
-        "collection": "member_tags",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "member_id",
-        "group": null,
-        "hidden": true,
-        "interface": null,
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": null,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "member_id",
-        "table": "member_tags",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "members",
-        "foreign_key_column": "id"
-      }
-    },
-    {
-      "collection": "member_tags",
+      "collection": "members",
       "field": "sort",
       "type": "integer",
       "meta": {
-        "collection": "member_tags",
+        "collection": "members",
         "conditions": null,
         "display": null,
         "display_options": null,
         "field": "sort",
         "group": null,
         "hidden": false,
-        "interface": null,
+        "interface": "input",
         "note": null,
         "options": null,
         "readonly": false,
         "required": false,
-        "sort": null,
+        "sort": 5,
         "special": null,
         "translations": null,
         "validation": null,
@@ -6702,7 +9098,7 @@
       },
       "schema": {
         "name": "sort",
-        "table": "member_tags",
+        "table": "members",
         "data_type": "integer",
         "default_value": null,
         "max_length": null,
@@ -6716,102 +9112,6 @@
         "has_auto_increment": false,
         "foreign_key_table": null,
         "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "member_tags",
-      "field": "tag_id",
-      "type": "uuid",
-      "meta": {
-        "collection": "member_tags",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "tag_id",
-        "group": null,
-        "hidden": true,
-        "interface": null,
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": null,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "tag_id",
-        "table": "member_tags",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "tags",
-        "foreign_key_column": "id"
-      }
-    },
-    {
-      "collection": "members",
-      "field": "action_image",
-      "type": "uuid",
-      "meta": {
-        "collection": "members",
-        "conditions": [
-          {
-            "name": "If published",
-            "rule": {
-              "status": {
-                "_eq": "published"
-              }
-            },
-            "required": true
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "action_image",
-        "group": null,
-        "hidden": false,
-        "interface": "file-image",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 13,
-        "special": [
-          "file"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "action_image",
-        "table": "members",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "directus_files",
-        "foreign_key_column": "id"
       }
     },
     {
@@ -6908,829 +9208,6 @@
     },
     {
       "collection": "members",
-      "field": "description",
-      "type": "text",
-      "meta": {
-        "collection": "members",
-        "conditions": [
-          {
-            "name": "If published",
-            "rule": {
-              "status": {
-                "_eq": "published"
-              }
-            },
-            "required": true
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "description",
-        "group": null,
-        "hidden": false,
-        "interface": "input-rich-text-html",
-        "note": null,
-        "options": {
-          "toolbar": [
-            "blockquote",
-            "bold",
-            "bullist",
-            "code",
-            "customLink",
-            "fullscreen",
-            "italic",
-            "numlist",
-            "removeformat",
-            "underline"
-          ]
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 11,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "description",
-        "table": "members",
-        "data_type": "text",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "members",
-      "field": "divider-hidden",
-      "type": "alias",
-      "meta": {
-        "collection": "members",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-hidden",
-        "group": null,
-        "hidden": true,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 19,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "members",
-      "field": "divider-member",
-      "type": "alias",
-      "meta": {
-        "collection": "members",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-member",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": {
-          "title": "Member"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 6,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "members",
-      "field": "divider-metadata",
-      "type": "alias",
-      "meta": {
-        "collection": "members",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-metadata",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": {
-          "title": "Metadata"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 1,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "members",
-      "field": "divider-relations",
-      "type": "alias",
-      "meta": {
-        "collection": "members",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-relations",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": {
-          "title": "Relations"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 14,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "members",
-      "field": "first_name",
-      "type": "string",
-      "meta": {
-        "collection": "members",
-        "conditions": [
-          {
-            "name": "If published",
-            "rule": {
-              "status": {
-                "_eq": "published"
-              }
-            },
-            "required": true
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "first_name",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 7,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "first_name",
-        "table": "members",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "members",
-      "field": "id",
-      "type": "uuid",
-      "meta": {
-        "collection": "members",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "id",
-        "group": null,
-        "hidden": true,
-        "interface": "input",
-        "note": null,
-        "options": null,
-        "readonly": true,
-        "required": false,
-        "sort": 20,
-        "special": [
-          "uuid"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "id",
-        "table": "members",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": false,
-        "is_unique": true,
-        "is_primary_key": true,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "members",
-      "field": "last_name",
-      "type": "string",
-      "meta": {
-        "collection": "members",
-        "conditions": [
-          {
-            "name": "If published",
-            "required": true,
-            "rule": {
-              "status": {
-                "_eq": "published"
-              }
-            }
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "last_name",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 8,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "last_name",
-        "table": "members",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "members",
-      "field": "meetups",
-      "type": "alias",
-      "meta": {
-        "collection": "members",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "meetups",
-        "group": null,
-        "hidden": false,
-        "interface": "list-m2m",
-        "note": null,
-        "options": {
-          "template": "{{meetup_id.title}}"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 17,
-        "special": [
-          "m2m"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "members",
-      "field": "normal_image",
-      "type": "uuid",
-      "meta": {
-        "collection": "members",
-        "conditions": [
-          {
-            "name": "If published",
-            "rule": {
-              "status": {
-                "_eq": "published"
-              }
-            },
-            "required": true
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "normal_image",
-        "group": null,
-        "hidden": false,
-        "interface": "file-image",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 12,
-        "special": [
-          "file"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "normal_image",
-        "table": "members",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "directus_files",
-        "foreign_key_column": "id"
-      }
-    },
-    {
-      "collection": "members",
-      "field": "notice-publish",
-      "type": "alias",
-      "meta": {
-        "collection": "members",
-        "conditions": [
-          {
-            "name": "If not draft",
-            "rule": {
-              "status": {
-                "_neq": "draft"
-              }
-            },
-            "hidden": true
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "notice-publish",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-notice",
-        "note": null,
-        "options": {
-          "text": "Wähle bei \"Published On\" ein Datum in der Zukunft, um den Member zu diesem Zeitpunk automatisch zu veröffentlichen."
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 2,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "members",
-      "field": "occupation",
-      "type": "string",
-      "meta": {
-        "collection": "members",
-        "conditions": [
-          {
-            "name": "If published",
-            "rule": {
-              "status": {
-                "_eq": "published"
-              }
-            },
-            "required": true
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "occupation",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 10,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "occupation",
-        "table": "members",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "members",
-      "field": "picks_of_the_day",
-      "type": "alias",
-      "meta": {
-        "collection": "members",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "picks_of_the_day",
-        "group": null,
-        "hidden": false,
-        "interface": "list-o2m",
-        "note": null,
-        "options": {
-          "template": "{{name}}"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 16,
-        "special": [
-          "o2m"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "members",
-      "field": "podcasts",
-      "type": "alias",
-      "meta": {
-        "collection": "members",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "podcasts",
-        "group": null,
-        "hidden": false,
-        "interface": "list-m2m",
-        "note": null,
-        "options": {
-          "template": "{{podcast_id.title}}"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 15,
-        "special": [
-          "m2m"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "members",
-      "field": "published_on",
-      "type": "timestamp",
-      "meta": {
-        "collection": "members",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "published_on",
-        "group": null,
-        "hidden": false,
-        "interface": "datetime",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 4,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "published_on",
-        "table": "members",
-        "data_type": "timestamp with time zone",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "members",
-      "field": "sort",
-      "type": "integer",
-      "meta": {
-        "collection": "members",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "sort",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 5,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "sort",
-        "table": "members",
-        "data_type": "integer",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": 32,
-        "numeric_scale": 0,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "members",
-      "field": "status",
-      "type": "string",
-      "meta": {
-        "collection": "members",
-        "conditions": null,
-        "display": "labels",
-        "display_options": {
-          "choices": [
-            {
-              "background": "#00C897",
-              "value": "published"
-            },
-            {
-              "background": "#D3DAE4",
-              "value": "draft"
-            },
-            {
-              "background": "#F7971C",
-              "value": "archived"
-            }
-          ],
-          "showAsDot": true
-        },
-        "field": "status",
-        "group": null,
-        "hidden": false,
-        "interface": "select-dropdown",
-        "note": null,
-        "options": {
-          "choices": [
-            {
-              "text": "$t:published",
-              "value": "published"
-            },
-            {
-              "text": "$t:draft",
-              "value": "draft"
-            },
-            {
-              "text": "$t:archived",
-              "value": "archived"
-            }
-          ]
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 3,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "status",
-        "table": "members",
-        "data_type": "character varying",
-        "default_value": "draft",
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": false,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "members",
-      "field": "tags",
-      "type": "alias",
-      "meta": {
-        "collection": "members",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "tags",
-        "group": null,
-        "hidden": false,
-        "interface": "list-m2m",
-        "note": null,
-        "options": {
-          "template": "{{tag_id.name}}"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 18,
-        "special": [
-          "m2m"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "members",
-      "field": "task_area",
-      "type": "string",
-      "meta": {
-        "collection": "members",
-        "conditions": [
-          {
-            "name": "If published",
-            "required": true,
-            "rule": {
-              "status": {
-                "_eq": "published"
-              }
-            }
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "task_area",
-        "group": null,
-        "hidden": false,
-        "interface": "select-dropdown",
-        "note": null,
-        "options": {
-          "choices": [
-            {
-              "text": "Podcast-Crew",
-              "value": "podcast_crew"
-            },
-            {
-              "text": "Behind the Scenes",
-              "value": "behind_the_scenes"
-            },
-            {
-              "text": "Sonstiges",
-              "value": "other"
-            }
-          ]
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 9,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "task_area",
-        "table": "members",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "members",
       "field": "updated_by",
       "type": "uuid",
       "meta": {
@@ -7812,6 +9289,887 @@
         "numeric_precision": null,
         "numeric_scale": null,
         "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "members",
+      "field": "published_on",
+      "type": "timestamp",
+      "meta": {
+        "collection": "members",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "published_on",
+        "group": null,
+        "hidden": false,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 4,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "published_on",
+        "table": "members",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "members",
+      "field": "first_name",
+      "type": "string",
+      "meta": {
+        "collection": "members",
+        "conditions": [
+          {
+            "name": "If published",
+            "rule": {
+              "status": {
+                "_eq": "published"
+              }
+            },
+            "required": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "first_name",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 7,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "first_name",
+        "table": "members",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "members",
+      "field": "last_name",
+      "type": "string",
+      "meta": {
+        "collection": "members",
+        "conditions": [
+          {
+            "name": "If published",
+            "required": true,
+            "rule": {
+              "status": {
+                "_eq": "published"
+              }
+            }
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "last_name",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 8,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "last_name",
+        "table": "members",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "members",
+      "field": "task_area",
+      "type": "string",
+      "meta": {
+        "collection": "members",
+        "conditions": [
+          {
+            "name": "If published",
+            "required": true,
+            "rule": {
+              "status": {
+                "_eq": "published"
+              }
+            }
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "task_area",
+        "group": null,
+        "hidden": false,
+        "interface": "select-dropdown",
+        "note": null,
+        "options": {
+          "choices": [
+            {
+              "text": "Podcast-Crew",
+              "value": "podcast_crew"
+            },
+            {
+              "text": "Behind the Scenes",
+              "value": "behind_the_scenes"
+            },
+            {
+              "text": "Sonstiges",
+              "value": "other"
+            }
+          ]
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 9,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "task_area",
+        "table": "members",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "members",
+      "field": "occupation",
+      "type": "string",
+      "meta": {
+        "collection": "members",
+        "conditions": [
+          {
+            "name": "If published",
+            "rule": {
+              "status": {
+                "_eq": "published"
+              }
+            },
+            "required": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "occupation",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 10,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "occupation",
+        "table": "members",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "members",
+      "field": "description",
+      "type": "text",
+      "meta": {
+        "collection": "members",
+        "conditions": [
+          {
+            "name": "If published",
+            "rule": {
+              "status": {
+                "_eq": "published"
+              }
+            },
+            "required": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "description",
+        "group": null,
+        "hidden": false,
+        "interface": "input-rich-text-html",
+        "note": null,
+        "options": {
+          "toolbar": [
+            "blockquote",
+            "bold",
+            "bullist",
+            "code",
+            "customLink",
+            "fullscreen",
+            "italic",
+            "numlist",
+            "removeformat",
+            "underline"
+          ]
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 11,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "description",
+        "table": "members",
+        "data_type": "text",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "members",
+      "field": "normal_image",
+      "type": "uuid",
+      "meta": {
+        "collection": "members",
+        "conditions": [
+          {
+            "name": "If published",
+            "rule": {
+              "status": {
+                "_eq": "published"
+              }
+            },
+            "required": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "normal_image",
+        "group": null,
+        "hidden": false,
+        "interface": "file-image",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 12,
+        "special": [
+          "file"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "normal_image",
+        "table": "members",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_files",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "members",
+      "field": "action_image",
+      "type": "uuid",
+      "meta": {
+        "collection": "members",
+        "conditions": [
+          {
+            "name": "If published",
+            "rule": {
+              "status": {
+                "_eq": "published"
+              }
+            },
+            "required": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "action_image",
+        "group": null,
+        "hidden": false,
+        "interface": "file-image",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 13,
+        "special": [
+          "file"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "action_image",
+        "table": "members",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_files",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "members",
+      "field": "picks_of_the_day",
+      "type": "alias",
+      "meta": {
+        "collection": "members",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "picks_of_the_day",
+        "group": null,
+        "hidden": false,
+        "interface": "list-o2m",
+        "note": null,
+        "options": {
+          "template": "{{name}}"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 17,
+        "special": [
+          "o2m"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "members",
+      "field": "divider-metadata",
+      "type": "alias",
+      "meta": {
+        "collection": "members",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-metadata",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": {
+          "title": "Metadata"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 1,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "members",
+      "field": "notice-publish",
+      "type": "alias",
+      "meta": {
+        "collection": "members",
+        "conditions": [
+          {
+            "name": "If not draft",
+            "rule": {
+              "status": {
+                "_neq": "draft"
+              }
+            },
+            "hidden": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "notice-publish",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-notice",
+        "note": null,
+        "options": {
+          "text": "Wähle bei \"Published On\" ein Datum in der Zukunft, um den Member zu diesem Zeitpunk automatisch zu veröffentlichen."
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 2,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "members",
+      "field": "divider-member",
+      "type": "alias",
+      "meta": {
+        "collection": "members",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-member",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": {
+          "title": "Member"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 6,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "members",
+      "field": "divider-relations",
+      "type": "alias",
+      "meta": {
+        "collection": "members",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-relations",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": {
+          "title": "Relations"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 14,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "members",
+      "field": "divider-hidden",
+      "type": "alias",
+      "meta": {
+        "collection": "members",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-hidden",
+        "group": null,
+        "hidden": true,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 19,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "members",
+      "field": "tags",
+      "type": "alias",
+      "meta": {
+        "collection": "members",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "tags",
+        "group": null,
+        "hidden": false,
+        "interface": "list-m2m",
+        "note": null,
+        "options": {
+          "template": "{{tag.name}}"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 18,
+        "special": [
+          "m2m"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "members",
+      "field": "meetups",
+      "type": "alias",
+      "meta": {
+        "collection": "members",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "meetups",
+        "group": null,
+        "hidden": false,
+        "interface": "list-m2m",
+        "note": null,
+        "options": {
+          "template": "{{meetup.title}}"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 15,
+        "special": [
+          "m2m"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "members",
+      "field": "podcasts",
+      "type": "alias",
+      "meta": {
+        "collection": "members",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "podcasts",
+        "group": null,
+        "hidden": false,
+        "interface": "list-m2m",
+        "note": null,
+        "options": {
+          "template": "{{podcast.title}}"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 16,
+        "special": [
+          "m2m"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "members",
+      "field": "team_member",
+      "type": "boolean",
+      "meta": {
+        "collection": "members",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "team_member",
+        "group": null,
+        "hidden": false,
+        "interface": "boolean",
+        "note": null,
+        "options": {
+          "label": "Is part of the core team"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 25,
+        "special": [
+          "cast-boolean"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "team_member",
+        "table": "members",
+        "data_type": "boolean",
+        "default_value": false,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "pick_of_the_day_page",
+      "field": "id",
+      "type": "uuid",
+      "meta": {
+        "collection": "pick_of_the_day_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "id",
+        "group": null,
+        "hidden": true,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 10,
+        "special": [
+          "uuid"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "id",
+        "table": "pick_of_the_day_page",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": false,
+        "is_unique": true,
+        "is_primary_key": true,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "pick_of_the_day_page",
+      "field": "status",
+      "type": "string",
+      "meta": {
+        "collection": "pick_of_the_day_page",
+        "conditions": null,
+        "display": "labels",
+        "display_options": {
+          "choices": [
+            {
+              "background": "#00C897",
+              "value": "published"
+            },
+            {
+              "background": "#D3DAE4",
+              "value": "draft"
+            },
+            {
+              "background": "#F7971C",
+              "value": "archived"
+            }
+          ],
+          "showAsDot": true
+        },
+        "field": "status",
+        "group": null,
+        "hidden": false,
+        "interface": "select-dropdown",
+        "note": null,
+        "options": {
+          "choices": [
+            {
+              "text": "$t:published",
+              "value": "published"
+            },
+            {
+              "text": "$t:draft",
+              "value": "draft"
+            },
+            {
+              "text": "$t:archived",
+              "value": "archived"
+            }
+          ]
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 2,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "status",
+        "table": "pick_of_the_day_page",
+        "data_type": "character varying",
+        "default_value": "draft",
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": false,
         "is_unique": false,
         "is_primary_key": false,
         "is_generated": false,
@@ -7904,427 +10262,6 @@
         "numeric_precision": null,
         "numeric_scale": null,
         "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "pick_of_the_day_page",
-      "field": "divider-content",
-      "type": "alias",
-      "meta": {
-        "collection": "pick_of_the_day_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-content",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": {
-          "title": "Content"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 6,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "pick_of_the_day_page",
-      "field": "divider-hidden",
-      "type": "alias",
-      "meta": {
-        "collection": "pick_of_the_day_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-hidden",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 9,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "pick_of_the_day_page",
-      "field": "divider-metadata",
-      "type": "alias",
-      "meta": {
-        "collection": "pick_of_the_day_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-metadata",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": {
-          "title": "Metadata"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 1,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "pick_of_the_day_page",
-      "field": "id",
-      "type": "uuid",
-      "meta": {
-        "collection": "pick_of_the_day_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "id",
-        "group": null,
-        "hidden": true,
-        "interface": "input",
-        "note": null,
-        "options": null,
-        "readonly": true,
-        "required": false,
-        "sort": 10,
-        "special": [
-          "uuid"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "id",
-        "table": "pick_of_the_day_page",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": false,
-        "is_unique": true,
-        "is_primary_key": true,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "pick_of_the_day_page",
-      "field": "intro_heading",
-      "type": "string",
-      "meta": {
-        "collection": "pick_of_the_day_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "intro_heading",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": true,
-        "sort": 7,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "intro_heading",
-        "table": "pick_of_the_day_page",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "pick_of_the_day_page",
-      "field": "intro_text",
-      "type": "text",
-      "meta": {
-        "collection": "pick_of_the_day_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "intro_text",
-        "group": null,
-        "hidden": false,
-        "interface": "input-rich-text-html",
-        "note": null,
-        "options": {
-          "toolbar": [
-            "bold",
-            "code",
-            "customLink",
-            "fullscreen",
-            "italic",
-            "removeformat",
-            "underline"
-          ]
-        },
-        "readonly": false,
-        "required": true,
-        "sort": 8,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "intro_text",
-        "table": "pick_of_the_day_page",
-        "data_type": "text",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "pick_of_the_day_page",
-      "field": "meta_description",
-      "type": "text",
-      "meta": {
-        "collection": "pick_of_the_day_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "meta_description",
-        "group": null,
-        "hidden": false,
-        "interface": "input-multiline",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": true,
-        "sort": 5,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "meta_description",
-        "table": "pick_of_the_day_page",
-        "data_type": "text",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "pick_of_the_day_page",
-      "field": "meta_title",
-      "type": "string",
-      "meta": {
-        "collection": "pick_of_the_day_page",
-        "conditions": null,
-        "display": null,
-        "display_options": {
-          "conditionalFormatting": null
-        },
-        "field": "meta_title",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": true,
-        "sort": 4,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "meta_title",
-        "table": "pick_of_the_day_page",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "pick_of_the_day_page",
-      "field": "notice-meta",
-      "type": "alias",
-      "meta": {
-        "collection": "pick_of_the_day_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "notice-meta",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-notice",
-        "note": null,
-        "options": {
-          "text": "Nach Möglichkeit sollte der Meta-Titel nicht länger als 42 Zeichen lang sein und die Meta-Beschreibung nicht länger als 160 Zeichen."
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 3,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "pick_of_the_day_page",
-      "field": "status",
-      "type": "string",
-      "meta": {
-        "collection": "pick_of_the_day_page",
-        "conditions": null,
-        "display": "labels",
-        "display_options": {
-          "choices": [
-            {
-              "background": "#00C897",
-              "value": "published"
-            },
-            {
-              "background": "#D3DAE4",
-              "value": "draft"
-            },
-            {
-              "background": "#F7971C",
-              "value": "archived"
-            }
-          ],
-          "showAsDot": true
-        },
-        "field": "status",
-        "group": null,
-        "hidden": false,
-        "interface": "select-dropdown",
-        "note": null,
-        "options": {
-          "choices": [
-            {
-              "text": "$t:published",
-              "value": "published"
-            },
-            {
-              "text": "$t:draft",
-              "value": "draft"
-            },
-            {
-              "text": "$t:archived",
-              "value": "archived"
-            }
-          ]
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 2,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "status",
-        "table": "pick_of_the_day_page",
-        "data_type": "character varying",
-        "default_value": "draft",
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": false,
         "is_unique": false,
         "is_primary_key": false,
         "is_generated": false,
@@ -8427,6 +10364,310 @@
       }
     },
     {
+      "collection": "pick_of_the_day_page",
+      "field": "divider-hidden",
+      "type": "alias",
+      "meta": {
+        "collection": "pick_of_the_day_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-hidden",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 9,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "pick_of_the_day_page",
+      "field": "divider-metadata",
+      "type": "alias",
+      "meta": {
+        "collection": "pick_of_the_day_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-metadata",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": {
+          "title": "Metadata"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 1,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "pick_of_the_day_page",
+      "field": "divider-content",
+      "type": "alias",
+      "meta": {
+        "collection": "pick_of_the_day_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-content",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": {
+          "title": "Content"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 6,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "pick_of_the_day_page",
+      "field": "notice-meta",
+      "type": "alias",
+      "meta": {
+        "collection": "pick_of_the_day_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "notice-meta",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-notice",
+        "note": null,
+        "options": {
+          "text": "Nach Möglichkeit sollte der Meta-Titel nicht länger als 42 Zeichen lang sein und die Meta-Beschreibung nicht länger als 160 Zeichen."
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 3,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "pick_of_the_day_page",
+      "field": "meta_title",
+      "type": "string",
+      "meta": {
+        "collection": "pick_of_the_day_page",
+        "conditions": null,
+        "display": null,
+        "display_options": {
+          "conditionalFormatting": null
+        },
+        "field": "meta_title",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": true,
+        "sort": 4,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "meta_title",
+        "table": "pick_of_the_day_page",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "pick_of_the_day_page",
+      "field": "meta_description",
+      "type": "text",
+      "meta": {
+        "collection": "pick_of_the_day_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "meta_description",
+        "group": null,
+        "hidden": false,
+        "interface": "input-multiline",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": true,
+        "sort": 5,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "meta_description",
+        "table": "pick_of_the_day_page",
+        "data_type": "text",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "pick_of_the_day_page",
+      "field": "intro_text",
+      "type": "text",
+      "meta": {
+        "collection": "pick_of_the_day_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "intro_text",
+        "group": null,
+        "hidden": false,
+        "interface": "input-rich-text-html",
+        "note": null,
+        "options": {
+          "toolbar": [
+            "bold",
+            "code",
+            "customLink",
+            "fullscreen",
+            "italic",
+            "removeformat",
+            "underline"
+          ]
+        },
+        "readonly": false,
+        "required": true,
+        "sort": 8,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "intro_text",
+        "table": "pick_of_the_day_page",
+        "data_type": "text",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "pick_of_the_day_page",
+      "field": "intro_heading",
+      "type": "string",
+      "meta": {
+        "collection": "pick_of_the_day_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "intro_heading",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": true,
+        "sort": 7,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "intro_heading",
+        "table": "pick_of_the_day_page",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
       "collection": "pick_of_the_day_tags",
       "field": "id",
       "type": "integer",
@@ -8470,14 +10711,14 @@
     },
     {
       "collection": "pick_of_the_day_tags",
-      "field": "pick_of_the_day_id",
+      "field": "pick_of_the_day",
       "type": "uuid",
       "meta": {
         "collection": "pick_of_the_day_tags",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "pick_of_the_day_id",
+        "field": "pick_of_the_day",
         "group": null,
         "hidden": true,
         "interface": null,
@@ -8493,7 +10734,7 @@
         "width": "full"
       },
       "schema": {
-        "name": "pick_of_the_day_id",
+        "name": "pick_of_the_day",
         "table": "pick_of_the_day_tags",
         "data_type": "uuid",
         "default_value": null,
@@ -8507,6 +10748,48 @@
         "generation_expression": null,
         "has_auto_increment": false,
         "foreign_key_table": "picks_of_the_day",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "pick_of_the_day_tags",
+      "field": "tag",
+      "type": "uuid",
+      "meta": {
+        "collection": "pick_of_the_day_tags",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "tag",
+        "group": null,
+        "hidden": true,
+        "interface": null,
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": null,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "tag",
+        "table": "pick_of_the_day_tags",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "tags",
         "foreign_key_column": "id"
       }
     },
@@ -8553,45 +10836,162 @@
       }
     },
     {
-      "collection": "pick_of_the_day_tags",
-      "field": "tag_id",
+      "collection": "picks_of_the_day",
+      "field": "id",
       "type": "uuid",
       "meta": {
-        "collection": "pick_of_the_day_tags",
+        "collection": "picks_of_the_day",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "tag_id",
+        "field": "id",
         "group": null,
         "hidden": true,
-        "interface": null,
+        "interface": "input",
         "note": null,
         "options": null,
-        "readonly": false,
+        "readonly": true,
         "required": false,
-        "sort": null,
-        "special": null,
+        "sort": 17,
+        "special": [
+          "uuid"
+        ],
         "translations": null,
         "validation": null,
         "validation_message": null,
-        "width": "full"
+        "width": "half"
       },
       "schema": {
-        "name": "tag_id",
-        "table": "pick_of_the_day_tags",
+        "name": "id",
+        "table": "picks_of_the_day",
         "data_type": "uuid",
         "default_value": null,
         "max_length": null,
         "numeric_precision": null,
         "numeric_scale": null,
+        "is_nullable": false,
+        "is_unique": true,
+        "is_primary_key": true,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "picks_of_the_day",
+      "field": "status",
+      "type": "string",
+      "meta": {
+        "collection": "picks_of_the_day",
+        "conditions": null,
+        "display": "labels",
+        "display_options": {
+          "choices": [
+            {
+              "background": "#00C897",
+              "value": "published"
+            },
+            {
+              "background": "#D3DAE4",
+              "value": "draft"
+            },
+            {
+              "background": "#F7971C",
+              "value": "archived"
+            }
+          ],
+          "showAsDot": true
+        },
+        "field": "status",
+        "group": null,
+        "hidden": false,
+        "interface": "select-dropdown",
+        "note": null,
+        "options": {
+          "choices": [
+            {
+              "text": "$t:published",
+              "value": "published"
+            },
+            {
+              "text": "$t:draft",
+              "value": "draft"
+            },
+            {
+              "text": "$t:archived",
+              "value": "archived"
+            }
+          ]
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 3,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "status",
+        "table": "picks_of_the_day",
+        "data_type": "character varying",
+        "default_value": "draft",
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": false,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "picks_of_the_day",
+      "field": "sort",
+      "type": "integer",
+      "meta": {
+        "collection": "picks_of_the_day",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "sort",
+        "group": null,
+        "hidden": true,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 18,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "sort",
+        "table": "picks_of_the_day",
+        "data_type": "integer",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": 32,
+        "numeric_scale": 0,
         "is_nullable": true,
         "is_unique": false,
         "is_primary_key": false,
         "is_generated": false,
         "generation_expression": null,
         "has_auto_increment": false,
-        "foreign_key_table": "tags",
-        "foreign_key_column": "id"
+        "foreign_key_table": null,
+        "foreign_key_column": null
       }
     },
     {
@@ -8688,6 +11088,194 @@
     },
     {
       "collection": "picks_of_the_day",
+      "field": "updated_by",
+      "type": "uuid",
+      "meta": {
+        "collection": "picks_of_the_day",
+        "conditions": null,
+        "display": "user",
+        "display_options": null,
+        "field": "updated_by",
+        "group": null,
+        "hidden": true,
+        "interface": "select-dropdown-m2o",
+        "note": null,
+        "options": {
+          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+        },
+        "readonly": true,
+        "required": false,
+        "sort": 21,
+        "special": [
+          "user-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "updated_by",
+        "table": "picks_of_the_day",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "picks_of_the_day",
+      "field": "updated_on",
+      "type": "timestamp",
+      "meta": {
+        "collection": "picks_of_the_day",
+        "conditions": null,
+        "display": "datetime",
+        "display_options": {
+          "relative": true
+        },
+        "field": "updated_on",
+        "group": null,
+        "hidden": true,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 22,
+        "special": [
+          "date-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "updated_on",
+        "table": "picks_of_the_day",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "picks_of_the_day",
+      "field": "published_on",
+      "type": "timestamp",
+      "meta": {
+        "collection": "picks_of_the_day",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "published_on",
+        "group": null,
+        "hidden": false,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 4,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "published_on",
+        "table": "picks_of_the_day",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "picks_of_the_day",
+      "field": "name",
+      "type": "string",
+      "meta": {
+        "collection": "picks_of_the_day",
+        "conditions": [
+          {
+            "name": "If published",
+            "rule": {
+              "status": {
+                "_eq": "published"
+              }
+            },
+            "required": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "name",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 6,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "name",
+        "table": "picks_of_the_day",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "picks_of_the_day",
       "field": "description",
       "type": "text",
       "meta": {
@@ -8753,6 +11341,264 @@
     },
     {
       "collection": "picks_of_the_day",
+      "field": "website_url",
+      "type": "string",
+      "meta": {
+        "collection": "picks_of_the_day",
+        "conditions": [
+          {
+            "name": "If published",
+            "rule": {
+              "status": {
+                "_eq": "published"
+              }
+            },
+            "required": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "website_url",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 7,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "website_url",
+        "table": "picks_of_the_day",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "picks_of_the_day",
+      "field": "image",
+      "type": "uuid",
+      "meta": {
+        "collection": "picks_of_the_day",
+        "conditions": [
+          {
+            "name": "If draft",
+            "rule": {
+              "status": {
+                "_eq": "draft"
+              }
+            },
+            "required": false,
+            "readonly": false,
+            "hidden": false
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "image",
+        "group": null,
+        "hidden": false,
+        "interface": "file-image",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 10,
+        "special": [
+          "file"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "image",
+        "table": "picks_of_the_day",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_files",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "picks_of_the_day",
+      "field": "podcast",
+      "type": "uuid",
+      "meta": {
+        "collection": "picks_of_the_day",
+        "conditions": [
+          {
+            "name": "If published",
+            "rule": {
+              "status": {
+                "_eq": "published"
+              }
+            },
+            "required": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "podcast",
+        "group": null,
+        "hidden": false,
+        "interface": "select-dropdown-m2o",
+        "note": null,
+        "options": {
+          "template": "{{title}}"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 12,
+        "special": [
+          "m2o"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "podcast",
+        "table": "picks_of_the_day",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "podcasts",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "picks_of_the_day",
+      "field": "member",
+      "type": "uuid",
+      "meta": {
+        "collection": "picks_of_the_day",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "member",
+        "group": null,
+        "hidden": false,
+        "interface": "select-dropdown-m2o",
+        "note": null,
+        "options": {
+          "template": "{{first_name}} {{last_name}}"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 13,
+        "special": [
+          "m2o"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "member",
+        "table": "picks_of_the_day",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "members",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "picks_of_the_day",
+      "field": "speaker",
+      "type": "uuid",
+      "meta": {
+        "collection": "picks_of_the_day",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "speaker",
+        "group": null,
+        "hidden": false,
+        "interface": "select-dropdown-m2o",
+        "note": null,
+        "options": {
+          "template": "{{first_name}} {{last_name}}"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 14,
+        "special": [
+          "m2o"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "speaker",
+        "table": "picks_of_the_day",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "speakers",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "picks_of_the_day",
       "field": "divider-hidden",
       "type": "alias",
       "meta": {
@@ -8799,6 +11645,46 @@
         "readonly": false,
         "required": false,
         "sort": 1,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "picks_of_the_day",
+      "field": "notice-publish",
+      "type": "alias",
+      "meta": {
+        "collection": "picks_of_the_day",
+        "conditions": [
+          {
+            "name": "If not draft",
+            "rule": {
+              "status": {
+                "_neq": "draft"
+              }
+            },
+            "hidden": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "notice-publish",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-notice",
+        "note": null,
+        "options": {
+          "text": "Wähle bei \"Published On\" ein Datum in der Zukunft, um den Pick zu diesem Zeitpunk automatisch zu veröffentlichen."
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 2,
         "special": [
           "alias",
           "no-data"
@@ -8871,205 +11757,6 @@
     },
     {
       "collection": "picks_of_the_day",
-      "field": "id",
-      "type": "uuid",
-      "meta": {
-        "collection": "picks_of_the_day",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "id",
-        "group": null,
-        "hidden": true,
-        "interface": "input",
-        "note": null,
-        "options": null,
-        "readonly": true,
-        "required": false,
-        "sort": 17,
-        "special": [
-          "uuid"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "id",
-        "table": "picks_of_the_day",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": false,
-        "is_unique": true,
-        "is_primary_key": true,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "picks_of_the_day",
-      "field": "image",
-      "type": "uuid",
-      "meta": {
-        "collection": "picks_of_the_day",
-        "conditions": [
-          {
-            "name": "If draft",
-            "rule": {
-              "status": {
-                "_eq": "draft"
-              }
-            },
-            "required": true,
-            "readonly": false
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "image",
-        "group": null,
-        "hidden": false,
-        "interface": "file-image",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 10,
-        "special": [
-          "file"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "image",
-        "table": "picks_of_the_day",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "directus_files",
-        "foreign_key_column": "id"
-      }
-    },
-    {
-      "collection": "picks_of_the_day",
-      "field": "member",
-      "type": "uuid",
-      "meta": {
-        "collection": "picks_of_the_day",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "member",
-        "group": null,
-        "hidden": false,
-        "interface": "select-dropdown-m2o",
-        "note": null,
-        "options": {
-          "template": "{{first_name}} {{last_name}}"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 13,
-        "special": [
-          "m2o"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "member",
-        "table": "picks_of_the_day",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "members",
-        "foreign_key_column": "id"
-      }
-    },
-    {
-      "collection": "picks_of_the_day",
-      "field": "name",
-      "type": "string",
-      "meta": {
-        "collection": "picks_of_the_day",
-        "conditions": [
-          {
-            "name": "If published",
-            "rule": {
-              "status": {
-                "_eq": "published"
-              }
-            },
-            "required": true
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "name",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 6,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "name",
-        "table": "picks_of_the_day",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "picks_of_the_day",
       "field": "notice-image",
       "type": "alias",
       "meta": {
@@ -9100,305 +11787,6 @@
     },
     {
       "collection": "picks_of_the_day",
-      "field": "notice-publish",
-      "type": "alias",
-      "meta": {
-        "collection": "picks_of_the_day",
-        "conditions": [
-          {
-            "name": "If not draft",
-            "rule": {
-              "status": {
-                "_neq": "draft"
-              }
-            },
-            "hidden": true
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "notice-publish",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-notice",
-        "note": null,
-        "options": {
-          "text": "Wähle bei \"Published On\" ein Datum in der Zukunft, um den Pick zu diesem Zeitpunk automatisch zu veröffentlichen."
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 2,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "picks_of_the_day",
-      "field": "podcast",
-      "type": "uuid",
-      "meta": {
-        "collection": "picks_of_the_day",
-        "conditions": [
-          {
-            "name": "If published",
-            "rule": {
-              "status": {
-                "_eq": "published"
-              }
-            },
-            "required": true
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "podcast",
-        "group": null,
-        "hidden": false,
-        "interface": "select-dropdown-m2o",
-        "note": null,
-        "options": {
-          "template": "{{title}}"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 12,
-        "special": [
-          "m2o"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "podcast",
-        "table": "picks_of_the_day",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "podcasts",
-        "foreign_key_column": "id"
-      }
-    },
-    {
-      "collection": "picks_of_the_day",
-      "field": "published_on",
-      "type": "timestamp",
-      "meta": {
-        "collection": "picks_of_the_day",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "published_on",
-        "group": null,
-        "hidden": false,
-        "interface": "datetime",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 4,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "published_on",
-        "table": "picks_of_the_day",
-        "data_type": "timestamp with time zone",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "picks_of_the_day",
-      "field": "sort",
-      "type": "integer",
-      "meta": {
-        "collection": "picks_of_the_day",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "sort",
-        "group": null,
-        "hidden": true,
-        "interface": "input",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 18,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "sort",
-        "table": "picks_of_the_day",
-        "data_type": "integer",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": 32,
-        "numeric_scale": 0,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "picks_of_the_day",
-      "field": "speaker",
-      "type": "uuid",
-      "meta": {
-        "collection": "picks_of_the_day",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "speaker",
-        "group": null,
-        "hidden": false,
-        "interface": "select-dropdown-m2o",
-        "note": null,
-        "options": {
-          "template": "{{first_name}} {{last_name}}"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 14,
-        "special": [
-          "m2o"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "speaker",
-        "table": "picks_of_the_day",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "speakers",
-        "foreign_key_column": "id"
-      }
-    },
-    {
-      "collection": "picks_of_the_day",
-      "field": "status",
-      "type": "string",
-      "meta": {
-        "collection": "picks_of_the_day",
-        "conditions": null,
-        "display": "labels",
-        "display_options": {
-          "choices": [
-            {
-              "background": "#00C897",
-              "value": "published"
-            },
-            {
-              "background": "#D3DAE4",
-              "value": "draft"
-            },
-            {
-              "background": "#F7971C",
-              "value": "archived"
-            }
-          ],
-          "showAsDot": true
-        },
-        "field": "status",
-        "group": null,
-        "hidden": false,
-        "interface": "select-dropdown",
-        "note": null,
-        "options": {
-          "choices": [
-            {
-              "text": "$t:published",
-              "value": "published"
-            },
-            {
-              "text": "$t:draft",
-              "value": "draft"
-            },
-            {
-              "text": "$t:archived",
-              "value": "archived"
-            }
-          ]
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 3,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "status",
-        "table": "picks_of_the_day",
-        "data_type": "character varying",
-        "default_value": "draft",
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": false,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "picks_of_the_day",
       "field": "tags",
       "type": "alias",
       "meta": {
@@ -9412,7 +11800,7 @@
         "interface": "list-m2m",
         "note": null,
         "options": {
-          "template": "{{tag_id.name}}"
+          "template": "{{tag.name}}"
         },
         "readonly": false,
         "required": false,
@@ -9424,152 +11812,6 @@
         "validation": null,
         "validation_message": null,
         "width": "full"
-      }
-    },
-    {
-      "collection": "picks_of_the_day",
-      "field": "updated_by",
-      "type": "uuid",
-      "meta": {
-        "collection": "picks_of_the_day",
-        "conditions": null,
-        "display": "user",
-        "display_options": null,
-        "field": "updated_by",
-        "group": null,
-        "hidden": true,
-        "interface": "select-dropdown-m2o",
-        "note": null,
-        "options": {
-          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
-        },
-        "readonly": true,
-        "required": false,
-        "sort": 21,
-        "special": [
-          "user-updated"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "updated_by",
-        "table": "picks_of_the_day",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "directus_users",
-        "foreign_key_column": "id"
-      }
-    },
-    {
-      "collection": "picks_of_the_day",
-      "field": "updated_on",
-      "type": "timestamp",
-      "meta": {
-        "collection": "picks_of_the_day",
-        "conditions": null,
-        "display": "datetime",
-        "display_options": {
-          "relative": true
-        },
-        "field": "updated_on",
-        "group": null,
-        "hidden": true,
-        "interface": "datetime",
-        "note": null,
-        "options": null,
-        "readonly": true,
-        "required": false,
-        "sort": 22,
-        "special": [
-          "date-updated"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "updated_on",
-        "table": "picks_of_the_day",
-        "data_type": "timestamp with time zone",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "picks_of_the_day",
-      "field": "website_url",
-      "type": "string",
-      "meta": {
-        "collection": "picks_of_the_day",
-        "conditions": [
-          {
-            "name": "If published",
-            "rule": {
-              "status": {
-                "_eq": "published"
-              }
-            },
-            "required": true
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "website_url",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 7,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "website_url",
-        "table": "picks_of_the_day",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
       }
     },
     {
@@ -9616,14 +11858,14 @@
     },
     {
       "collection": "podcast_members",
-      "field": "member_id",
+      "field": "podcast",
       "type": "uuid",
       "meta": {
         "collection": "podcast_members",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "member_id",
+        "field": "podcast",
         "group": null,
         "hidden": true,
         "interface": null,
@@ -9639,49 +11881,7 @@
         "width": "full"
       },
       "schema": {
-        "name": "member_id",
-        "table": "podcast_members",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "members",
-        "foreign_key_column": "id"
-      }
-    },
-    {
-      "collection": "podcast_members",
-      "field": "podcast_id",
-      "type": "uuid",
-      "meta": {
-        "collection": "podcast_members",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "podcast_id",
-        "group": null,
-        "hidden": true,
-        "interface": null,
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": null,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "podcast_id",
+        "name": "podcast",
         "table": "podcast_members",
         "data_type": "uuid",
         "default_value": null,
@@ -9695,6 +11895,48 @@
         "generation_expression": null,
         "has_auto_increment": false,
         "foreign_key_table": "podcasts",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "podcast_members",
+      "field": "member",
+      "type": "uuid",
+      "meta": {
+        "collection": "podcast_members",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "member",
+        "group": null,
+        "hidden": true,
+        "interface": null,
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": null,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "member",
+        "table": "podcast_members",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "members",
         "foreign_key_column": "id"
       }
     },
@@ -9742,24 +11984,24 @@
     },
     {
       "collection": "podcast_page",
-      "field": "cover_image",
+      "field": "id",
       "type": "uuid",
       "meta": {
         "collection": "podcast_page",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "cover_image",
+        "field": "id",
         "group": null,
-        "hidden": false,
-        "interface": "file-image",
+        "hidden": true,
+        "interface": "input",
         "note": null,
         "options": null,
-        "readonly": false,
-        "required": true,
-        "sort": 7,
+        "readonly": true,
+        "required": false,
+        "sort": 16,
         "special": [
-          "file"
+          "uuid"
         ],
         "translations": null,
         "validation": null,
@@ -9767,21 +12009,94 @@
         "width": "full"
       },
       "schema": {
-        "name": "cover_image",
+        "name": "id",
         "table": "podcast_page",
         "data_type": "uuid",
         "default_value": null,
         "max_length": null,
         "numeric_precision": null,
         "numeric_scale": null,
-        "is_nullable": true,
+        "is_nullable": false,
+        "is_unique": true,
+        "is_primary_key": true,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "podcast_page",
+      "field": "status",
+      "type": "string",
+      "meta": {
+        "collection": "podcast_page",
+        "conditions": null,
+        "display": "labels",
+        "display_options": {
+          "choices": [
+            {
+              "background": "#00C897",
+              "value": "published"
+            },
+            {
+              "background": "#D3DAE4",
+              "value": "draft"
+            },
+            {
+              "background": "#F7971C",
+              "value": "archived"
+            }
+          ],
+          "showAsDot": true
+        },
+        "field": "status",
+        "group": null,
+        "hidden": false,
+        "interface": "select-dropdown",
+        "note": null,
+        "options": {
+          "choices": [
+            {
+              "text": "$t:published",
+              "value": "published"
+            },
+            {
+              "text": "$t:draft",
+              "value": "draft"
+            },
+            {
+              "text": "$t:archived",
+              "value": "archived"
+            }
+          ]
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 2,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "status",
+        "table": "podcast_page",
+        "data_type": "character varying",
+        "default_value": "draft",
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": false,
         "is_unique": false,
         "is_primary_key": false,
         "is_generated": false,
         "generation_expression": null,
         "has_auto_increment": false,
-        "foreign_key_table": "directus_files",
-        "foreign_key_column": "id"
+        "foreign_key_table": null,
+        "foreign_key_column": null
       }
     },
     {
@@ -9803,7 +12118,7 @@
         },
         "readonly": true,
         "required": false,
-        "sort": 16,
+        "sort": 17,
         "special": [
           "user-created"
         ],
@@ -9849,7 +12164,7 @@
         "options": null,
         "readonly": true,
         "required": false,
-        "sort": 17,
+        "sort": 18,
         "special": [
           "date-created"
         ],
@@ -9878,116 +12193,94 @@
     },
     {
       "collection": "podcast_page",
-      "field": "cto_special_heading",
-      "type": "string",
+      "field": "updated_by",
+      "type": "uuid",
       "meta": {
         "collection": "podcast_page",
         "conditions": null,
-        "display": null,
+        "display": "user",
         "display_options": null,
-        "field": "cto_special_heading",
+        "field": "updated_by",
         "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": true,
-        "sort": 12,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "cto_special_heading",
-        "table": "podcast_page",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "podcast_page",
-      "field": "deep_dive_heading",
-      "type": "string",
-      "meta": {
-        "collection": "podcast_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "deep_dive_heading",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": true,
-        "sort": 11,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "deep_dive_heading",
-        "table": "podcast_page",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "podcast_page",
-      "field": "divider-content",
-      "type": "alias",
-      "meta": {
-        "collection": "podcast_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-content",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
+        "hidden": true,
+        "interface": "select-dropdown-m2o",
         "note": null,
         "options": {
-          "title": "Content"
+          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
         },
-        "readonly": false,
+        "readonly": true,
         "required": false,
-        "sort": 6,
+        "sort": 19,
         "special": [
-          "alias",
-          "no-data"
+          "user-updated"
         ],
         "translations": null,
         "validation": null,
         "validation_message": null,
-        "width": "full"
+        "width": "half"
+      },
+      "schema": {
+        "name": "updated_by",
+        "table": "podcast_page",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "podcast_page",
+      "field": "updated_on",
+      "type": "timestamp",
+      "meta": {
+        "collection": "podcast_page",
+        "conditions": null,
+        "display": "datetime",
+        "display_options": {
+          "relative": true
+        },
+        "field": "updated_on",
+        "group": null,
+        "hidden": true,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 20,
+        "special": [
+          "date-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "updated_on",
+        "table": "podcast_page",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
       }
     },
     {
@@ -10007,7 +12300,7 @@
         "options": null,
         "readonly": false,
         "required": false,
-        "sort": 14,
+        "sort": 15,
         "special": [
           "alias",
           "no-data"
@@ -10050,41 +12343,147 @@
     },
     {
       "collection": "podcast_page",
-      "field": "id",
-      "type": "uuid",
+      "field": "divider-content",
+      "type": "alias",
       "meta": {
         "collection": "podcast_page",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "id",
+        "field": "divider-content",
         "group": null,
-        "hidden": true,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": {
+          "title": "Content"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 6,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "podcast_page",
+      "field": "notice-meta",
+      "type": "alias",
+      "meta": {
+        "collection": "podcast_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "notice-meta",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-notice",
+        "note": null,
+        "options": {
+          "text": "Nach Möglichkeit sollte der Meta-Titel nicht länger als 42 Zeichen lang sein und die Meta-Beschreibung nicht länger als 160 Zeichen."
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 3,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "podcast_page",
+      "field": "meta_title",
+      "type": "string",
+      "meta": {
+        "collection": "podcast_page",
+        "conditions": null,
+        "display": null,
+        "display_options": {
+          "conditionalFormatting": null
+        },
+        "field": "meta_title",
+        "group": null,
+        "hidden": false,
         "interface": "input",
         "note": null,
-        "options": null,
-        "readonly": true,
-        "required": false,
-        "sort": 15,
-        "special": [
-          "uuid"
-        ],
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": true,
+        "sort": 4,
+        "special": null,
         "translations": null,
         "validation": null,
         "validation_message": null,
         "width": "full"
       },
       "schema": {
-        "name": "id",
+        "name": "meta_title",
         "table": "podcast_page",
-        "data_type": "uuid",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "podcast_page",
+      "field": "meta_description",
+      "type": "text",
+      "meta": {
+        "collection": "podcast_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "meta_description",
+        "group": null,
+        "hidden": false,
+        "interface": "input-multiline",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": true,
+        "sort": 5,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "meta_description",
+        "table": "podcast_page",
+        "data_type": "text",
         "default_value": null,
         "max_length": null,
         "numeric_precision": null,
         "numeric_scale": null,
-        "is_nullable": false,
-        "is_unique": true,
-        "is_primary_key": true,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
         "is_generated": false,
         "generation_expression": null,
         "has_auto_increment": false,
@@ -10240,36 +12639,34 @@
     },
     {
       "collection": "podcast_page",
-      "field": "meta_description",
-      "type": "text",
+      "field": "deep_dive_heading",
+      "type": "string",
       "meta": {
         "collection": "podcast_page",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "meta_description",
+        "field": "deep_dive_heading",
         "group": null,
         "hidden": false,
-        "interface": "input-multiline",
+        "interface": "input",
         "note": null,
-        "options": {
-          "trim": true
-        },
+        "options": null,
         "readonly": false,
         "required": true,
-        "sort": 5,
+        "sort": 12,
         "special": null,
         "translations": null,
         "validation": null,
         "validation_message": null,
-        "width": "full"
+        "width": "half"
       },
       "schema": {
-        "name": "meta_description",
+        "name": "deep_dive_heading",
         "table": "podcast_page",
-        "data_type": "text",
+        "data_type": "character varying",
         "default_value": null,
-        "max_length": null,
+        "max_length": 255,
         "numeric_precision": null,
         "numeric_scale": null,
         "is_nullable": true,
@@ -10284,34 +12681,30 @@
     },
     {
       "collection": "podcast_page",
-      "field": "meta_title",
+      "field": "cto_special_heading",
       "type": "string",
       "meta": {
         "collection": "podcast_page",
         "conditions": null,
         "display": null,
-        "display_options": {
-          "conditionalFormatting": null
-        },
-        "field": "meta_title",
+        "display_options": null,
+        "field": "cto_special_heading",
         "group": null,
         "hidden": false,
         "interface": "input",
         "note": null,
-        "options": {
-          "trim": true
-        },
+        "options": null,
         "readonly": false,
         "required": true,
-        "sort": 4,
+        "sort": 13,
         "special": null,
         "translations": null,
         "validation": null,
         "validation_message": null,
-        "width": "full"
+        "width": "half"
       },
       "schema": {
-        "name": "meta_title",
+        "name": "cto_special_heading",
         "table": "podcast_page",
         "data_type": "character varying",
         "default_value": null,
@@ -10345,7 +12738,7 @@
         "options": null,
         "readonly": false,
         "required": true,
-        "sort": 13,
+        "sort": 11,
         "special": null,
         "translations": null,
         "validation": null,
@@ -10372,137 +12765,32 @@
     },
     {
       "collection": "podcast_page",
-      "field": "notice-meta",
-      "type": "alias",
+      "field": "cover_image",
+      "type": "uuid",
       "meta": {
         "collection": "podcast_page",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "notice-meta",
+        "field": "cover_image",
         "group": null,
         "hidden": false,
-        "interface": "presentation-notice",
+        "interface": "file-image",
         "note": null,
-        "options": {
-          "text": "Nach Möglichkeit sollte der Meta-Titel nicht länger als 42 Zeichen lang sein und die Meta-Beschreibung nicht länger als 160 Zeichen."
-        },
+        "options": null,
         "readonly": false,
-        "required": false,
-        "sort": 3,
+        "required": true,
+        "sort": 7,
         "special": [
-          "alias",
-          "no-data"
+          "file"
         ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "podcast_page",
-      "field": "status",
-      "type": "string",
-      "meta": {
-        "collection": "podcast_page",
-        "conditions": null,
-        "display": "labels",
-        "display_options": {
-          "choices": [
-            {
-              "background": "#00C897",
-              "value": "published"
-            },
-            {
-              "background": "#D3DAE4",
-              "value": "draft"
-            },
-            {
-              "background": "#F7971C",
-              "value": "archived"
-            }
-          ],
-          "showAsDot": true
-        },
-        "field": "status",
-        "group": null,
-        "hidden": false,
-        "interface": "select-dropdown",
-        "note": null,
-        "options": {
-          "choices": [
-            {
-              "text": "$t:published",
-              "value": "published"
-            },
-            {
-              "text": "$t:draft",
-              "value": "draft"
-            },
-            {
-              "text": "$t:archived",
-              "value": "archived"
-            }
-          ]
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 2,
-        "special": null,
         "translations": null,
         "validation": null,
         "validation_message": null,
         "width": "full"
       },
       "schema": {
-        "name": "status",
-        "table": "podcast_page",
-        "data_type": "character varying",
-        "default_value": "draft",
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": false,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "podcast_page",
-      "field": "updated_by",
-      "type": "uuid",
-      "meta": {
-        "collection": "podcast_page",
-        "conditions": null,
-        "display": "user",
-        "display_options": null,
-        "field": "updated_by",
-        "group": null,
-        "hidden": true,
-        "interface": "select-dropdown-m2o",
-        "note": null,
-        "options": {
-          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
-        },
-        "readonly": true,
-        "required": false,
-        "sort": 18,
-        "special": [
-          "user-updated"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "updated_by",
+        "name": "cover_image",
         "table": "podcast_page",
         "data_type": "uuid",
         "default_value": null,
@@ -10515,44 +12803,40 @@
         "is_generated": false,
         "generation_expression": null,
         "has_auto_increment": false,
-        "foreign_key_table": "directus_users",
+        "foreign_key_table": "directus_files",
         "foreign_key_column": "id"
       }
     },
     {
       "collection": "podcast_page",
-      "field": "updated_on",
-      "type": "timestamp",
+      "field": "other_heading",
+      "type": "string",
       "meta": {
         "collection": "podcast_page",
         "conditions": null,
-        "display": "datetime",
-        "display_options": {
-          "relative": true
-        },
-        "field": "updated_on",
+        "display": null,
+        "display_options": null,
+        "field": "other_heading",
         "group": null,
-        "hidden": true,
-        "interface": "datetime",
+        "hidden": false,
+        "interface": "input",
         "note": null,
         "options": null,
-        "readonly": true,
-        "required": false,
-        "sort": 19,
-        "special": [
-          "date-updated"
-        ],
+        "readonly": false,
+        "required": true,
+        "sort": 14,
+        "special": null,
         "translations": null,
         "validation": null,
         "validation_message": null,
         "width": "half"
       },
       "schema": {
-        "name": "updated_on",
+        "name": "other_heading",
         "table": "podcast_page",
-        "data_type": "timestamp with time zone",
+        "data_type": "character varying",
         "default_value": null,
-        "max_length": null,
+        "max_length": 255,
         "numeric_precision": null,
         "numeric_scale": null,
         "is_nullable": true,
@@ -10609,14 +12893,14 @@
     },
     {
       "collection": "podcast_speakers",
-      "field": "podcast_id",
+      "field": "podcast",
       "type": "uuid",
       "meta": {
         "collection": "podcast_speakers",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "podcast_id",
+        "field": "podcast",
         "group": null,
         "hidden": true,
         "interface": null,
@@ -10632,7 +12916,7 @@
         "width": "full"
       },
       "schema": {
-        "name": "podcast_id",
+        "name": "podcast",
         "table": "podcast_speakers",
         "data_type": "uuid",
         "default_value": null,
@@ -10646,6 +12930,48 @@
         "generation_expression": null,
         "has_auto_increment": false,
         "foreign_key_table": "podcasts",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "podcast_speakers",
+      "field": "speaker",
+      "type": "uuid",
+      "meta": {
+        "collection": "podcast_speakers",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "speaker",
+        "group": null,
+        "hidden": true,
+        "interface": null,
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": null,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "speaker",
+        "table": "podcast_speakers",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "speakers",
         "foreign_key_column": "id"
       }
     },
@@ -10689,48 +13015,6 @@
         "has_auto_increment": false,
         "foreign_key_table": null,
         "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "podcast_speakers",
-      "field": "speaker_id",
-      "type": "uuid",
-      "meta": {
-        "collection": "podcast_speakers",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "speaker_id",
-        "group": null,
-        "hidden": true,
-        "interface": null,
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": null,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "speaker_id",
-        "table": "podcast_speakers",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "speakers",
-        "foreign_key_column": "id"
       }
     },
     {
@@ -10777,14 +13061,14 @@
     },
     {
       "collection": "podcast_tags",
-      "field": "podcast_id",
+      "field": "podcast",
       "type": "uuid",
       "meta": {
         "collection": "podcast_tags",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "podcast_id",
+        "field": "podcast",
         "group": null,
         "hidden": true,
         "interface": null,
@@ -10800,7 +13084,7 @@
         "width": "full"
       },
       "schema": {
-        "name": "podcast_id",
+        "name": "podcast",
         "table": "podcast_tags",
         "data_type": "uuid",
         "default_value": null,
@@ -10814,6 +13098,48 @@
         "generation_expression": null,
         "has_auto_increment": false,
         "foreign_key_table": "podcasts",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "podcast_tags",
+      "field": "tag",
+      "type": "uuid",
+      "meta": {
+        "collection": "podcast_tags",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "tag",
+        "group": null,
+        "hidden": true,
+        "interface": null,
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": null,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "tag",
+        "table": "podcast_tags",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "tags",
         "foreign_key_column": "id"
       }
     },
@@ -10849,607 +13175,6 @@
         "max_length": null,
         "numeric_precision": 32,
         "numeric_scale": 0,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "podcast_tags",
-      "field": "tag_id",
-      "type": "uuid",
-      "meta": {
-        "collection": "podcast_tags",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "tag_id",
-        "group": null,
-        "hidden": true,
-        "interface": null,
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": null,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "tag_id",
-        "table": "podcast_tags",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "tags",
-        "foreign_key_column": "id"
-      }
-    },
-    {
-      "collection": "podcasts",
-      "field": "apple_url",
-      "type": "string",
-      "meta": {
-        "collection": "podcasts",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "apple_url",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 15,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "apple_url",
-        "table": "podcasts",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "podcasts",
-      "field": "audio_file",
-      "type": "uuid",
-      "meta": {
-        "collection": "podcasts",
-        "conditions": [
-          {
-            "name": "If published",
-            "rule": {
-              "status": {
-                "_eq": "published"
-              }
-            },
-            "required": true
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "audio_file",
-        "group": null,
-        "hidden": false,
-        "interface": "file",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 11,
-        "special": [
-          "file"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "audio_file",
-        "table": "podcasts",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "directus_files",
-        "foreign_key_column": "id"
-      }
-    },
-    {
-      "collection": "podcasts",
-      "field": "audio_url",
-      "type": "string",
-      "meta": {
-        "collection": "podcasts",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "audio_url",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 12,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "audio_url",
-        "table": "podcasts",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "podcasts",
-      "field": "banner_image",
-      "type": "uuid",
-      "meta": {
-        "collection": "podcasts",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "banner_image",
-        "group": null,
-        "hidden": false,
-        "interface": "file-image",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 10,
-        "special": [
-          "file"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "banner_image",
-        "table": "podcasts",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "directus_files",
-        "foreign_key_column": "id"
-      }
-    },
-    {
-      "collection": "podcasts",
-      "field": "cover_image",
-      "type": "uuid",
-      "meta": {
-        "collection": "podcasts",
-        "conditions": [
-          {
-            "name": "If published",
-            "rule": {
-              "status": {
-                "_eq": "published"
-              }
-            },
-            "required": true
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "cover_image",
-        "group": null,
-        "hidden": false,
-        "interface": "file-image",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 9,
-        "special": [
-          "file"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "cover_image",
-        "table": "podcasts",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "directus_files",
-        "foreign_key_column": "id"
-      }
-    },
-    {
-      "collection": "podcasts",
-      "field": "created_by",
-      "type": "uuid",
-      "meta": {
-        "collection": "podcasts",
-        "conditions": null,
-        "display": "user",
-        "display_options": null,
-        "field": "created_by",
-        "group": null,
-        "hidden": true,
-        "interface": "select-dropdown-m2o",
-        "note": null,
-        "options": {
-          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
-        },
-        "readonly": true,
-        "required": false,
-        "sort": 26,
-        "special": [
-          "user-created"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "created_by",
-        "table": "podcasts",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "directus_users",
-        "foreign_key_column": "id"
-      }
-    },
-    {
-      "collection": "podcasts",
-      "field": "created_on",
-      "type": "timestamp",
-      "meta": {
-        "collection": "podcasts",
-        "conditions": null,
-        "display": "datetime",
-        "display_options": {
-          "relative": true
-        },
-        "field": "created_on",
-        "group": null,
-        "hidden": true,
-        "interface": "datetime",
-        "note": null,
-        "options": null,
-        "readonly": true,
-        "required": false,
-        "sort": 27,
-        "special": [
-          "date-created"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "created_on",
-        "table": "podcasts",
-        "data_type": "timestamp with time zone",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "podcasts",
-      "field": "description",
-      "type": "text",
-      "meta": {
-        "collection": "podcasts",
-        "conditions": [
-          {
-            "name": "If published",
-            "rule": {
-              "status": {
-                "_eq": "published"
-              }
-            },
-            "required": true
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "description",
-        "group": null,
-        "hidden": false,
-        "interface": "input-rich-text-html",
-        "note": null,
-        "options": {
-          "toolbar": [
-            "blockquote",
-            "bold",
-            "bullist",
-            "code",
-            "customLink",
-            "fullscreen",
-            "italic",
-            "numlist",
-            "removeformat",
-            "underline"
-          ]
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 13,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "description",
-        "table": "podcasts",
-        "data_type": "text",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "podcasts",
-      "field": "divider-hidden",
-      "type": "alias",
-      "meta": {
-        "collection": "podcasts",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-hidden",
-        "group": null,
-        "hidden": true,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 23,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "podcasts",
-      "field": "divider-metadata",
-      "type": "alias",
-      "meta": {
-        "collection": "podcasts",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-metadata",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": {
-          "title": "Metadata"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 1,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "podcasts",
-      "field": "divider-podcast",
-      "type": "alias",
-      "meta": {
-        "collection": "podcasts",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-podcast",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": {
-          "title": "Podcast"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 5,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "podcasts",
-      "field": "divider-relations",
-      "type": "alias",
-      "meta": {
-        "collection": "podcasts",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-relations",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": {
-          "title": "Relations"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 18,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "podcasts",
-      "field": "google_url",
-      "type": "string",
-      "meta": {
-        "collection": "podcasts",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "google_url",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 16,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "google_url",
-        "table": "podcasts",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
         "is_nullable": true,
         "is_unique": false,
         "is_primary_key": false,
@@ -11477,7 +13202,7 @@
         "options": null,
         "readonly": true,
         "required": false,
-        "sort": 24,
+        "sort": 27,
         "special": [
           "uuid"
         ],
@@ -11497,390 +13222,6 @@
         "is_nullable": false,
         "is_unique": true,
         "is_primary_key": true,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "podcasts",
-      "field": "members",
-      "type": "alias",
-      "meta": {
-        "collection": "podcasts",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "members",
-        "group": null,
-        "hidden": false,
-        "interface": "list-m2m",
-        "note": null,
-        "options": {
-          "template": "{{member_id.first_name}} {{member_id.last_name}}"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 19,
-        "special": [
-          "m2m"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "podcasts",
-      "field": "notice-publish",
-      "type": "alias",
-      "meta": {
-        "collection": "podcasts",
-        "conditions": [
-          {
-            "name": "If not draft",
-            "rule": {
-              "status": {
-                "_neq": "draft"
-              }
-            },
-            "hidden": true
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "notice-publish",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-notice",
-        "note": null,
-        "options": {
-          "text": "Wähle bei \"Published On\" ein Datum in der Zukunft, um die Podcastfolge zu diesem Zeitpunk automatisch zu veröffentlichen."
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 2,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "podcasts",
-      "field": "number",
-      "type": "string",
-      "meta": {
-        "collection": "podcasts",
-        "conditions": [
-          {
-            "name": "If published",
-            "rule": {
-              "status": {
-                "_eq": "published"
-              }
-            },
-            "required": true
-          },
-          {
-            "name": "If Deep Dive",
-            "rule": {
-              "type": {
-                "_eq": "deep_dive"
-              }
-            },
-            "options": {
-              "placeholder": "999"
-            }
-          },
-          {
-            "name": "If CTO-Special",
-            "rule": {
-              "type": {
-                "_eq": "cto_special"
-              }
-            },
-            "options": {
-              "placeholder": "#99"
-            }
-          },
-          {
-            "name": "If News",
-            "rule": {
-              "type": {
-                "_eq": "news"
-              }
-            },
-            "options": {
-              "placeholder": "01/22"
-            }
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "number",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 7,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "number",
-        "table": "podcasts",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "podcasts",
-      "field": "picks_of_the_day",
-      "type": "alias",
-      "meta": {
-        "collection": "podcasts",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "picks_of_the_day",
-        "group": null,
-        "hidden": false,
-        "interface": "list-o2m",
-        "note": null,
-        "options": {
-          "template": "{{name}}"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 21,
-        "special": [
-          "o2m"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "podcasts",
-      "field": "published_on",
-      "type": "timestamp",
-      "meta": {
-        "collection": "podcasts",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "published_on",
-        "group": null,
-        "hidden": false,
-        "interface": "datetime",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 4,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "published_on",
-        "table": "podcasts",
-        "data_type": "timestamp with time zone",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "podcasts",
-      "field": "slug",
-      "type": "string",
-      "meta": {
-        "collection": "podcasts",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "slug",
-        "group": null,
-        "hidden": true,
-        "interface": "input",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 25,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "slug",
-        "table": "podcasts",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "podcasts",
-      "field": "sort",
-      "type": "integer",
-      "meta": {
-        "collection": "podcasts",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "sort",
-        "group": null,
-        "hidden": true,
-        "interface": "input",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 30,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "sort",
-        "table": "podcasts",
-        "data_type": "integer",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": 32,
-        "numeric_scale": 0,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "podcasts",
-      "field": "speakers",
-      "type": "alias",
-      "meta": {
-        "collection": "podcasts",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "speakers",
-        "group": null,
-        "hidden": false,
-        "interface": "list-m2m",
-        "note": null,
-        "options": {
-          "template": "{{speaker_id.first_name}} {{speaker_id.last_name}}"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 20,
-        "special": [
-          "m2m"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "podcasts",
-      "field": "spotify_url",
-      "type": "string",
-      "meta": {
-        "collection": "podcasts",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "spotify_url",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 17,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "spotify_url",
-        "table": "podcasts",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
         "is_generated": false,
         "generation_expression": null,
         "has_auto_increment": false,
@@ -11936,7 +13277,7 @@
         },
         "readonly": false,
         "required": false,
-        "sort": 3,
+        "sort": 4,
         "special": null,
         "translations": null,
         "validation": null,
@@ -11963,63 +13304,22 @@
     },
     {
       "collection": "podcasts",
-      "field": "tags",
-      "type": "alias",
+      "field": "sort",
+      "type": "integer",
       "meta": {
         "collection": "podcasts",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "tags",
+        "field": "sort",
         "group": null,
-        "hidden": false,
-        "interface": "list-m2m",
-        "note": null,
-        "options": {
-          "template": "{{tag_id.name}}"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 22,
-        "special": [
-          "m2m"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "podcasts",
-      "field": "title",
-      "type": "string",
-      "meta": {
-        "collection": "podcasts",
-        "conditions": [
-          {
-            "name": "If published",
-            "rule": {
-              "status": {
-                "_eq": "published"
-              }
-            },
-            "required": true
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "title",
-        "group": null,
-        "hidden": false,
+        "hidden": true,
         "interface": "input",
         "note": null,
-        "options": {
-          "trim": true
-        },
+        "options": null,
         "readonly": false,
         "required": false,
-        "sort": 8,
+        "sort": 34,
         "special": null,
         "translations": null,
         "validation": null,
@@ -12027,11 +13327,103 @@
         "width": "full"
       },
       "schema": {
-        "name": "title",
+        "name": "sort",
         "table": "podcasts",
-        "data_type": "character varying",
+        "data_type": "integer",
         "default_value": null,
-        "max_length": 255,
+        "max_length": null,
+        "numeric_precision": 32,
+        "numeric_scale": 0,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "created_by",
+      "type": "uuid",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": null,
+        "display": "user",
+        "display_options": null,
+        "field": "created_by",
+        "group": null,
+        "hidden": true,
+        "interface": "select-dropdown-m2o",
+        "note": null,
+        "options": {
+          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+        },
+        "readonly": true,
+        "required": false,
+        "sort": 30,
+        "special": [
+          "user-created"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "created_by",
+        "table": "podcasts",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "created_on",
+      "type": "timestamp",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": null,
+        "display": "datetime",
+        "display_options": {
+          "relative": true
+        },
+        "field": "created_on",
+        "group": null,
+        "hidden": true,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 31,
+        "special": [
+          "date-created"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "created_on",
+        "table": "podcasts",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
         "numeric_precision": null,
         "numeric_scale": null,
         "is_nullable": true,
@@ -12046,46 +13438,168 @@
     },
     {
       "collection": "podcasts",
-      "field": "transcript",
-      "type": "text",
+      "field": "updated_by",
+      "type": "uuid",
       "meta": {
         "collection": "podcasts",
-        "conditions": [
-          {
-            "name": "If null",
-            "rule": {
-              "transcript": {
-                "_null": true
-              }
-            },
-            "hidden": true
-          }
-        ],
-        "display": null,
+        "conditions": null,
+        "display": "user",
         "display_options": null,
-        "field": "transcript",
+        "field": "updated_by",
         "group": null,
-        "hidden": false,
-        "interface": "input-multiline",
+        "hidden": true,
+        "interface": "select-dropdown-m2o",
         "note": null,
         "options": {
-          "trim": true
+          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
         },
+        "readonly": true,
+        "required": false,
+        "sort": 32,
+        "special": [
+          "user-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "updated_by",
+        "table": "podcasts",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "updated_on",
+      "type": "timestamp",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": null,
+        "display": "datetime",
+        "display_options": {
+          "relative": true
+        },
+        "field": "updated_on",
+        "group": null,
+        "hidden": true,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 33,
+        "special": [
+          "date-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "updated_on",
+        "table": "podcasts",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "published_on",
+      "type": "timestamp",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "published_on",
+        "group": null,
+        "hidden": false,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
         "readonly": false,
         "required": false,
-        "sort": 14,
+        "sort": 5,
         "special": null,
         "translations": null,
         "validation": null,
         "validation_message": null,
-        "width": "full"
+        "width": "half"
       },
       "schema": {
-        "name": "transcript",
+        "name": "published_on",
         "table": "podcasts",
-        "data_type": "text",
+        "data_type": "timestamp with time zone",
         "default_value": null,
         "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "slug",
+      "type": "string",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "slug",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 28,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "slug",
+        "table": "podcasts",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
         "numeric_precision": null,
         "numeric_scale": null,
         "is_nullable": true,
@@ -12144,7 +13658,7 @@
         },
         "readonly": false,
         "required": false,
-        "sort": 6,
+        "sort": 8,
         "special": null,
         "translations": null,
         "validation": null,
@@ -12171,243 +13685,76 @@
     },
     {
       "collection": "podcasts",
-      "field": "updated_by",
-      "type": "uuid",
-      "meta": {
-        "collection": "podcasts",
-        "conditions": null,
-        "display": "user",
-        "display_options": null,
-        "field": "updated_by",
-        "group": null,
-        "hidden": true,
-        "interface": "select-dropdown-m2o",
-        "note": null,
-        "options": {
-          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
-        },
-        "readonly": true,
-        "required": false,
-        "sort": 28,
-        "special": [
-          "user-updated"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "updated_by",
-        "table": "podcasts",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "directus_users",
-        "foreign_key_column": "id"
-      }
-    },
-    {
-      "collection": "podcasts",
-      "field": "updated_on",
-      "type": "timestamp",
-      "meta": {
-        "collection": "podcasts",
-        "conditions": null,
-        "display": "datetime",
-        "display_options": {
-          "relative": true
-        },
-        "field": "updated_on",
-        "group": null,
-        "hidden": true,
-        "interface": "datetime",
-        "note": null,
-        "options": null,
-        "readonly": true,
-        "required": false,
-        "sort": 29,
-        "special": [
-          "date-updated"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "updated_on",
-        "table": "podcasts",
-        "data_type": "timestamp with time zone",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "privacy_page",
-      "field": "created_by",
-      "type": "uuid",
-      "meta": {
-        "collection": "privacy_page",
-        "conditions": null,
-        "display": "user",
-        "display_options": null,
-        "field": "created_by",
-        "group": null,
-        "hidden": true,
-        "interface": "select-dropdown-m2o",
-        "note": null,
-        "options": {
-          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
-        },
-        "readonly": true,
-        "required": false,
-        "sort": 6,
-        "special": [
-          "user-created"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "created_by",
-        "table": "privacy_page",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "directus_users",
-        "foreign_key_column": "id"
-      }
-    },
-    {
-      "collection": "privacy_page",
-      "field": "created_on",
-      "type": "timestamp",
-      "meta": {
-        "collection": "privacy_page",
-        "conditions": null,
-        "display": "datetime",
-        "display_options": {
-          "relative": true
-        },
-        "field": "created_on",
-        "group": null,
-        "hidden": true,
-        "interface": "datetime",
-        "note": null,
-        "options": null,
-        "readonly": true,
-        "required": false,
-        "sort": 7,
-        "special": [
-          "date-created"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "created_on",
-        "table": "privacy_page",
-        "data_type": "timestamp with time zone",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "privacy_page",
-      "field": "divider-hidden",
-      "type": "alias",
-      "meta": {
-        "collection": "privacy_page",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-hidden",
-        "group": null,
-        "hidden": true,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 4,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "privacy_page",
-      "field": "heading",
+      "field": "number",
       "type": "string",
       "meta": {
-        "collection": "privacy_page",
-        "conditions": null,
+        "collection": "podcasts",
+        "conditions": [
+          {
+            "name": "If Deep Dive",
+            "rule": {
+              "type": {
+                "_eq": "deep_dive"
+              }
+            },
+            "options": {
+              "placeholder": "999"
+            }
+          },
+          {
+            "name": "If CTO-Special",
+            "rule": {
+              "type": {
+                "_eq": "cto_special"
+              }
+            },
+            "options": {
+              "placeholder": "#99"
+            }
+          },
+          {
+            "name": "If News",
+            "rule": {
+              "type": {
+                "_eq": "news"
+              }
+            },
+            "options": {
+              "placeholder": "01/22"
+            }
+          },
+          {
+            "name": "If published",
+            "rule": {
+              "status": {
+                "_eq": "published"
+              }
+            },
+            "required": true
+          }
+        ],
         "display": null,
         "display_options": null,
-        "field": "heading",
+        "field": "number",
         "group": null,
         "hidden": false,
         "interface": "input",
         "note": null,
-        "options": null,
+        "options": {
+          "trim": true
+        },
         "readonly": false,
-        "required": true,
-        "sort": 2,
+        "required": false,
+        "sort": 9,
         "special": null,
         "translations": null,
         "validation": null,
         "validation_message": null,
-        "width": "full"
+        "width": "half"
       },
       "schema": {
-        "name": "heading",
-        "table": "privacy_page",
+        "name": "number",
+        "table": "podcasts",
         "data_type": "character varying",
         "default_value": null,
         "max_length": 255,
@@ -12421,6 +13768,1073 @@
         "has_auto_increment": false,
         "foreign_key_table": null,
         "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "title",
+      "type": "string",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": [
+          {
+            "name": "If published",
+            "rule": {
+              "status": {
+                "_eq": "published"
+              }
+            },
+            "required": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "title",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 10,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "title",
+        "table": "podcasts",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "cover_image",
+      "type": "uuid",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": [
+          {
+            "name": "If published",
+            "rule": {
+              "status": {
+                "_eq": "published"
+              }
+            },
+            "required": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "cover_image",
+        "group": null,
+        "hidden": false,
+        "interface": "file-image",
+        "note": null,
+        "options": {
+          "folder": "35140572-5f04-494b-b197-bd9ef1edc33d"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 11,
+        "special": [
+          "file"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "cover_image",
+        "table": "podcasts",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_files",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "banner_image",
+      "type": "uuid",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "banner_image",
+        "group": null,
+        "hidden": false,
+        "interface": "file-image",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 12,
+        "special": [
+          "file"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "banner_image",
+        "table": "podcasts",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_files",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "description",
+      "type": "text",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": [
+          {
+            "name": "If published",
+            "rule": {
+              "status": {
+                "_eq": "published"
+              }
+            },
+            "required": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "description",
+        "group": null,
+        "hidden": false,
+        "interface": "input-rich-text-html",
+        "note": null,
+        "options": {
+          "tinymceOverrides": {
+            "browser_spellcheck": true
+          },
+          "toolbar": [
+            "blockquote",
+            "bold",
+            "bullist",
+            "code",
+            "customLink",
+            "fullscreen",
+            "italic",
+            "numlist",
+            "removeformat",
+            "underline"
+          ]
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 15,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "description",
+        "table": "podcasts",
+        "data_type": "text",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "audio_file",
+      "type": "uuid",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": [
+          {
+            "name": "If published",
+            "rule": {
+              "status": {
+                "_eq": "published"
+              }
+            },
+            "required": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "audio_file",
+        "group": null,
+        "hidden": false,
+        "interface": "file",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 13,
+        "special": [
+          "file"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "audio_file",
+        "table": "podcasts",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_files",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "audio_url",
+      "type": "string",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "audio_url",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 14,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "audio_url",
+        "table": "podcasts",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "transcript",
+      "type": "text",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": [
+          {
+            "name": "If null",
+            "rule": {
+              "transcript": {
+                "_null": true
+              }
+            },
+            "hidden": false,
+            "options": {
+              "trim": false,
+              "font": "sans-serif",
+              "clear": false
+            }
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "transcript",
+        "group": null,
+        "hidden": false,
+        "interface": "input-multiline",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 17,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "transcript",
+        "table": "podcasts",
+        "data_type": "text",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "apple_url",
+      "type": "string",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "apple_url",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 18,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "apple_url",
+        "table": "podcasts",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "google_url",
+      "type": "string",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "google_url",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 19,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "google_url",
+        "table": "podcasts",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "spotify_url",
+      "type": "string",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "spotify_url",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 20,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "spotify_url",
+        "table": "podcasts",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "picks_of_the_day",
+      "type": "alias",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "picks_of_the_day",
+        "group": null,
+        "hidden": false,
+        "interface": "list-o2m",
+        "note": null,
+        "options": {
+          "template": "{{name}}"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 24,
+        "special": [
+          "o2m"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "divider-hidden",
+      "type": "alias",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-hidden",
+        "group": null,
+        "hidden": true,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 26,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "divider-metadata",
+      "type": "alias",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-metadata",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": {
+          "title": "Metadata"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 2,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "divider-podcast",
+      "type": "alias",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-podcast",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": {
+          "title": "Podcast"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 7,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "notice-publish",
+      "type": "alias",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": [
+          {
+            "name": "If not draft",
+            "rule": {
+              "status": {
+                "_neq": "draft"
+              }
+            },
+            "hidden": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "notice-publish",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-notice",
+        "note": null,
+        "options": {
+          "text": "Wähle bei \"Published On\" ein Datum in der Zukunft, um die Podcastfolge zu diesem Zeitpunk automatisch zu veröffentlichen."
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 3,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "divider-relations",
+      "type": "alias",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-relations",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": {
+          "title": "Relations"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 21,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "buzzsprout_id",
+      "type": "integer",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "buzzsprout_id",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 29,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "buzzsprout_id",
+        "table": "podcasts",
+        "data_type": "integer",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": 32,
+        "numeric_scale": 0,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "notice-buzzsprout",
+      "type": "alias",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": [
+          {
+            "name": "If Buzzsprout ID is null",
+            "rule": {
+              "buzzsprout_id": {
+                "_null": true
+              }
+            },
+            "hidden": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "notice-buzzsprout",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-notice",
+        "note": null,
+        "options": {
+          "text": "Die Podcastfolge wurde zu Buzzsprout hinzugefügt und alle weitere Änderungen, die du hier vornimmst, werden automatisch mit Buzzsprout synchronisiert."
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 1,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "members",
+      "type": "alias",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "members",
+        "group": null,
+        "hidden": false,
+        "interface": "list-m2m",
+        "note": null,
+        "options": {
+          "template": "{{member.first_name}} {{member.last_name}}"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 22,
+        "special": [
+          "m2m"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "speakers",
+      "type": "alias",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "speakers",
+        "group": null,
+        "hidden": false,
+        "interface": "list-m2m",
+        "note": null,
+        "options": {
+          "template": "{{speaker.first_name}} {{speaker.last_name}}"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 23,
+        "special": [
+          "m2m"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "tags",
+      "type": "alias",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "tags",
+        "group": null,
+        "hidden": false,
+        "interface": "list-m2m",
+        "note": null,
+        "options": {
+          "template": "{{tag.name}}"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 25,
+        "special": [
+          "m2m"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "notes",
+      "type": "text",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "notes",
+        "group": null,
+        "hidden": false,
+        "interface": "input-multiline",
+        "note": null,
+        "options": {
+          "placeholder": "Notizen für Social Media o.ä. // Wird nicht veröffentlicht"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 16,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "notes",
+        "table": "podcasts",
+        "data_type": "text",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "transcription_id",
+      "type": "string",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "transcription_id",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 35,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "transcription_id",
+        "table": "podcasts",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "transcription_export_id",
+      "type": "string",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "transcription_export_id",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 36,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "transcription_export_id",
+        "table": "podcasts",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "transcription_done",
+      "type": "boolean",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "transcription_done",
+        "group": null,
+        "hidden": true,
+        "interface": "boolean",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 37,
+        "special": [
+          "cast-boolean"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "transcription_done",
+        "table": "podcasts",
+        "data_type": "boolean",
+        "default_value": false,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "publishable",
+      "type": "alias",
+      "meta": {
+        "collection": "podcasts",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "publishable",
+        "group": null,
+        "hidden": false,
+        "interface": "publishable",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 6,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
       }
     },
     {
@@ -12538,6 +14952,218 @@
         "has_auto_increment": false,
         "foreign_key_table": null,
         "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "privacy_page",
+      "field": "created_by",
+      "type": "uuid",
+      "meta": {
+        "collection": "privacy_page",
+        "conditions": null,
+        "display": "user",
+        "display_options": null,
+        "field": "created_by",
+        "group": null,
+        "hidden": true,
+        "interface": "select-dropdown-m2o",
+        "note": null,
+        "options": {
+          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+        },
+        "readonly": true,
+        "required": false,
+        "sort": 6,
+        "special": [
+          "user-created"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "created_by",
+        "table": "privacy_page",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "privacy_page",
+      "field": "created_on",
+      "type": "timestamp",
+      "meta": {
+        "collection": "privacy_page",
+        "conditions": null,
+        "display": "datetime",
+        "display_options": {
+          "relative": true
+        },
+        "field": "created_on",
+        "group": null,
+        "hidden": true,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 7,
+        "special": [
+          "date-created"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "created_on",
+        "table": "privacy_page",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "privacy_page",
+      "field": "updated_by",
+      "type": "uuid",
+      "meta": {
+        "collection": "privacy_page",
+        "conditions": null,
+        "display": "user",
+        "display_options": null,
+        "field": "updated_by",
+        "group": null,
+        "hidden": true,
+        "interface": "select-dropdown-m2o",
+        "note": null,
+        "options": {
+          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+        },
+        "readonly": true,
+        "required": false,
+        "sort": 8,
+        "special": [
+          "user-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "updated_by",
+        "table": "privacy_page",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "privacy_page",
+      "field": "updated_on",
+      "type": "timestamp",
+      "meta": {
+        "collection": "privacy_page",
+        "conditions": null,
+        "display": "datetime",
+        "display_options": {
+          "relative": true
+        },
+        "field": "updated_on",
+        "group": null,
+        "hidden": true,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 9,
+        "special": [
+          "date-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "updated_on",
+        "table": "privacy_page",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "privacy_page",
+      "field": "divider-hidden",
+      "type": "alias",
+      "meta": {
+        "collection": "privacy_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-hidden",
+        "group": null,
+        "hidden": true,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 4,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
       }
     },
     {
@@ -12600,14 +15226,183 @@
     },
     {
       "collection": "privacy_page",
-      "field": "updated_by",
-      "type": "uuid",
+      "field": "heading",
+      "type": "string",
       "meta": {
         "collection": "privacy_page",
         "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "heading",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": true,
+        "sort": 2,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "heading",
+        "table": "privacy_page",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profile_creation_page",
+      "field": "id",
+      "type": "integer",
+      "meta": {
+        "collection": "profile_creation_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "id",
+        "group": null,
+        "hidden": true,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 1,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "id",
+        "table": "profile_creation_page",
+        "data_type": "integer",
+        "default_value": "nextval('profile_creation_page_id_seq'::regclass)",
+        "max_length": null,
+        "numeric_precision": 32,
+        "numeric_scale": 0,
+        "is_nullable": false,
+        "is_unique": true,
+        "is_primary_key": true,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": true,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profile_creation_page",
+      "field": "status",
+      "type": "string",
+      "meta": {
+        "collection": "profile_creation_page",
+        "conditions": null,
+        "display": "labels",
+        "display_options": {
+          "choices": [
+            {
+              "text": "$t:published",
+              "value": "published",
+              "color": "var(--theme--primary)",
+              "foreground": "var(--theme--primary)",
+              "background": "var(--theme--primary-background)"
+            },
+            {
+              "text": "$t:draft",
+              "value": "draft",
+              "color": "var(--theme--foreground)",
+              "foreground": "var(--theme--foreground)",
+              "background": "var(--theme--background-normal)"
+            },
+            {
+              "text": "$t:archived",
+              "value": "archived",
+              "color": "var(--theme--warning)",
+              "foreground": "var(--theme--warning)",
+              "background": "var(--theme--warning-background)"
+            }
+          ],
+          "showAsDot": true
+        },
+        "field": "status",
+        "group": null,
+        "hidden": false,
+        "interface": "select-dropdown",
+        "note": null,
+        "options": {
+          "choices": [
+            {
+              "text": "$t:published",
+              "value": "published",
+              "color": "var(--theme--primary)"
+            },
+            {
+              "text": "$t:draft",
+              "value": "draft",
+              "color": "var(--theme--foreground)"
+            },
+            {
+              "text": "$t:archived",
+              "value": "archived",
+              "color": "var(--theme--warning)"
+            }
+          ]
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 2,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "status",
+        "table": "profile_creation_page",
+        "data_type": "character varying",
+        "default_value": "draft",
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": false,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profile_creation_page",
+      "field": "user_created",
+      "type": "uuid",
+      "meta": {
+        "collection": "profile_creation_page",
+        "conditions": null,
         "display": "user",
         "display_options": null,
-        "field": "updated_by",
+        "field": "user_created",
         "group": null,
         "hidden": true,
         "interface": "select-dropdown-m2o",
@@ -12617,9 +15412,9 @@
         },
         "readonly": true,
         "required": false,
-        "sort": 8,
+        "sort": 3,
         "special": [
-          "user-updated"
+          "user-created"
         ],
         "translations": null,
         "validation": null,
@@ -12627,8 +15422,8 @@
         "width": "half"
       },
       "schema": {
-        "name": "updated_by",
-        "table": "privacy_page",
+        "name": "user_created",
+        "table": "profile_creation_page",
         "data_type": "uuid",
         "default_value": null,
         "max_length": null,
@@ -12645,17 +15440,17 @@
       }
     },
     {
-      "collection": "privacy_page",
-      "field": "updated_on",
+      "collection": "profile_creation_page",
+      "field": "date_created",
       "type": "timestamp",
       "meta": {
-        "collection": "privacy_page",
+        "collection": "profile_creation_page",
         "conditions": null,
         "display": "datetime",
         "display_options": {
           "relative": true
         },
-        "field": "updated_on",
+        "field": "date_created",
         "group": null,
         "hidden": true,
         "interface": "datetime",
@@ -12663,7 +15458,99 @@
         "options": null,
         "readonly": true,
         "required": false,
-        "sort": 9,
+        "sort": 4,
+        "special": [
+          "date-created"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "date_created",
+        "table": "profile_creation_page",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profile_creation_page",
+      "field": "user_updated",
+      "type": "uuid",
+      "meta": {
+        "collection": "profile_creation_page",
+        "conditions": null,
+        "display": "user",
+        "display_options": null,
+        "field": "user_updated",
+        "group": null,
+        "hidden": true,
+        "interface": "select-dropdown-m2o",
+        "note": null,
+        "options": {
+          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+        },
+        "readonly": true,
+        "required": false,
+        "sort": 5,
+        "special": [
+          "user-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "user_updated",
+        "table": "profile_creation_page",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "profile_creation_page",
+      "field": "date_updated",
+      "type": "timestamp",
+      "meta": {
+        "collection": "profile_creation_page",
+        "conditions": null,
+        "display": "datetime",
+        "display_options": {
+          "relative": true
+        },
+        "field": "date_updated",
+        "group": null,
+        "hidden": true,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 6,
         "special": [
           "date-updated"
         ],
@@ -12673,11 +15560,1878 @@
         "width": "half"
       },
       "schema": {
-        "name": "updated_on",
-        "table": "privacy_page",
+        "name": "date_updated",
+        "table": "profile_creation_page",
         "data_type": "timestamp with time zone",
         "default_value": null,
         "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profile_creation_page",
+      "field": "heading",
+      "type": "string",
+      "meta": {
+        "collection": "profile_creation_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "heading",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 7,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "heading",
+        "table": "profile_creation_page",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profile_creation_page",
+      "field": "intro_text",
+      "type": "text",
+      "meta": {
+        "collection": "profile_creation_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "intro_text",
+        "group": null,
+        "hidden": false,
+        "interface": "input-rich-text-html",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 8,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "intro_text",
+        "table": "profile_creation_page",
+        "data_type": "text",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profile_creation_page",
+      "field": "emoji_heading",
+      "type": "string",
+      "meta": {
+        "collection": "profile_creation_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "emoji_heading",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 9,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "emoji_heading",
+        "table": "profile_creation_page",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profile_creation_page",
+      "field": "emoji_text",
+      "type": "string",
+      "meta": {
+        "collection": "profile_creation_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "emoji_text",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 10,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "emoji_text",
+        "table": "profile_creation_page",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profile_creation_page",
+      "field": "interests_heading",
+      "type": "string",
+      "meta": {
+        "collection": "profile_creation_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "interests_heading",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 11,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "interests_heading",
+        "table": "profile_creation_page",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profile_creation_page",
+      "field": "interests_text",
+      "type": "string",
+      "meta": {
+        "collection": "profile_creation_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "interests_text",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 12,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "interests_text",
+        "table": "profile_creation_page",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profile_creation_page",
+      "field": "profile_change_text",
+      "type": "string",
+      "meta": {
+        "collection": "profile_creation_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "profile_change_text",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 13,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "profile_change_text",
+        "table": "profile_creation_page",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profile_creation_page",
+      "field": "creation_done_text",
+      "type": "text",
+      "meta": {
+        "collection": "profile_creation_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "creation_done_text",
+        "group": null,
+        "hidden": false,
+        "interface": "input-rich-text-html",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 14,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "creation_done_text",
+        "table": "profile_creation_page",
+        "data_type": "text",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profiles",
+      "field": "id",
+      "type": "uuid",
+      "meta": {
+        "collection": "profiles",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "id",
+        "group": null,
+        "hidden": true,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 1,
+        "special": [
+          "uuid"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "id",
+        "table": "profiles",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": false,
+        "is_unique": true,
+        "is_primary_key": true,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profiles",
+      "field": "status",
+      "type": "string",
+      "meta": {
+        "collection": "profiles",
+        "conditions": null,
+        "display": "labels",
+        "display_options": {
+          "choices": [
+            {
+              "text": "$t:published",
+              "value": "published",
+              "color": "var(--theme--primary)",
+              "foreground": "var(--theme--primary)",
+              "background": "var(--theme--primary-background)"
+            },
+            {
+              "text": "$t:draft",
+              "value": "draft",
+              "color": "var(--theme--foreground)",
+              "foreground": "var(--theme--foreground)",
+              "background": "var(--theme--background-normal)"
+            },
+            {
+              "text": "$t:archived",
+              "value": "archived",
+              "color": "var(--theme--warning)",
+              "foreground": "var(--theme--warning)",
+              "background": "var(--theme--warning-background)"
+            }
+          ],
+          "showAsDot": true
+        },
+        "field": "status",
+        "group": null,
+        "hidden": false,
+        "interface": "select-dropdown",
+        "note": null,
+        "options": {
+          "choices": [
+            {
+              "text": "$t:published",
+              "value": "published",
+              "color": "var(--theme--primary)"
+            },
+            {
+              "text": "$t:draft",
+              "value": "draft",
+              "color": "var(--theme--foreground)"
+            },
+            {
+              "text": "$t:archived",
+              "value": "archived",
+              "color": "var(--theme--warning)"
+            }
+          ]
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 2,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "status",
+        "table": "profiles",
+        "data_type": "character varying",
+        "default_value": "draft",
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": false,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profiles",
+      "field": "sort",
+      "type": "integer",
+      "meta": {
+        "collection": "profiles",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "sort",
+        "group": null,
+        "hidden": true,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 3,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "sort",
+        "table": "profiles",
+        "data_type": "integer",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": 32,
+        "numeric_scale": 0,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profiles",
+      "field": "user_created",
+      "type": "uuid",
+      "meta": {
+        "collection": "profiles",
+        "conditions": null,
+        "display": "user",
+        "display_options": null,
+        "field": "user_created",
+        "group": null,
+        "hidden": true,
+        "interface": "select-dropdown-m2o",
+        "note": null,
+        "options": {
+          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+        },
+        "readonly": true,
+        "required": false,
+        "sort": 4,
+        "special": [
+          "user-created"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "user_created",
+        "table": "profiles",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "profiles",
+      "field": "date_created",
+      "type": "timestamp",
+      "meta": {
+        "collection": "profiles",
+        "conditions": null,
+        "display": "datetime",
+        "display_options": {
+          "relative": true
+        },
+        "field": "date_created",
+        "group": null,
+        "hidden": true,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 5,
+        "special": [
+          "date-created"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "date_created",
+        "table": "profiles",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profiles",
+      "field": "user_updated",
+      "type": "uuid",
+      "meta": {
+        "collection": "profiles",
+        "conditions": null,
+        "display": "user",
+        "display_options": null,
+        "field": "user_updated",
+        "group": null,
+        "hidden": true,
+        "interface": "select-dropdown-m2o",
+        "note": null,
+        "options": {
+          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+        },
+        "readonly": true,
+        "required": false,
+        "sort": 6,
+        "special": [
+          "user-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "user_updated",
+        "table": "profiles",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "profiles",
+      "field": "date_updated",
+      "type": "timestamp",
+      "meta": {
+        "collection": "profiles",
+        "conditions": null,
+        "display": "datetime",
+        "display_options": {
+          "relative": true
+        },
+        "field": "date_updated",
+        "group": null,
+        "hidden": true,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 7,
+        "special": [
+          "date-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "date_updated",
+        "table": "profiles",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profiles",
+      "field": "first_name",
+      "type": "string",
+      "meta": {
+        "collection": "profiles",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "first_name",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 8,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "first_name",
+        "table": "profiles",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profiles",
+      "field": "last_name",
+      "type": "string",
+      "meta": {
+        "collection": "profiles",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "last_name",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 9,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "last_name",
+        "table": "profiles",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profiles",
+      "field": "display_name",
+      "type": "string",
+      "meta": {
+        "collection": "profiles",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "display_name",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "placeholder": null
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 10,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "display_name",
+        "table": "profiles",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profiles",
+      "field": "description",
+      "type": "text",
+      "meta": {
+        "collection": "profiles",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "description",
+        "group": null,
+        "hidden": false,
+        "interface": "input-rich-text-html",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 11,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "description",
+        "table": "profiles",
+        "data_type": "text",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profiles",
+      "field": "job_role",
+      "type": "string",
+      "meta": {
+        "collection": "profiles",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "job_role",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 12,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "job_role",
+        "table": "profiles",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profiles",
+      "field": "job_employer",
+      "type": "string",
+      "meta": {
+        "collection": "profiles",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "job_employer",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 13,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "job_employer",
+        "table": "profiles",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profiles",
+      "field": "profile_image",
+      "type": "uuid",
+      "meta": {
+        "collection": "profiles",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "profile_image",
+        "group": null,
+        "hidden": false,
+        "interface": "file-image",
+        "note": null,
+        "options": {
+          "folder": "219301e9-b452-488b-ac4f-3ffcb1885e5d"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 14,
+        "special": [
+          "file"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "profile_image",
+        "table": "profiles",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_files",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "profiles",
+      "field": "emojis",
+      "type": "alias",
+      "meta": {
+        "collection": "profiles",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "emojis",
+        "group": null,
+        "hidden": false,
+        "interface": "list-m2m",
+        "note": null,
+        "options": {
+          "enableCreate": false
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 15,
+        "special": [
+          "m2m"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "profiles",
+      "field": "interested_tags",
+      "type": "alias",
+      "meta": {
+        "collection": "profiles",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "interested_tags",
+        "group": null,
+        "hidden": false,
+        "interface": "list-m2m",
+        "note": null,
+        "options": {
+          "enableCreate": false
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 16,
+        "special": [
+          "m2m"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "profiles",
+      "field": "world_public",
+      "type": "boolean",
+      "meta": {
+        "collection": "profiles",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "world_public",
+        "group": null,
+        "hidden": false,
+        "interface": "boolean",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 18,
+        "special": [
+          "cast-boolean"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "world_public",
+        "table": "profiles",
+        "data_type": "boolean",
+        "default_value": false,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profiles",
+      "field": "slug",
+      "type": "string",
+      "meta": {
+        "collection": "profiles",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "slug",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 17,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "slug",
+        "table": "profiles",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": true,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profiles",
+      "field": "slug_suffix",
+      "type": "string",
+      "meta": {
+        "collection": "profiles",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "slug_suffix",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 19,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "slug_suffix",
+        "table": "profiles",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profiles",
+      "field": "update_slug",
+      "type": "boolean",
+      "meta": {
+        "collection": "profiles",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "update_slug",
+        "group": null,
+        "hidden": false,
+        "interface": "boolean",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 20,
+        "special": [
+          "cast-boolean"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "update_slug",
+        "table": "profiles",
+        "data_type": "boolean",
+        "default_value": true,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profiles",
+      "field": "users",
+      "type": "alias",
+      "meta": {
+        "collection": "profiles",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "users",
+        "group": null,
+        "hidden": false,
+        "interface": "list-m2m",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 21,
+        "special": [
+          "m2m"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "profiles_emojis",
+      "field": "id",
+      "type": "integer",
+      "meta": {
+        "collection": "profiles_emojis",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "id",
+        "group": null,
+        "hidden": true,
+        "interface": null,
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 1,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "id",
+        "table": "profiles_emojis",
+        "data_type": "integer",
+        "default_value": "nextval('profiles_emojis_id_seq'::regclass)",
+        "max_length": null,
+        "numeric_precision": 32,
+        "numeric_scale": 0,
+        "is_nullable": false,
+        "is_unique": true,
+        "is_primary_key": true,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": true,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profiles_emojis",
+      "field": "profiles_id",
+      "type": "uuid",
+      "meta": {
+        "collection": "profiles_emojis",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "profiles_id",
+        "group": null,
+        "hidden": true,
+        "interface": null,
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 2,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "profiles_id",
+        "table": "profiles_emojis",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "profiles",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "profiles_emojis",
+      "field": "emojis_id",
+      "type": "uuid",
+      "meta": {
+        "collection": "profiles_emojis",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "emojis_id",
+        "group": null,
+        "hidden": true,
+        "interface": null,
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 3,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "emojis_id",
+        "table": "profiles_emojis",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "emojis",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "profiles_tags",
+      "field": "id",
+      "type": "integer",
+      "meta": {
+        "collection": "profiles_tags",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "id",
+        "group": null,
+        "hidden": true,
+        "interface": null,
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 1,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "id",
+        "table": "profiles_tags",
+        "data_type": "integer",
+        "default_value": "nextval('profiles_tags_id_seq'::regclass)",
+        "max_length": null,
+        "numeric_precision": 32,
+        "numeric_scale": 0,
+        "is_nullable": false,
+        "is_unique": true,
+        "is_primary_key": true,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": true,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "profiles_tags",
+      "field": "profiles_id",
+      "type": "uuid",
+      "meta": {
+        "collection": "profiles_tags",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "profiles_id",
+        "group": null,
+        "hidden": true,
+        "interface": null,
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 2,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "profiles_id",
+        "table": "profiles_tags",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "profiles",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "profiles_tags",
+      "field": "tags_id",
+      "type": "uuid",
+      "meta": {
+        "collection": "profiles_tags",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "tags_id",
+        "group": null,
+        "hidden": true,
+        "interface": null,
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 3,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "tags_id",
+        "table": "profiles_tags",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "tags",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "raffle_page",
+      "field": "id",
+      "type": "integer",
+      "meta": {
+        "collection": "raffle_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "id",
+        "group": null,
+        "hidden": true,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 1,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "id",
+        "table": "raffle_page",
+        "data_type": "integer",
+        "default_value": "nextval('raffle_page_id_seq'::regclass)",
+        "max_length": null,
+        "numeric_precision": 32,
+        "numeric_scale": 0,
+        "is_nullable": false,
+        "is_unique": true,
+        "is_primary_key": true,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": true,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "raffle_page",
+      "field": "user_created",
+      "type": "uuid",
+      "meta": {
+        "collection": "raffle_page",
+        "conditions": null,
+        "display": "user",
+        "display_options": null,
+        "field": "user_created",
+        "group": null,
+        "hidden": true,
+        "interface": "select-dropdown-m2o",
+        "note": null,
+        "options": {
+          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+        },
+        "readonly": true,
+        "required": false,
+        "sort": 5,
+        "special": [
+          "user-created"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "user_created",
+        "table": "raffle_page",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "raffle_page",
+      "field": "date_created",
+      "type": "timestamp",
+      "meta": {
+        "collection": "raffle_page",
+        "conditions": null,
+        "display": "datetime",
+        "display_options": {
+          "relative": true
+        },
+        "field": "date_created",
+        "group": null,
+        "hidden": true,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 6,
+        "special": [
+          "date-created"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "date_created",
+        "table": "raffle_page",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "raffle_page",
+      "field": "user_updated",
+      "type": "uuid",
+      "meta": {
+        "collection": "raffle_page",
+        "conditions": null,
+        "display": "user",
+        "display_options": null,
+        "field": "user_updated",
+        "group": null,
+        "hidden": true,
+        "interface": "select-dropdown-m2o",
+        "note": null,
+        "options": {
+          "template": "{{avatar.$thumbnail}} {{first_name}} {{last_name}}"
+        },
+        "readonly": true,
+        "required": false,
+        "sort": 7,
+        "special": [
+          "user-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "user_updated",
+        "table": "raffle_page",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "raffle_page",
+      "field": "date_updated",
+      "type": "timestamp",
+      "meta": {
+        "collection": "raffle_page",
+        "conditions": null,
+        "display": "datetime",
+        "display_options": {
+          "relative": true
+        },
+        "field": "date_updated",
+        "group": null,
+        "hidden": true,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 8,
+        "special": [
+          "date-updated"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "date_updated",
+        "table": "raffle_page",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "raffle_page",
+      "field": "heading",
+      "type": "string",
+      "meta": {
+        "collection": "raffle_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "heading",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": true,
+        "sort": 3,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "heading",
+        "table": "raffle_page",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": false,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "raffle_page",
+      "field": "text",
+      "type": "text",
+      "meta": {
+        "collection": "raffle_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "text",
+        "group": null,
+        "hidden": false,
+        "interface": "input-rich-text-html",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": true,
+        "sort": 4,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "text",
+        "table": "raffle_page",
+        "data_type": "text",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": false,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "raffle_page",
+      "field": "status",
+      "type": "string",
+      "meta": {
+        "collection": "raffle_page",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "status",
+        "group": null,
+        "hidden": false,
+        "interface": "select-dropdown",
+        "note": null,
+        "options": {
+          "choices": [
+            {
+              "text": "Published",
+              "value": "published"
+            },
+            {
+              "text": "Draft",
+              "value": "draft"
+            },
+            {
+              "text": "Archived",
+              "value": "archived"
+            }
+          ]
+        },
+        "readonly": false,
+        "required": true,
+        "sort": 2,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "status",
+        "table": "raffle_page",
+        "data_type": "character varying",
+        "default_value": "draft",
+        "max_length": 255,
         "numeric_precision": null,
         "numeric_scale": null,
         "is_nullable": true,
@@ -12734,6 +17488,90 @@
     },
     {
       "collection": "speaker_tags",
+      "field": "speaker",
+      "type": "uuid",
+      "meta": {
+        "collection": "speaker_tags",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "speaker",
+        "group": null,
+        "hidden": true,
+        "interface": null,
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": null,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "speaker",
+        "table": "speaker_tags",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "speakers",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "speaker_tags",
+      "field": "tag",
+      "type": "uuid",
+      "meta": {
+        "collection": "speaker_tags",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "tag",
+        "group": null,
+        "hidden": true,
+        "interface": null,
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": null,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "tag",
+        "table": "speaker_tags",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "tags",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "speaker_tags",
       "field": "sort",
       "type": "integer",
       "meta": {
@@ -12775,109 +17613,98 @@
       }
     },
     {
-      "collection": "speaker_tags",
-      "field": "speaker_id",
-      "type": "uuid",
-      "meta": {
-        "collection": "speaker_tags",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "speaker_id",
-        "group": null,
-        "hidden": true,
-        "interface": null,
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": null,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "speaker_id",
-        "table": "speaker_tags",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "speakers",
-        "foreign_key_column": "id"
-      }
-    },
-    {
-      "collection": "speaker_tags",
-      "field": "tag_id",
-      "type": "uuid",
-      "meta": {
-        "collection": "speaker_tags",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "tag_id",
-        "group": null,
-        "hidden": true,
-        "interface": null,
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": null,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "tag_id",
-        "table": "speaker_tags",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "tags",
-        "foreign_key_column": "id"
-      }
-    },
-    {
       "collection": "speakers",
-      "field": "academic_title",
-      "type": "string",
+      "field": "id",
+      "type": "uuid",
       "meta": {
         "collection": "speakers",
         "conditions": null,
         "display": null,
         "display_options": null,
-        "field": "academic_title",
+        "field": "id",
         "group": null,
-        "hidden": false,
+        "hidden": true,
         "interface": "input",
         "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 26,
+        "special": [
+          "uuid"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "id",
+        "table": "speakers",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": false,
+        "is_unique": true,
+        "is_primary_key": true,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "speakers",
+      "field": "status",
+      "type": "string",
+      "meta": {
+        "collection": "speakers",
+        "conditions": null,
+        "display": "labels",
+        "display_options": {
+          "choices": [
+            {
+              "background": "#00C897",
+              "value": "published"
+            },
+            {
+              "background": "#D3DAE4",
+              "value": "draft"
+            },
+            {
+              "background": "#F7971C",
+              "value": "archived"
+            }
+          ],
+          "showAsDot": true
+        },
+        "field": "status",
+        "group": null,
+        "hidden": false,
+        "interface": "select-dropdown",
+        "note": null,
         "options": {
-          "trim": true
+          "choices": [
+            {
+              "text": "$t:published",
+              "value": "published"
+            },
+            {
+              "text": "$t:draft",
+              "value": "draft"
+            },
+            {
+              "text": "$t:archived",
+              "value": "archived"
+            }
+          ]
         },
         "readonly": false,
         "required": false,
-        "sort": 7,
+        "sort": 3,
         "special": null,
         "translations": null,
         "validation": null,
@@ -12885,13 +17712,55 @@
         "width": "half"
       },
       "schema": {
-        "name": "academic_title",
+        "name": "status",
         "table": "speakers",
         "data_type": "character varying",
-        "default_value": null,
+        "default_value": "draft",
         "max_length": 255,
         "numeric_precision": null,
         "numeric_scale": null,
+        "is_nullable": false,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "speakers",
+      "field": "sort",
+      "type": "integer",
+      "meta": {
+        "collection": "speakers",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "sort",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 5,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "sort",
+        "table": "speakers",
+        "data_type": "integer",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": 32,
+        "numeric_scale": 0,
         "is_nullable": true,
         "is_unique": false,
         "is_primary_key": false,
@@ -12982,1021 +17851,6 @@
         "data_type": "timestamp with time zone",
         "default_value": null,
         "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "speakers",
-      "field": "description",
-      "type": "text",
-      "meta": {
-        "collection": "speakers",
-        "conditions": [
-          {
-            "name": "If published",
-            "rule": {
-              "status": {
-                "_eq": "published"
-              }
-            },
-            "required": true
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "description",
-        "group": null,
-        "hidden": false,
-        "interface": "input-rich-text-html",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 11,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "description",
-        "table": "speakers",
-        "data_type": "text",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "speakers",
-      "field": "divider-hidden",
-      "type": "alias",
-      "meta": {
-        "collection": "speakers",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-hidden",
-        "group": null,
-        "hidden": true,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 25,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "speakers",
-      "field": "divider-metadata",
-      "type": "alias",
-      "meta": {
-        "collection": "speakers",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-metadata",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": {
-          "title": "Metadata"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 1,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "speakers",
-      "field": "divider-relations",
-      "type": "alias",
-      "meta": {
-        "collection": "speakers",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-relations",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": {
-          "title": "Relations"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 20,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "speakers",
-      "field": "divider-speaker",
-      "type": "alias",
-      "meta": {
-        "collection": "speakers",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-speaker",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": {
-          "title": "Speaker"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 6,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "speakers",
-      "field": "event_image",
-      "type": "uuid",
-      "meta": {
-        "collection": "speakers",
-        "conditions": [
-          {
-            "name": "If published",
-            "rule": {
-              "status": {
-                "_eq": "published"
-              }
-            },
-            "required": true
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "event_image",
-        "group": null,
-        "hidden": false,
-        "interface": "file-image",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 13,
-        "special": [
-          "file"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "event_image",
-        "table": "speakers",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "directus_files",
-        "foreign_key_column": "id"
-      }
-    },
-    {
-      "collection": "speakers",
-      "field": "first_name",
-      "type": "string",
-      "meta": {
-        "collection": "speakers",
-        "conditions": [
-          {
-            "name": "If published",
-            "rule": {
-              "status": {
-                "_eq": "published"
-              }
-            },
-            "required": true
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "first_name",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 9,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "first_name",
-        "table": "speakers",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "speakers",
-      "field": "github_url",
-      "type": "string",
-      "meta": {
-        "collection": "speakers",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "github_url",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 17,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "github_url",
-        "table": "speakers",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "speakers",
-      "field": "id",
-      "type": "uuid",
-      "meta": {
-        "collection": "speakers",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "id",
-        "group": null,
-        "hidden": true,
-        "interface": "input",
-        "note": null,
-        "options": null,
-        "readonly": true,
-        "required": false,
-        "sort": 26,
-        "special": [
-          "uuid"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "id",
-        "table": "speakers",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": false,
-        "is_unique": true,
-        "is_primary_key": true,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "speakers",
-      "field": "instagram_url",
-      "type": "string",
-      "meta": {
-        "collection": "speakers",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "instagram_url",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 18,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "instagram_url",
-        "table": "speakers",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "speakers",
-      "field": "last_name",
-      "type": "string",
-      "meta": {
-        "collection": "speakers",
-        "conditions": [
-          {
-            "name": "If published",
-            "rule": {
-              "status": {
-                "_eq": "published"
-              }
-            },
-            "required": true
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "last_name",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 10,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "last_name",
-        "table": "speakers",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "speakers",
-      "field": "linkedin_url",
-      "type": "string",
-      "meta": {
-        "collection": "speakers",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "linkedin_url",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 16,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "linkedin_url",
-        "table": "speakers",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "speakers",
-      "field": "meetups",
-      "type": "alias",
-      "meta": {
-        "collection": "speakers",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "meetups",
-        "group": null,
-        "hidden": false,
-        "interface": "list-m2m",
-        "note": null,
-        "options": {
-          "template": "{{meetup_id.title}}"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 21,
-        "special": [
-          "m2m"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "speakers",
-      "field": "notice-publish",
-      "type": "alias",
-      "meta": {
-        "collection": "speakers",
-        "conditions": [
-          {
-            "name": "If not draft",
-            "rule": {
-              "status": {
-                "_neq": "draft"
-              }
-            },
-            "hidden": true
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "notice-publish",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-notice",
-        "note": null,
-        "options": {
-          "text": "Wähle bei \"Published On\" ein Datum in der Zukunft, um das Meetup zu diesem Zeitpunk automatisch zu veröffentlichen."
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 2,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "speakers",
-      "field": "occupation",
-      "type": "string",
-      "meta": {
-        "collection": "speakers",
-        "conditions": [
-          {
-            "name": "If published",
-            "rule": {
-              "status": {
-                "_eq": "published"
-              }
-            },
-            "required": true
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "occupation",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 8,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "occupation",
-        "table": "speakers",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "speakers",
-      "field": "picks_of_the_day",
-      "type": "alias",
-      "meta": {
-        "collection": "speakers",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "picks_of_the_day",
-        "group": null,
-        "hidden": false,
-        "interface": "list-o2m",
-        "note": null,
-        "options": {
-          "template": "{{name}}"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 23,
-        "special": [
-          "o2m"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "speakers",
-      "field": "podcasts",
-      "type": "alias",
-      "meta": {
-        "collection": "speakers",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "podcasts",
-        "group": null,
-        "hidden": false,
-        "interface": "list-m2m",
-        "note": null,
-        "options": {
-          "template": "{{podcast_id.title}}"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 22,
-        "special": [
-          "m2m"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "speakers",
-      "field": "profile_image",
-      "type": "uuid",
-      "meta": {
-        "collection": "speakers",
-        "conditions": [
-          {
-            "name": "If published",
-            "rule": {
-              "status": {
-                "_eq": "published"
-              }
-            },
-            "required": true
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "profile_image",
-        "group": null,
-        "hidden": false,
-        "interface": "file-image",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 12,
-        "special": [
-          "file"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "profile_image",
-        "table": "speakers",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": "directus_files",
-        "foreign_key_column": "id"
-      }
-    },
-    {
-      "collection": "speakers",
-      "field": "published_on",
-      "type": "timestamp",
-      "meta": {
-        "collection": "speakers",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "published_on",
-        "group": null,
-        "hidden": false,
-        "interface": "datetime",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 4,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "published_on",
-        "table": "speakers",
-        "data_type": "timestamp with time zone",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "speakers",
-      "field": "slug",
-      "type": "string",
-      "meta": {
-        "collection": "speakers",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "slug",
-        "group": null,
-        "hidden": true,
-        "interface": "input",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 27,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "slug",
-        "table": "speakers",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "speakers",
-      "field": "sort",
-      "type": "integer",
-      "meta": {
-        "collection": "speakers",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "sort",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 5,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "sort",
-        "table": "speakers",
-        "data_type": "integer",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": 32,
-        "numeric_scale": 0,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "speakers",
-      "field": "status",
-      "type": "string",
-      "meta": {
-        "collection": "speakers",
-        "conditions": null,
-        "display": "labels",
-        "display_options": {
-          "choices": [
-            {
-              "background": "#00C897",
-              "value": "published"
-            },
-            {
-              "background": "#D3DAE4",
-              "value": "draft"
-            },
-            {
-              "background": "#F7971C",
-              "value": "archived"
-            }
-          ],
-          "showAsDot": true
-        },
-        "field": "status",
-        "group": null,
-        "hidden": false,
-        "interface": "select-dropdown",
-        "note": null,
-        "options": {
-          "choices": [
-            {
-              "text": "$t:published",
-              "value": "published"
-            },
-            {
-              "text": "$t:draft",
-              "value": "draft"
-            },
-            {
-              "text": "$t:archived",
-              "value": "archived"
-            }
-          ]
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 3,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "status",
-        "table": "speakers",
-        "data_type": "character varying",
-        "default_value": "draft",
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": false,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "speakers",
-      "field": "tags",
-      "type": "alias",
-      "meta": {
-        "collection": "speakers",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "tags",
-        "group": null,
-        "hidden": false,
-        "interface": "list-m2m",
-        "note": null,
-        "options": {
-          "template": "{{tag_id.name}}"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 24,
-        "special": [
-          "m2m"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "speakers",
-      "field": "twitter_url",
-      "type": "string",
-      "meta": {
-        "collection": "speakers",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "twitter_url",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 15,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "twitter_url",
-        "table": "speakers",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
         "numeric_precision": null,
         "numeric_scale": null,
         "is_nullable": true,
@@ -14103,6 +17957,456 @@
     },
     {
       "collection": "speakers",
+      "field": "published_on",
+      "type": "timestamp",
+      "meta": {
+        "collection": "speakers",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "published_on",
+        "group": null,
+        "hidden": false,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 4,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "published_on",
+        "table": "speakers",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "speakers",
+      "field": "slug",
+      "type": "string",
+      "meta": {
+        "collection": "speakers",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "slug",
+        "group": null,
+        "hidden": true,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 27,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "slug",
+        "table": "speakers",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "speakers",
+      "field": "academic_title",
+      "type": "string",
+      "meta": {
+        "collection": "speakers",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "academic_title",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 7,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "academic_title",
+        "table": "speakers",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "speakers",
+      "field": "first_name",
+      "type": "string",
+      "meta": {
+        "collection": "speakers",
+        "conditions": [
+          {
+            "name": "If published",
+            "rule": {
+              "status": {
+                "_eq": "published"
+              }
+            },
+            "required": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "first_name",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 9,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "first_name",
+        "table": "speakers",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "speakers",
+      "field": "last_name",
+      "type": "string",
+      "meta": {
+        "collection": "speakers",
+        "conditions": [
+          {
+            "name": "If published",
+            "rule": {
+              "status": {
+                "_eq": "published"
+              }
+            },
+            "required": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "last_name",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 10,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "last_name",
+        "table": "speakers",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "speakers",
+      "field": "occupation",
+      "type": "string",
+      "meta": {
+        "collection": "speakers",
+        "conditions": [
+          {
+            "name": "If published",
+            "rule": {
+              "status": {
+                "_eq": "published"
+              }
+            },
+            "required": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "occupation",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 8,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "occupation",
+        "table": "speakers",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "speakers",
+      "field": "description",
+      "type": "text",
+      "meta": {
+        "collection": "speakers",
+        "conditions": [
+          {
+            "name": "If published",
+            "rule": {
+              "status": {
+                "_eq": "published"
+              }
+            },
+            "required": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "description",
+        "group": null,
+        "hidden": false,
+        "interface": "input-rich-text-html",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 11,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "description",
+        "table": "speakers",
+        "data_type": "text",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "speakers",
+      "field": "profile_image",
+      "type": "uuid",
+      "meta": {
+        "collection": "speakers",
+        "conditions": [
+          {
+            "name": "If published",
+            "rule": {
+              "status": {
+                "_eq": "published"
+              }
+            },
+            "required": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "profile_image",
+        "group": null,
+        "hidden": false,
+        "interface": "file-image",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 12,
+        "special": [
+          "file"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "profile_image",
+        "table": "speakers",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_files",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "speakers",
+      "field": "event_image",
+      "type": "uuid",
+      "meta": {
+        "collection": "speakers",
+        "conditions": [
+          {
+            "name": "If published",
+            "rule": {
+              "status": {
+                "_eq": "published"
+              }
+            },
+            "required": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "event_image",
+        "group": null,
+        "hidden": false,
+        "interface": "file-image",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 13,
+        "special": [
+          "file"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "event_image",
+        "table": "speakers",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": "directus_files",
+        "foreign_key_column": "id"
+      }
+    },
+    {
+      "collection": "speakers",
       "field": "website_url",
       "type": "string",
       "meta": {
@@ -14129,6 +18433,182 @@
       },
       "schema": {
         "name": "website_url",
+        "table": "speakers",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "speakers",
+      "field": "twitter_url",
+      "type": "string",
+      "meta": {
+        "collection": "speakers",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "twitter_url",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 15,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "twitter_url",
+        "table": "speakers",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "speakers",
+      "field": "linkedin_url",
+      "type": "string",
+      "meta": {
+        "collection": "speakers",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "linkedin_url",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 16,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "linkedin_url",
+        "table": "speakers",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "speakers",
+      "field": "github_url",
+      "type": "string",
+      "meta": {
+        "collection": "speakers",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "github_url",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 17,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "github_url",
+        "table": "speakers",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "speakers",
+      "field": "instagram_url",
+      "type": "string",
+      "meta": {
+        "collection": "speakers",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "instagram_url",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 18,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "instagram_url",
         "table": "speakers",
         "data_type": "character varying",
         "default_value": null,
@@ -14179,6 +18659,439 @@
         "max_length": 255,
         "numeric_precision": null,
         "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "speakers",
+      "field": "picks_of_the_day",
+      "type": "alias",
+      "meta": {
+        "collection": "speakers",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "picks_of_the_day",
+        "group": null,
+        "hidden": false,
+        "interface": "list-o2m",
+        "note": null,
+        "options": {
+          "template": "{{name}}"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 23,
+        "special": [
+          "o2m"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "speakers",
+      "field": "divider-metadata",
+      "type": "alias",
+      "meta": {
+        "collection": "speakers",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-metadata",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": {
+          "title": "Metadata"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 1,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "speakers",
+      "field": "divider-speaker",
+      "type": "alias",
+      "meta": {
+        "collection": "speakers",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-speaker",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": {
+          "title": "Speaker"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 6,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "speakers",
+      "field": "divider-relations",
+      "type": "alias",
+      "meta": {
+        "collection": "speakers",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-relations",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": {
+          "title": "Relations"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 20,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "speakers",
+      "field": "notice-publish",
+      "type": "alias",
+      "meta": {
+        "collection": "speakers",
+        "conditions": [
+          {
+            "name": "If not draft",
+            "rule": {
+              "status": {
+                "_neq": "draft"
+              }
+            },
+            "hidden": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "notice-publish",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-notice",
+        "note": null,
+        "options": {
+          "text": "Wähle bei \"Published On\" ein Datum in der Zukunft, um das Meetup zu diesem Zeitpunk automatisch zu veröffentlichen."
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 2,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "speakers",
+      "field": "divider-hidden",
+      "type": "alias",
+      "meta": {
+        "collection": "speakers",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-hidden",
+        "group": null,
+        "hidden": true,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 25,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "speakers",
+      "field": "meetups",
+      "type": "alias",
+      "meta": {
+        "collection": "speakers",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "meetups",
+        "group": null,
+        "hidden": false,
+        "interface": "list-m2m",
+        "note": null,
+        "options": {
+          "template": "{{meetup.title}}"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 21,
+        "special": [
+          "m2m"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "speakers",
+      "field": "podcasts",
+      "type": "alias",
+      "meta": {
+        "collection": "speakers",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "podcasts",
+        "group": null,
+        "hidden": false,
+        "interface": "list-m2m",
+        "note": null,
+        "options": {
+          "template": "{{podcast.title}}"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 22,
+        "special": [
+          "m2m"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "speakers",
+      "field": "tags",
+      "type": "alias",
+      "meta": {
+        "collection": "speakers",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "tags",
+        "group": null,
+        "hidden": false,
+        "interface": "list-m2m",
+        "note": null,
+        "options": {
+          "template": "{{tag.name}}"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 24,
+        "special": [
+          "m2m"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "tags",
+      "field": "id",
+      "type": "uuid",
+      "meta": {
+        "collection": "tags",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "id",
+        "group": null,
+        "hidden": true,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": true,
+        "required": false,
+        "sort": 14,
+        "special": [
+          "uuid"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "id",
+        "table": "tags",
+        "data_type": "uuid",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": false,
+        "is_unique": true,
+        "is_primary_key": true,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "tags",
+      "field": "status",
+      "type": "string",
+      "meta": {
+        "collection": "tags",
+        "conditions": null,
+        "display": "labels",
+        "display_options": {
+          "choices": [
+            {
+              "background": "#00C897",
+              "value": "published"
+            },
+            {
+              "background": "#D3DAE4",
+              "value": "draft"
+            },
+            {
+              "background": "#F7971C",
+              "value": "archived"
+            }
+          ],
+          "showAsDot": true
+        },
+        "field": "status",
+        "group": null,
+        "hidden": false,
+        "interface": "select-dropdown",
+        "note": null,
+        "options": {
+          "choices": [
+            {
+              "text": "$t:published",
+              "value": "published"
+            },
+            {
+              "text": "$t:draft",
+              "value": "draft"
+            },
+            {
+              "text": "$t:archived",
+              "value": "archived"
+            }
+          ]
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 3,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "status",
+        "table": "tags",
+        "data_type": "character varying",
+        "default_value": "draft",
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": false,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "tags",
+      "field": "sort",
+      "type": "integer",
+      "meta": {
+        "collection": "tags",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "sort",
+        "group": null,
+        "hidden": true,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 15,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "sort",
+        "table": "tags",
+        "data_type": "integer",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": 32,
+        "numeric_scale": 0,
         "is_nullable": true,
         "is_unique": false,
         "is_primary_key": false,
@@ -14283,554 +19196,6 @@
     },
     {
       "collection": "tags",
-      "field": "divider-hidden",
-      "type": "alias",
-      "meta": {
-        "collection": "tags",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-hidden",
-        "group": null,
-        "hidden": true,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 13,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "tags",
-      "field": "divider-metadata",
-      "type": "alias",
-      "meta": {
-        "collection": "tags",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-metadata",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": {
-          "title": "Metadata"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 1,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "tags",
-      "field": "divider-relations",
-      "type": "alias",
-      "meta": {
-        "collection": "tags",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-relations",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": {
-          "title": "Relations"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 7,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "tags",
-      "field": "divider-tag",
-      "type": "alias",
-      "meta": {
-        "collection": "tags",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "divider-tag",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-divider",
-        "note": null,
-        "options": {
-          "title": "Tag"
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 5,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "tags",
-      "field": "id",
-      "type": "uuid",
-      "meta": {
-        "collection": "tags",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "id",
-        "group": null,
-        "hidden": true,
-        "interface": "input",
-        "note": null,
-        "options": null,
-        "readonly": true,
-        "required": false,
-        "sort": 14,
-        "special": [
-          "uuid"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "id",
-        "table": "tags",
-        "data_type": "uuid",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": false,
-        "is_unique": true,
-        "is_primary_key": true,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "tags",
-      "field": "meetups",
-      "type": "alias",
-      "meta": {
-        "collection": "tags",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "meetups",
-        "group": null,
-        "hidden": false,
-        "interface": "list-m2m",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 9,
-        "special": [
-          "m2m"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "tags",
-      "field": "members",
-      "type": "alias",
-      "meta": {
-        "collection": "tags",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "members",
-        "group": null,
-        "hidden": false,
-        "interface": "list-m2m",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 11,
-        "special": [
-          "m2m"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "tags",
-      "field": "name",
-      "type": "string",
-      "meta": {
-        "collection": "tags",
-        "conditions": [
-          {
-            "name": "If published",
-            "rule": {
-              "status": {
-                "_eq": "published"
-              }
-            },
-            "required": true
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "name",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": {
-          "trim": true
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 6,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "name",
-        "table": "tags",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "tags",
-      "field": "notice-publish",
-      "type": "alias",
-      "meta": {
-        "collection": "tags",
-        "conditions": [
-          {
-            "name": "If not draft",
-            "rule": {
-              "status": {
-                "_neq": "draft"
-              }
-            },
-            "hidden": true
-          }
-        ],
-        "display": null,
-        "display_options": null,
-        "field": "notice-publish",
-        "group": null,
-        "hidden": false,
-        "interface": "presentation-notice",
-        "note": null,
-        "options": {
-          "text": "Wähle bei \"Published On\" ein Datum in der Zukunft, um den Tag zu diesem Zeitpunk automatisch zu veröffentlichen."
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 2,
-        "special": [
-          "alias",
-          "no-data"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "tags",
-      "field": "picks_of_the_day",
-      "type": "alias",
-      "meta": {
-        "collection": "tags",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "picks_of_the_day",
-        "group": null,
-        "hidden": false,
-        "interface": "list-m2m",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 10,
-        "special": [
-          "m2m"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "tags",
-      "field": "podcasts",
-      "type": "alias",
-      "meta": {
-        "collection": "tags",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "podcasts",
-        "group": null,
-        "hidden": false,
-        "interface": "list-m2m",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 8,
-        "special": [
-          "m2m"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "tags",
-      "field": "published_on",
-      "type": "timestamp",
-      "meta": {
-        "collection": "tags",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "published_on",
-        "group": null,
-        "hidden": false,
-        "interface": "datetime",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 4,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "published_on",
-        "table": "tags",
-        "data_type": "timestamp with time zone",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "tags",
-      "field": "sort",
-      "type": "integer",
-      "meta": {
-        "collection": "tags",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "sort",
-        "group": null,
-        "hidden": true,
-        "interface": "input",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 15,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "sort",
-        "table": "tags",
-        "data_type": "integer",
-        "default_value": null,
-        "max_length": null,
-        "numeric_precision": 32,
-        "numeric_scale": 0,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "tags",
-      "field": "speakers",
-      "type": "alias",
-      "meta": {
-        "collection": "tags",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "speakers",
-        "group": null,
-        "hidden": false,
-        "interface": "list-m2m",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "sort": 12,
-        "special": [
-          "m2m"
-        ],
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      }
-    },
-    {
-      "collection": "tags",
-      "field": "status",
-      "type": "string",
-      "meta": {
-        "collection": "tags",
-        "conditions": null,
-        "display": "labels",
-        "display_options": {
-          "choices": [
-            {
-              "background": "#00C897",
-              "value": "published"
-            },
-            {
-              "background": "#D3DAE4",
-              "value": "draft"
-            },
-            {
-              "background": "#F7971C",
-              "value": "archived"
-            }
-          ],
-          "showAsDot": true
-        },
-        "field": "status",
-        "group": null,
-        "hidden": false,
-        "interface": "select-dropdown",
-        "note": null,
-        "options": {
-          "choices": [
-            {
-              "text": "$t:published",
-              "value": "published"
-            },
-            {
-              "text": "$t:draft",
-              "value": "draft"
-            },
-            {
-              "text": "$t:archived",
-              "value": "archived"
-            }
-          ]
-        },
-        "readonly": false,
-        "required": false,
-        "sort": 3,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "half"
-      },
-      "schema": {
-        "name": "status",
-        "table": "tags",
-        "data_type": "character varying",
-        "default_value": "draft",
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": false,
-        "is_unique": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "tags",
       "field": "updated_by",
       "type": "uuid",
       "meta": {
@@ -14920,34 +19285,408 @@
         "foreign_key_table": null,
         "foreign_key_column": null
       }
+    },
+    {
+      "collection": "tags",
+      "field": "published_on",
+      "type": "timestamp",
+      "meta": {
+        "collection": "tags",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "published_on",
+        "group": null,
+        "hidden": false,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 4,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "published_on",
+        "table": "tags",
+        "data_type": "timestamp with time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "tags",
+      "field": "name",
+      "type": "string",
+      "meta": {
+        "collection": "tags",
+        "conditions": [
+          {
+            "name": "If published",
+            "rule": {
+              "status": {
+                "_eq": "published"
+              }
+            },
+            "required": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "name",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": {
+          "trim": true
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 6,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "name",
+        "table": "tags",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "tags",
+      "field": "divider-metadata",
+      "type": "alias",
+      "meta": {
+        "collection": "tags",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-metadata",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": {
+          "title": "Metadata"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 1,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "tags",
+      "field": "divider-tag",
+      "type": "alias",
+      "meta": {
+        "collection": "tags",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-tag",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": {
+          "title": "Tag"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 5,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "tags",
+      "field": "divider-relations",
+      "type": "alias",
+      "meta": {
+        "collection": "tags",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-relations",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": {
+          "title": "Relations"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 7,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "tags",
+      "field": "divider-hidden",
+      "type": "alias",
+      "meta": {
+        "collection": "tags",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "divider-hidden",
+        "group": null,
+        "hidden": true,
+        "interface": "presentation-divider",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "sort": 13,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "tags",
+      "field": "notice-publish",
+      "type": "alias",
+      "meta": {
+        "collection": "tags",
+        "conditions": [
+          {
+            "name": "If not draft",
+            "rule": {
+              "status": {
+                "_neq": "draft"
+              }
+            },
+            "hidden": true
+          }
+        ],
+        "display": null,
+        "display_options": null,
+        "field": "notice-publish",
+        "group": null,
+        "hidden": false,
+        "interface": "presentation-notice",
+        "note": null,
+        "options": {
+          "text": "Wähle bei \"Published On\" ein Datum in der Zukunft, um den Tag zu diesem Zeitpunk automatisch zu veröffentlichen."
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 2,
+        "special": [
+          "alias",
+          "no-data"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "tags",
+      "field": "members",
+      "type": "alias",
+      "meta": {
+        "collection": "tags",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "members",
+        "group": null,
+        "hidden": false,
+        "interface": "list-m2m",
+        "note": null,
+        "options": {
+          "template": "{{member.first_name}} {{member.last_name}}"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 10,
+        "special": [
+          "m2m"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "tags",
+      "field": "meetups",
+      "type": "alias",
+      "meta": {
+        "collection": "tags",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "meetups",
+        "group": null,
+        "hidden": false,
+        "interface": "list-m2m",
+        "note": null,
+        "options": {
+          "template": "{{meetup.title}}"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 9,
+        "special": [
+          "m2m"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "tags",
+      "field": "picks_of_the_day",
+      "type": "alias",
+      "meta": {
+        "collection": "tags",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "picks_of_the_day",
+        "group": null,
+        "hidden": false,
+        "interface": "list-m2m",
+        "note": null,
+        "options": {
+          "template": "{{pick_of_the_day.name}}"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 12,
+        "special": [
+          "m2m"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "tags",
+      "field": "podcasts",
+      "type": "alias",
+      "meta": {
+        "collection": "tags",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "podcasts",
+        "group": null,
+        "hidden": false,
+        "interface": "list-m2m",
+        "note": null,
+        "options": {
+          "template": "{{podcast.title}}"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 8,
+        "special": [
+          "m2m"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
+    },
+    {
+      "collection": "tags",
+      "field": "speakers",
+      "type": "alias",
+      "meta": {
+        "collection": "tags",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "speakers",
+        "group": null,
+        "hidden": false,
+        "interface": "list-m2m",
+        "note": null,
+        "options": {
+          "template": "{{speaker.first_name}} {{speaker.last_name}}"
+        },
+        "readonly": false,
+        "required": false,
+        "sort": 11,
+        "special": [
+          "m2m"
+        ],
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      }
     }
   ],
   "relations": [
-    {
-      "collection": "about_page",
-      "field": "cover_image",
-      "related_collection": "directus_files",
-      "meta": {
-        "junction_field": null,
-        "many_collection": "about_page",
-        "many_field": "cover_image",
-        "one_allowed_collections": null,
-        "one_collection": "directus_files",
-        "one_collection_field": null,
-        "one_deselect_action": "nullify",
-        "one_field": null,
-        "sort_field": null
-      },
-      "schema": {
-        "table": "about_page",
-        "column": "cover_image",
-        "foreign_key_table": "directus_files",
-        "foreign_key_column": "id",
-        "constraint_name": "about_page_cover_image_foreign",
-        "on_update": "NO ACTION",
-        "on_delete": "SET NULL"
-      }
-    },
     {
       "collection": "about_page",
       "field": "created_by",
@@ -14999,6 +19738,131 @@
       }
     },
     {
+      "collection": "about_page",
+      "field": "cover_image",
+      "related_collection": "directus_files",
+      "meta": {
+        "junction_field": null,
+        "many_collection": "about_page",
+        "many_field": "cover_image",
+        "one_allowed_collections": null,
+        "one_collection": "directus_files",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": null,
+        "sort_field": null
+      },
+      "schema": {
+        "table": "about_page",
+        "column": "cover_image",
+        "foreign_key_table": "directus_files",
+        "foreign_key_column": "id",
+        "constraint_name": "about_page_cover_image_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "SET NULL"
+      }
+    },
+    {
+      "collection": "badges",
+      "field": "user_created",
+      "related_collection": "directus_users",
+      "meta": {
+        "junction_field": null,
+        "many_collection": "badges",
+        "many_field": "user_created",
+        "one_allowed_collections": null,
+        "one_collection": "directus_users",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": null,
+        "sort_field": null
+      },
+      "schema": {
+        "table": "badges",
+        "column": "user_created",
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id",
+        "constraint_name": "badges_user_created_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "NO ACTION"
+      }
+    },
+    {
+      "collection": "badges",
+      "field": "user_updated",
+      "related_collection": "directus_users",
+      "meta": {
+        "junction_field": null,
+        "many_collection": "badges",
+        "many_field": "user_updated",
+        "one_allowed_collections": null,
+        "one_collection": "directus_users",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": null,
+        "sort_field": null
+      },
+      "schema": {
+        "table": "badges",
+        "column": "user_updated",
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id",
+        "constraint_name": "badges_user_updated_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "NO ACTION"
+      }
+    },
+    {
+      "collection": "coc_page",
+      "field": "user_updated",
+      "related_collection": "directus_users",
+      "meta": {
+        "junction_field": null,
+        "many_collection": "coc_page",
+        "many_field": "user_updated",
+        "one_allowed_collections": null,
+        "one_collection": "directus_users",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": null,
+        "sort_field": null
+      },
+      "schema": {
+        "table": "coc_page",
+        "column": "user_updated",
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id",
+        "constraint_name": "coc_page_user_updated_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "NO ACTION"
+      }
+    },
+    {
+      "collection": "coc_page",
+      "field": "user_created",
+      "related_collection": "directus_users",
+      "meta": {
+        "junction_field": null,
+        "many_collection": "coc_page",
+        "many_field": "user_created",
+        "one_allowed_collections": null,
+        "one_collection": "directus_users",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": null,
+        "sort_field": null
+      },
+      "schema": {
+        "table": "coc_page",
+        "column": "user_created",
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id",
+        "constraint_name": "coc_page_user_created_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "NO ACTION"
+      }
+    },
+    {
       "collection": "contact_page",
       "field": "created_by",
       "related_collection": "directus_users",
@@ -15044,6 +19908,56 @@
         "foreign_key_table": "directus_users",
         "foreign_key_column": "id",
         "constraint_name": "contact_page_updated_by_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "NO ACTION"
+      }
+    },
+    {
+      "collection": "emojis",
+      "field": "user_created",
+      "related_collection": "directus_users",
+      "meta": {
+        "junction_field": null,
+        "many_collection": "emojis",
+        "many_field": "user_created",
+        "one_allowed_collections": null,
+        "one_collection": "directus_users",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": null,
+        "sort_field": null
+      },
+      "schema": {
+        "table": "emojis",
+        "column": "user_created",
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id",
+        "constraint_name": "emojis_user_created_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "NO ACTION"
+      }
+    },
+    {
+      "collection": "emojis",
+      "field": "user_updated",
+      "related_collection": "directus_users",
+      "meta": {
+        "junction_field": null,
+        "many_collection": "emojis",
+        "many_field": "user_updated",
+        "one_allowed_collections": null,
+        "one_collection": "directus_users",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": null,
+        "sort_field": null
+      },
+      "schema": {
+        "table": "emojis",
+        "column": "user_updated",
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id",
+        "constraint_name": "emojis_user_updated_foreign",
         "on_update": "NO ACTION",
         "on_delete": "NO ACTION"
       }
@@ -15175,37 +20089,12 @@
     },
     {
       "collection": "home_page_podcasts",
-      "field": "home_page_id",
-      "related_collection": "home_page",
-      "meta": {
-        "junction_field": "podcast_id",
-        "many_collection": "home_page_podcasts",
-        "many_field": "home_page_id",
-        "one_allowed_collections": null,
-        "one_collection": "home_page",
-        "one_collection_field": null,
-        "one_deselect_action": "nullify",
-        "one_field": "podcasts",
-        "sort_field": "sort"
-      },
-      "schema": {
-        "table": "home_page_podcasts",
-        "column": "home_page_id",
-        "foreign_key_table": "home_page",
-        "foreign_key_column": "id",
-        "constraint_name": "home_page_podcasts_home_page_id_foreign",
-        "on_update": "NO ACTION",
-        "on_delete": "SET NULL"
-      }
-    },
-    {
-      "collection": "home_page_podcasts",
-      "field": "podcast_id",
+      "field": "podcast",
       "related_collection": "podcasts",
       "meta": {
-        "junction_field": "home_page_id",
+        "junction_field": "home_page",
         "many_collection": "home_page_podcasts",
-        "many_field": "podcast_id",
+        "many_field": "podcast",
         "one_allowed_collections": null,
         "one_collection": "podcasts",
         "one_collection_field": null,
@@ -15215,10 +20104,35 @@
       },
       "schema": {
         "table": "home_page_podcasts",
-        "column": "podcast_id",
+        "column": "podcast",
         "foreign_key_table": "podcasts",
         "foreign_key_column": "id",
-        "constraint_name": "home_page_podcasts_podcast_id_foreign",
+        "constraint_name": "home_page_podcasts_podcast_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "SET NULL"
+      }
+    },
+    {
+      "collection": "home_page_podcasts",
+      "field": "home_page",
+      "related_collection": "home_page",
+      "meta": {
+        "junction_field": "podcast",
+        "many_collection": "home_page_podcasts",
+        "many_field": "home_page",
+        "one_allowed_collections": null,
+        "one_collection": "home_page",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": null,
+        "sort_field": "sort"
+      },
+      "schema": {
+        "table": "home_page_podcasts",
+        "column": "home_page",
+        "foreign_key_table": "home_page",
+        "foreign_key_column": "id",
+        "constraint_name": "home_page_podcasts_home_page_foreign",
         "on_update": "NO ACTION",
         "on_delete": "SET NULL"
       }
@@ -15274,13 +20188,113 @@
       }
     },
     {
+      "collection": "junction_directus_users_profiles",
+      "field": "profiles_id",
+      "related_collection": "profiles",
+      "meta": {
+        "junction_field": "directus_users_id",
+        "many_collection": "junction_directus_users_profiles",
+        "many_field": "profiles_id",
+        "one_allowed_collections": null,
+        "one_collection": "profiles",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": "users",
+        "sort_field": null
+      },
+      "schema": {
+        "table": "junction_directus_users_profiles",
+        "column": "profiles_id",
+        "foreign_key_table": "profiles",
+        "foreign_key_column": "id",
+        "constraint_name": "junction_directus_users_profiles_profiles_id_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "SET NULL"
+      }
+    },
+    {
+      "collection": "junction_directus_users_profiles",
+      "field": "directus_users_id",
+      "related_collection": "directus_users",
+      "meta": {
+        "junction_field": "profiles_id",
+        "many_collection": "junction_directus_users_profiles",
+        "many_field": "directus_users_id",
+        "one_allowed_collections": null,
+        "one_collection": "directus_users",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": "profiles",
+        "sort_field": null
+      },
+      "schema": {
+        "table": "junction_directus_users_profiles",
+        "column": "directus_users_id",
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id",
+        "constraint_name": "junction_directus_users_profiles_directus_users_id_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "SET NULL"
+      }
+    },
+    {
+      "collection": "login_page",
+      "field": "user_created",
+      "related_collection": "directus_users",
+      "meta": {
+        "junction_field": null,
+        "many_collection": "login_page",
+        "many_field": "user_created",
+        "one_allowed_collections": null,
+        "one_collection": "directus_users",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": null,
+        "sort_field": null
+      },
+      "schema": {
+        "table": "login_page",
+        "column": "user_created",
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id",
+        "constraint_name": "login_page_user_created_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "NO ACTION"
+      }
+    },
+    {
+      "collection": "login_page",
+      "field": "user_updated",
+      "related_collection": "directus_users",
+      "meta": {
+        "junction_field": null,
+        "many_collection": "login_page",
+        "many_field": "user_updated",
+        "one_allowed_collections": null,
+        "one_collection": "directus_users",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": null,
+        "sort_field": null
+      },
+      "schema": {
+        "table": "login_page",
+        "column": "user_updated",
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id",
+        "constraint_name": "login_page_user_updated_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "NO ACTION"
+      }
+    },
+    {
       "collection": "meetup_gallery_images",
-      "field": "directus_file_id",
+      "field": "image",
       "related_collection": "directus_files",
       "meta": {
-        "junction_field": "meetup_id",
+        "junction_field": "meetup",
         "many_collection": "meetup_gallery_images",
-        "many_field": "directus_file_id",
+        "many_field": "image",
         "one_allowed_collections": null,
         "one_collection": "directus_files",
         "one_collection_field": null,
@@ -15290,22 +20304,22 @@
       },
       "schema": {
         "table": "meetup_gallery_images",
-        "column": "directus_file_id",
+        "column": "image",
         "foreign_key_table": "directus_files",
         "foreign_key_column": "id",
-        "constraint_name": "meetup_gallery_images_directus_file_id_foreign",
+        "constraint_name": "meetup_gallery_images_image_foreign",
         "on_update": "NO ACTION",
         "on_delete": "SET NULL"
       }
     },
     {
       "collection": "meetup_gallery_images",
-      "field": "meetup_id",
+      "field": "meetup",
       "related_collection": "meetups",
       "meta": {
-        "junction_field": "directus_file_id",
+        "junction_field": "image",
         "many_collection": "meetup_gallery_images",
-        "many_field": "meetup_id",
+        "many_field": "meetup",
         "one_allowed_collections": null,
         "one_collection": "meetups",
         "one_collection_field": null,
@@ -15315,22 +20329,47 @@
       },
       "schema": {
         "table": "meetup_gallery_images",
-        "column": "meetup_id",
+        "column": "meetup",
         "foreign_key_table": "meetups",
         "foreign_key_column": "id",
-        "constraint_name": "meetup_gallery_images_meetup_id_foreign",
+        "constraint_name": "meetup_gallery_images_meetup_foreign",
         "on_update": "NO ACTION",
         "on_delete": "SET NULL"
       }
     },
     {
       "collection": "meetup_members",
-      "field": "meetup_id",
+      "field": "member",
+      "related_collection": "members",
+      "meta": {
+        "junction_field": "meetup",
+        "many_collection": "meetup_members",
+        "many_field": "member",
+        "one_allowed_collections": null,
+        "one_collection": "members",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": "meetups",
+        "sort_field": null
+      },
+      "schema": {
+        "table": "meetup_members",
+        "column": "member",
+        "foreign_key_table": "members",
+        "foreign_key_column": "id",
+        "constraint_name": "meetup_members_member_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "SET NULL"
+      }
+    },
+    {
+      "collection": "meetup_members",
+      "field": "meetup",
       "related_collection": "meetups",
       "meta": {
-        "junction_field": "member_id",
+        "junction_field": "member",
         "many_collection": "meetup_members",
-        "many_field": "meetup_id",
+        "many_field": "meetup",
         "one_allowed_collections": null,
         "one_collection": "meetups",
         "one_collection_field": null,
@@ -15340,60 +20379,10 @@
       },
       "schema": {
         "table": "meetup_members",
-        "column": "meetup_id",
+        "column": "meetup",
         "foreign_key_table": "meetups",
         "foreign_key_column": "id",
-        "constraint_name": "meetup_members_meetup_id_foreign",
-        "on_update": "NO ACTION",
-        "on_delete": "SET NULL"
-      }
-    },
-    {
-      "collection": "meetup_members",
-      "field": "member_id",
-      "related_collection": "members",
-      "meta": {
-        "junction_field": "meetup_id",
-        "many_collection": "meetup_members",
-        "many_field": "member_id",
-        "one_allowed_collections": null,
-        "one_collection": "members",
-        "one_collection_field": null,
-        "one_deselect_action": "nullify",
-        "one_field": "meetups",
-        "sort_field": "sort"
-      },
-      "schema": {
-        "table": "meetup_members",
-        "column": "member_id",
-        "foreign_key_table": "members",
-        "foreign_key_column": "id",
-        "constraint_name": "meetup_members_member_id_foreign",
-        "on_update": "NO ACTION",
-        "on_delete": "SET NULL"
-      }
-    },
-    {
-      "collection": "meetup_page",
-      "field": "cover_image",
-      "related_collection": "directus_files",
-      "meta": {
-        "junction_field": null,
-        "many_collection": "meetup_page",
-        "many_field": "cover_image",
-        "one_allowed_collections": null,
-        "one_collection": "directus_files",
-        "one_collection_field": null,
-        "one_deselect_action": "nullify",
-        "one_field": null,
-        "sort_field": null
-      },
-      "schema": {
-        "table": "meetup_page",
-        "column": "cover_image",
-        "foreign_key_table": "directus_files",
-        "foreign_key_column": "id",
-        "constraint_name": "meetup_page_cover_image_foreign",
+        "constraint_name": "meetup_members_meetup_foreign",
         "on_update": "NO ACTION",
         "on_delete": "SET NULL"
       }
@@ -15449,112 +20438,12 @@
       }
     },
     {
-      "collection": "meetup_speakers",
-      "field": "meetup_id",
-      "related_collection": "meetups",
-      "meta": {
-        "junction_field": "speaker_id",
-        "many_collection": "meetup_speakers",
-        "many_field": "meetup_id",
-        "one_allowed_collections": null,
-        "one_collection": "meetups",
-        "one_collection_field": null,
-        "one_deselect_action": "nullify",
-        "one_field": "speakers",
-        "sort_field": "sort"
-      },
-      "schema": {
-        "table": "meetup_speakers",
-        "column": "meetup_id",
-        "foreign_key_table": "meetups",
-        "foreign_key_column": "id",
-        "constraint_name": "meetup_speakers_meetup_id_foreign",
-        "on_update": "NO ACTION",
-        "on_delete": "SET NULL"
-      }
-    },
-    {
-      "collection": "meetup_speakers",
-      "field": "speaker_id",
-      "related_collection": "speakers",
-      "meta": {
-        "junction_field": "meetup_id",
-        "many_collection": "meetup_speakers",
-        "many_field": "speaker_id",
-        "one_allowed_collections": null,
-        "one_collection": "speakers",
-        "one_collection_field": null,
-        "one_deselect_action": "nullify",
-        "one_field": "meetups",
-        "sort_field": "sort"
-      },
-      "schema": {
-        "table": "meetup_speakers",
-        "column": "speaker_id",
-        "foreign_key_table": "speakers",
-        "foreign_key_column": "id",
-        "constraint_name": "meetup_speakers_speaker_id_foreign",
-        "on_update": "NO ACTION",
-        "on_delete": "SET NULL"
-      }
-    },
-    {
-      "collection": "meetup_tags",
-      "field": "meetup_id",
-      "related_collection": "meetups",
-      "meta": {
-        "junction_field": "tag_id",
-        "many_collection": "meetup_tags",
-        "many_field": "meetup_id",
-        "one_allowed_collections": null,
-        "one_collection": "meetups",
-        "one_collection_field": null,
-        "one_deselect_action": "nullify",
-        "one_field": "tags",
-        "sort_field": "sort"
-      },
-      "schema": {
-        "table": "meetup_tags",
-        "column": "meetup_id",
-        "foreign_key_table": "meetups",
-        "foreign_key_column": "id",
-        "constraint_name": "meetup_tags_meetup_id_foreign",
-        "on_update": "NO ACTION",
-        "on_delete": "SET NULL"
-      }
-    },
-    {
-      "collection": "meetup_tags",
-      "field": "tag_id",
-      "related_collection": "tags",
-      "meta": {
-        "junction_field": "meetup_id",
-        "many_collection": "meetup_tags",
-        "many_field": "tag_id",
-        "one_allowed_collections": null,
-        "one_collection": "tags",
-        "one_collection_field": null,
-        "one_deselect_action": "nullify",
-        "one_field": "meetups",
-        "sort_field": null
-      },
-      "schema": {
-        "table": "meetup_tags",
-        "column": "tag_id",
-        "foreign_key_table": "tags",
-        "foreign_key_column": "id",
-        "constraint_name": "meetup_tags_tag_id_foreign",
-        "on_update": "NO ACTION",
-        "on_delete": "SET NULL"
-      }
-    },
-    {
-      "collection": "meetups",
+      "collection": "meetup_page",
       "field": "cover_image",
       "related_collection": "directus_files",
       "meta": {
         "junction_field": null,
-        "many_collection": "meetups",
+        "many_collection": "meetup_page",
         "many_field": "cover_image",
         "one_allowed_collections": null,
         "one_collection": "directus_files",
@@ -15564,11 +20453,111 @@
         "sort_field": null
       },
       "schema": {
-        "table": "meetups",
+        "table": "meetup_page",
         "column": "cover_image",
         "foreign_key_table": "directus_files",
         "foreign_key_column": "id",
-        "constraint_name": "meetups_cover_image_foreign",
+        "constraint_name": "meetup_page_cover_image_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "SET NULL"
+      }
+    },
+    {
+      "collection": "meetup_speakers",
+      "field": "speaker",
+      "related_collection": "speakers",
+      "meta": {
+        "junction_field": "meetup",
+        "many_collection": "meetup_speakers",
+        "many_field": "speaker",
+        "one_allowed_collections": null,
+        "one_collection": "speakers",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": "meetups",
+        "sort_field": null
+      },
+      "schema": {
+        "table": "meetup_speakers",
+        "column": "speaker",
+        "foreign_key_table": "speakers",
+        "foreign_key_column": "id",
+        "constraint_name": "meetup_speakers_speaker_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "SET NULL"
+      }
+    },
+    {
+      "collection": "meetup_speakers",
+      "field": "meetup",
+      "related_collection": "meetups",
+      "meta": {
+        "junction_field": "speaker",
+        "many_collection": "meetup_speakers",
+        "many_field": "meetup",
+        "one_allowed_collections": null,
+        "one_collection": "meetups",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": "speakers",
+        "sort_field": "sort"
+      },
+      "schema": {
+        "table": "meetup_speakers",
+        "column": "meetup",
+        "foreign_key_table": "meetups",
+        "foreign_key_column": "id",
+        "constraint_name": "meetup_speakers_meetup_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "SET NULL"
+      }
+    },
+    {
+      "collection": "meetup_tags",
+      "field": "tag",
+      "related_collection": "tags",
+      "meta": {
+        "junction_field": "meetup",
+        "many_collection": "meetup_tags",
+        "many_field": "tag",
+        "one_allowed_collections": null,
+        "one_collection": "tags",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": "meetups",
+        "sort_field": null
+      },
+      "schema": {
+        "table": "meetup_tags",
+        "column": "tag",
+        "foreign_key_table": "tags",
+        "foreign_key_column": "id",
+        "constraint_name": "meetup_tags_tag_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "SET NULL"
+      }
+    },
+    {
+      "collection": "meetup_tags",
+      "field": "meetup",
+      "related_collection": "meetups",
+      "meta": {
+        "junction_field": "tag",
+        "many_collection": "meetup_tags",
+        "many_field": "meetup",
+        "one_allowed_collections": null,
+        "one_collection": "meetups",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": "tags",
+        "sort_field": "sort"
+      },
+      "schema": {
+        "table": "meetup_tags",
+        "column": "meetup",
+        "foreign_key_table": "meetups",
+        "foreign_key_column": "id",
+        "constraint_name": "meetup_tags_meetup_foreign",
         "on_update": "NO ACTION",
         "on_delete": "SET NULL"
       }
@@ -15624,38 +20613,38 @@
       }
     },
     {
-      "collection": "member_tags",
-      "field": "member_id",
-      "related_collection": "members",
+      "collection": "meetups",
+      "field": "cover_image",
+      "related_collection": "directus_files",
       "meta": {
-        "junction_field": "tag_id",
-        "many_collection": "member_tags",
-        "many_field": "member_id",
+        "junction_field": null,
+        "many_collection": "meetups",
+        "many_field": "cover_image",
         "one_allowed_collections": null,
-        "one_collection": "members",
+        "one_collection": "directus_files",
         "one_collection_field": null,
         "one_deselect_action": "nullify",
-        "one_field": "tags",
-        "sort_field": "sort"
+        "one_field": null,
+        "sort_field": null
       },
       "schema": {
-        "table": "member_tags",
-        "column": "member_id",
-        "foreign_key_table": "members",
+        "table": "meetups",
+        "column": "cover_image",
+        "foreign_key_table": "directus_files",
         "foreign_key_column": "id",
-        "constraint_name": "member_tags_member_id_foreign",
+        "constraint_name": "meetups_cover_image_foreign",
         "on_update": "NO ACTION",
         "on_delete": "SET NULL"
       }
     },
     {
       "collection": "member_tags",
-      "field": "tag_id",
+      "field": "tag",
       "related_collection": "tags",
       "meta": {
-        "junction_field": "member_id",
+        "junction_field": "member",
         "many_collection": "member_tags",
-        "many_field": "tag_id",
+        "many_field": "tag",
         "one_allowed_collections": null,
         "one_collection": "tags",
         "one_collection_field": null,
@@ -15665,35 +20654,35 @@
       },
       "schema": {
         "table": "member_tags",
-        "column": "tag_id",
+        "column": "tag",
         "foreign_key_table": "tags",
         "foreign_key_column": "id",
-        "constraint_name": "member_tags_tag_id_foreign",
+        "constraint_name": "member_tags_tag_foreign",
         "on_update": "NO ACTION",
         "on_delete": "SET NULL"
       }
     },
     {
-      "collection": "members",
-      "field": "action_image",
-      "related_collection": "directus_files",
+      "collection": "member_tags",
+      "field": "member",
+      "related_collection": "members",
       "meta": {
-        "junction_field": null,
-        "many_collection": "members",
-        "many_field": "action_image",
+        "junction_field": "tag",
+        "many_collection": "member_tags",
+        "many_field": "member",
         "one_allowed_collections": null,
-        "one_collection": "directus_files",
+        "one_collection": "members",
         "one_collection_field": null,
         "one_deselect_action": "nullify",
-        "one_field": null,
-        "sort_field": null
+        "one_field": "tags",
+        "sort_field": "sort"
       },
       "schema": {
-        "table": "members",
-        "column": "action_image",
-        "foreign_key_table": "directus_files",
+        "table": "member_tags",
+        "column": "member",
+        "foreign_key_table": "members",
         "foreign_key_column": "id",
-        "constraint_name": "members_action_image_foreign",
+        "constraint_name": "member_tags_member_foreign",
         "on_update": "NO ACTION",
         "on_delete": "SET NULL"
       }
@@ -15725,6 +20714,31 @@
     },
     {
       "collection": "members",
+      "field": "updated_by",
+      "related_collection": "directus_users",
+      "meta": {
+        "junction_field": null,
+        "many_collection": "members",
+        "many_field": "updated_by",
+        "one_allowed_collections": null,
+        "one_collection": "directus_users",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": null,
+        "sort_field": null
+      },
+      "schema": {
+        "table": "members",
+        "column": "updated_by",
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id",
+        "constraint_name": "members_updated_by_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "NO ACTION"
+      }
+    },
+    {
+      "collection": "members",
       "field": "normal_image",
       "related_collection": "directus_files",
       "meta": {
@@ -15750,14 +20764,14 @@
     },
     {
       "collection": "members",
-      "field": "updated_by",
-      "related_collection": "directus_users",
+      "field": "action_image",
+      "related_collection": "directus_files",
       "meta": {
         "junction_field": null,
         "many_collection": "members",
-        "many_field": "updated_by",
+        "many_field": "action_image",
         "one_allowed_collections": null,
-        "one_collection": "directus_users",
+        "one_collection": "directus_files",
         "one_collection_field": null,
         "one_deselect_action": "nullify",
         "one_field": null,
@@ -15765,12 +20779,12 @@
       },
       "schema": {
         "table": "members",
-        "column": "updated_by",
-        "foreign_key_table": "directus_users",
+        "column": "action_image",
+        "foreign_key_table": "directus_files",
         "foreign_key_column": "id",
-        "constraint_name": "members_updated_by_foreign",
+        "constraint_name": "members_action_image_foreign",
         "on_update": "NO ACTION",
-        "on_delete": "NO ACTION"
+        "on_delete": "SET NULL"
       }
     },
     {
@@ -15825,37 +20839,12 @@
     },
     {
       "collection": "pick_of_the_day_tags",
-      "field": "pick_of_the_day_id",
-      "related_collection": "picks_of_the_day",
-      "meta": {
-        "junction_field": "tag_id",
-        "many_collection": "pick_of_the_day_tags",
-        "many_field": "pick_of_the_day_id",
-        "one_allowed_collections": null,
-        "one_collection": "picks_of_the_day",
-        "one_collection_field": null,
-        "one_deselect_action": "nullify",
-        "one_field": "tags",
-        "sort_field": "sort"
-      },
-      "schema": {
-        "table": "pick_of_the_day_tags",
-        "column": "pick_of_the_day_id",
-        "foreign_key_table": "picks_of_the_day",
-        "foreign_key_column": "id",
-        "constraint_name": "pick_of_the_day_tags_pick_of_the_day_id_foreign",
-        "on_update": "NO ACTION",
-        "on_delete": "SET NULL"
-      }
-    },
-    {
-      "collection": "pick_of_the_day_tags",
-      "field": "tag_id",
+      "field": "tag",
       "related_collection": "tags",
       "meta": {
-        "junction_field": "pick_of_the_day_id",
+        "junction_field": "pick_of_the_day",
         "many_collection": "pick_of_the_day_tags",
-        "many_field": "tag_id",
+        "many_field": "tag",
         "one_allowed_collections": null,
         "one_collection": "tags",
         "one_collection_field": null,
@@ -15865,10 +20854,35 @@
       },
       "schema": {
         "table": "pick_of_the_day_tags",
-        "column": "tag_id",
+        "column": "tag",
         "foreign_key_table": "tags",
         "foreign_key_column": "id",
-        "constraint_name": "pick_of_the_day_tags_tag_id_foreign",
+        "constraint_name": "pick_of_the_day_tags_tag_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "SET NULL"
+      }
+    },
+    {
+      "collection": "pick_of_the_day_tags",
+      "field": "pick_of_the_day",
+      "related_collection": "picks_of_the_day",
+      "meta": {
+        "junction_field": "tag",
+        "many_collection": "pick_of_the_day_tags",
+        "many_field": "pick_of_the_day",
+        "one_allowed_collections": null,
+        "one_collection": "picks_of_the_day",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": "tags",
+        "sort_field": "sort"
+      },
+      "schema": {
+        "table": "pick_of_the_day_tags",
+        "column": "pick_of_the_day",
+        "foreign_key_table": "picks_of_the_day",
+        "foreign_key_column": "id",
+        "constraint_name": "pick_of_the_day_tags_pick_of_the_day_foreign",
         "on_update": "NO ACTION",
         "on_delete": "SET NULL"
       }
@@ -15900,6 +20914,31 @@
     },
     {
       "collection": "picks_of_the_day",
+      "field": "updated_by",
+      "related_collection": "directus_users",
+      "meta": {
+        "junction_field": null,
+        "many_collection": "picks_of_the_day",
+        "many_field": "updated_by",
+        "one_allowed_collections": null,
+        "one_collection": "directus_users",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": null,
+        "sort_field": null
+      },
+      "schema": {
+        "table": "picks_of_the_day",
+        "column": "updated_by",
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id",
+        "constraint_name": "picks_of_the_day_updated_by_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "NO ACTION"
+      }
+    },
+    {
+      "collection": "picks_of_the_day",
       "field": "image",
       "related_collection": "directus_files",
       "meta": {
@@ -15919,31 +20958,6 @@
         "foreign_key_table": "directus_files",
         "foreign_key_column": "id",
         "constraint_name": "picks_of_the_day_image_foreign",
-        "on_update": "NO ACTION",
-        "on_delete": "SET NULL"
-      }
-    },
-    {
-      "collection": "picks_of_the_day",
-      "field": "member",
-      "related_collection": "members",
-      "meta": {
-        "junction_field": null,
-        "many_collection": "picks_of_the_day",
-        "many_field": "member",
-        "one_allowed_collections": null,
-        "one_collection": "members",
-        "one_collection_field": null,
-        "one_deselect_action": "nullify",
-        "one_field": "picks_of_the_day",
-        "sort_field": "sort"
-      },
-      "schema": {
-        "table": "picks_of_the_day",
-        "column": "member",
-        "foreign_key_table": "members",
-        "foreign_key_column": "id",
-        "constraint_name": "picks_of_the_day_member_foreign",
         "on_update": "NO ACTION",
         "on_delete": "SET NULL"
       }
@@ -15975,6 +20989,31 @@
     },
     {
       "collection": "picks_of_the_day",
+      "field": "member",
+      "related_collection": "members",
+      "meta": {
+        "junction_field": null,
+        "many_collection": "picks_of_the_day",
+        "many_field": "member",
+        "one_allowed_collections": null,
+        "one_collection": "members",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": "picks_of_the_day",
+        "sort_field": "sort"
+      },
+      "schema": {
+        "table": "picks_of_the_day",
+        "column": "member",
+        "foreign_key_table": "members",
+        "foreign_key_column": "id",
+        "constraint_name": "picks_of_the_day_member_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "SET NULL"
+      }
+    },
+    {
+      "collection": "picks_of_the_day",
       "field": "speaker",
       "related_collection": "speakers",
       "meta": {
@@ -15999,63 +21038,38 @@
       }
     },
     {
-      "collection": "picks_of_the_day",
-      "field": "updated_by",
-      "related_collection": "directus_users",
-      "meta": {
-        "junction_field": null,
-        "many_collection": "picks_of_the_day",
-        "many_field": "updated_by",
-        "one_allowed_collections": null,
-        "one_collection": "directus_users",
-        "one_collection_field": null,
-        "one_deselect_action": "nullify",
-        "one_field": null,
-        "sort_field": null
-      },
-      "schema": {
-        "table": "picks_of_the_day",
-        "column": "updated_by",
-        "foreign_key_table": "directus_users",
-        "foreign_key_column": "id",
-        "constraint_name": "picks_of_the_day_updated_by_foreign",
-        "on_update": "NO ACTION",
-        "on_delete": "NO ACTION"
-      }
-    },
-    {
       "collection": "podcast_members",
-      "field": "member_id",
+      "field": "member",
       "related_collection": "members",
       "meta": {
-        "junction_field": "podcast_id",
+        "junction_field": "podcast",
         "many_collection": "podcast_members",
-        "many_field": "member_id",
+        "many_field": "member",
         "one_allowed_collections": null,
         "one_collection": "members",
         "one_collection_field": null,
         "one_deselect_action": "nullify",
         "one_field": "podcasts",
-        "sort_field": "sort"
+        "sort_field": null
       },
       "schema": {
         "table": "podcast_members",
-        "column": "member_id",
+        "column": "member",
         "foreign_key_table": "members",
         "foreign_key_column": "id",
-        "constraint_name": "podcast_members_member_id_foreign",
+        "constraint_name": "podcast_members_member_foreign",
         "on_update": "NO ACTION",
         "on_delete": "SET NULL"
       }
     },
     {
       "collection": "podcast_members",
-      "field": "podcast_id",
+      "field": "podcast",
       "related_collection": "podcasts",
       "meta": {
-        "junction_field": "member_id",
+        "junction_field": "member",
         "many_collection": "podcast_members",
-        "many_field": "podcast_id",
+        "many_field": "podcast",
         "one_allowed_collections": null,
         "one_collection": "podcasts",
         "one_collection_field": null,
@@ -16065,35 +21079,10 @@
       },
       "schema": {
         "table": "podcast_members",
-        "column": "podcast_id",
+        "column": "podcast",
         "foreign_key_table": "podcasts",
         "foreign_key_column": "id",
-        "constraint_name": "podcast_members_podcast_id_foreign",
-        "on_update": "NO ACTION",
-        "on_delete": "SET NULL"
-      }
-    },
-    {
-      "collection": "podcast_page",
-      "field": "cover_image",
-      "related_collection": "directus_files",
-      "meta": {
-        "junction_field": null,
-        "many_collection": "podcast_page",
-        "many_field": "cover_image",
-        "one_allowed_collections": null,
-        "one_collection": "directus_files",
-        "one_collection_field": null,
-        "one_deselect_action": "nullify",
-        "one_field": null,
-        "sort_field": null
-      },
-      "schema": {
-        "table": "podcast_page",
-        "column": "cover_image",
-        "foreign_key_table": "directus_files",
-        "foreign_key_column": "id",
-        "constraint_name": "podcast_page_cover_image_foreign",
+        "constraint_name": "podcast_members_podcast_foreign",
         "on_update": "NO ACTION",
         "on_delete": "SET NULL"
       }
@@ -16149,162 +21138,12 @@
       }
     },
     {
-      "collection": "podcast_speakers",
-      "field": "podcast_id",
-      "related_collection": "podcasts",
-      "meta": {
-        "junction_field": "speaker_id",
-        "many_collection": "podcast_speakers",
-        "many_field": "podcast_id",
-        "one_allowed_collections": null,
-        "one_collection": "podcasts",
-        "one_collection_field": null,
-        "one_deselect_action": "nullify",
-        "one_field": "speakers",
-        "sort_field": "sort"
-      },
-      "schema": {
-        "table": "podcast_speakers",
-        "column": "podcast_id",
-        "foreign_key_table": "podcasts",
-        "foreign_key_column": "id",
-        "constraint_name": "podcast_speakers_podcast_id_foreign",
-        "on_update": "NO ACTION",
-        "on_delete": "SET NULL"
-      }
-    },
-    {
-      "collection": "podcast_speakers",
-      "field": "speaker_id",
-      "related_collection": "speakers",
-      "meta": {
-        "junction_field": "podcast_id",
-        "many_collection": "podcast_speakers",
-        "many_field": "speaker_id",
-        "one_allowed_collections": null,
-        "one_collection": "speakers",
-        "one_collection_field": null,
-        "one_deselect_action": "nullify",
-        "one_field": "podcasts",
-        "sort_field": "sort"
-      },
-      "schema": {
-        "table": "podcast_speakers",
-        "column": "speaker_id",
-        "foreign_key_table": "speakers",
-        "foreign_key_column": "id",
-        "constraint_name": "podcast_speakers_speaker_id_foreign",
-        "on_update": "NO ACTION",
-        "on_delete": "SET NULL"
-      }
-    },
-    {
-      "collection": "podcast_tags",
-      "field": "podcast_id",
-      "related_collection": "podcasts",
-      "meta": {
-        "junction_field": "tag_id",
-        "many_collection": "podcast_tags",
-        "many_field": "podcast_id",
-        "one_allowed_collections": null,
-        "one_collection": "podcasts",
-        "one_collection_field": null,
-        "one_deselect_action": "nullify",
-        "one_field": "tags",
-        "sort_field": "sort"
-      },
-      "schema": {
-        "table": "podcast_tags",
-        "column": "podcast_id",
-        "foreign_key_table": "podcasts",
-        "foreign_key_column": "id",
-        "constraint_name": "podcast_tags_podcast_id_foreign",
-        "on_update": "NO ACTION",
-        "on_delete": "SET NULL"
-      }
-    },
-    {
-      "collection": "podcast_tags",
-      "field": "tag_id",
-      "related_collection": "tags",
-      "meta": {
-        "junction_field": "podcast_id",
-        "many_collection": "podcast_tags",
-        "many_field": "tag_id",
-        "one_allowed_collections": null,
-        "one_collection": "tags",
-        "one_collection_field": null,
-        "one_deselect_action": "nullify",
-        "one_field": "podcasts",
-        "sort_field": null
-      },
-      "schema": {
-        "table": "podcast_tags",
-        "column": "tag_id",
-        "foreign_key_table": "tags",
-        "foreign_key_column": "id",
-        "constraint_name": "podcast_tags_tag_id_foreign",
-        "on_update": "NO ACTION",
-        "on_delete": "SET NULL"
-      }
-    },
-    {
-      "collection": "podcasts",
-      "field": "audio_file",
-      "related_collection": "directus_files",
-      "meta": {
-        "junction_field": null,
-        "many_collection": "podcasts",
-        "many_field": "audio_file",
-        "one_allowed_collections": null,
-        "one_collection": "directus_files",
-        "one_collection_field": null,
-        "one_deselect_action": "nullify",
-        "one_field": null,
-        "sort_field": null
-      },
-      "schema": {
-        "table": "podcasts",
-        "column": "audio_file",
-        "foreign_key_table": "directus_files",
-        "foreign_key_column": "id",
-        "constraint_name": "podcasts_audio_file_foreign",
-        "on_update": "NO ACTION",
-        "on_delete": "SET NULL"
-      }
-    },
-    {
-      "collection": "podcasts",
-      "field": "banner_image",
-      "related_collection": "directus_files",
-      "meta": {
-        "junction_field": null,
-        "many_collection": "podcasts",
-        "many_field": "banner_image",
-        "one_allowed_collections": null,
-        "one_collection": "directus_files",
-        "one_collection_field": null,
-        "one_deselect_action": "nullify",
-        "one_field": null,
-        "sort_field": null
-      },
-      "schema": {
-        "table": "podcasts",
-        "column": "banner_image",
-        "foreign_key_table": "directus_files",
-        "foreign_key_column": "id",
-        "constraint_name": "podcasts_banner_image_foreign",
-        "on_update": "NO ACTION",
-        "on_delete": "SET NULL"
-      }
-    },
-    {
-      "collection": "podcasts",
+      "collection": "podcast_page",
       "field": "cover_image",
       "related_collection": "directus_files",
       "meta": {
         "junction_field": null,
-        "many_collection": "podcasts",
+        "many_collection": "podcast_page",
         "many_field": "cover_image",
         "one_allowed_collections": null,
         "one_collection": "directus_files",
@@ -16314,11 +21153,111 @@
         "sort_field": null
       },
       "schema": {
-        "table": "podcasts",
+        "table": "podcast_page",
         "column": "cover_image",
         "foreign_key_table": "directus_files",
         "foreign_key_column": "id",
-        "constraint_name": "podcasts_cover_image_foreign",
+        "constraint_name": "podcast_page_cover_image_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "SET NULL"
+      }
+    },
+    {
+      "collection": "podcast_speakers",
+      "field": "speaker",
+      "related_collection": "speakers",
+      "meta": {
+        "junction_field": "podcast",
+        "many_collection": "podcast_speakers",
+        "many_field": "speaker",
+        "one_allowed_collections": null,
+        "one_collection": "speakers",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": "podcasts",
+        "sort_field": null
+      },
+      "schema": {
+        "table": "podcast_speakers",
+        "column": "speaker",
+        "foreign_key_table": "speakers",
+        "foreign_key_column": "id",
+        "constraint_name": "podcast_speakers_speaker_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "SET NULL"
+      }
+    },
+    {
+      "collection": "podcast_speakers",
+      "field": "podcast",
+      "related_collection": "podcasts",
+      "meta": {
+        "junction_field": "speaker",
+        "many_collection": "podcast_speakers",
+        "many_field": "podcast",
+        "one_allowed_collections": null,
+        "one_collection": "podcasts",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": "speakers",
+        "sort_field": "sort"
+      },
+      "schema": {
+        "table": "podcast_speakers",
+        "column": "podcast",
+        "foreign_key_table": "podcasts",
+        "foreign_key_column": "id",
+        "constraint_name": "podcast_speakers_podcast_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "SET NULL"
+      }
+    },
+    {
+      "collection": "podcast_tags",
+      "field": "tag",
+      "related_collection": "tags",
+      "meta": {
+        "junction_field": "podcast",
+        "many_collection": "podcast_tags",
+        "many_field": "tag",
+        "one_allowed_collections": null,
+        "one_collection": "tags",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": "podcasts",
+        "sort_field": null
+      },
+      "schema": {
+        "table": "podcast_tags",
+        "column": "tag",
+        "foreign_key_table": "tags",
+        "foreign_key_column": "id",
+        "constraint_name": "podcast_tags_tag_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "SET NULL"
+      }
+    },
+    {
+      "collection": "podcast_tags",
+      "field": "podcast",
+      "related_collection": "podcasts",
+      "meta": {
+        "junction_field": "tag",
+        "many_collection": "podcast_tags",
+        "many_field": "podcast",
+        "one_allowed_collections": null,
+        "one_collection": "podcasts",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": "tags",
+        "sort_field": "sort"
+      },
+      "schema": {
+        "table": "podcast_tags",
+        "column": "podcast",
+        "foreign_key_table": "podcasts",
+        "foreign_key_column": "id",
+        "constraint_name": "podcast_tags_podcast_foreign",
         "on_update": "NO ACTION",
         "on_delete": "SET NULL"
       }
@@ -16374,6 +21313,81 @@
       }
     },
     {
+      "collection": "podcasts",
+      "field": "cover_image",
+      "related_collection": "directus_files",
+      "meta": {
+        "junction_field": null,
+        "many_collection": "podcasts",
+        "many_field": "cover_image",
+        "one_allowed_collections": null,
+        "one_collection": "directus_files",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": null,
+        "sort_field": null
+      },
+      "schema": {
+        "table": "podcasts",
+        "column": "cover_image",
+        "foreign_key_table": "directus_files",
+        "foreign_key_column": "id",
+        "constraint_name": "podcasts_cover_image_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "SET NULL"
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "banner_image",
+      "related_collection": "directus_files",
+      "meta": {
+        "junction_field": null,
+        "many_collection": "podcasts",
+        "many_field": "banner_image",
+        "one_allowed_collections": null,
+        "one_collection": "directus_files",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": null,
+        "sort_field": null
+      },
+      "schema": {
+        "table": "podcasts",
+        "column": "banner_image",
+        "foreign_key_table": "directus_files",
+        "foreign_key_column": "id",
+        "constraint_name": "podcasts_banner_image_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "SET NULL"
+      }
+    },
+    {
+      "collection": "podcasts",
+      "field": "audio_file",
+      "related_collection": "directus_files",
+      "meta": {
+        "junction_field": null,
+        "many_collection": "podcasts",
+        "many_field": "audio_file",
+        "one_allowed_collections": null,
+        "one_collection": "directus_files",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": null,
+        "sort_field": null
+      },
+      "schema": {
+        "table": "podcasts",
+        "column": "audio_file",
+        "foreign_key_table": "directus_files",
+        "foreign_key_column": "id",
+        "constraint_name": "podcasts_audio_file_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "SET NULL"
+      }
+    },
+    {
       "collection": "privacy_page",
       "field": "created_by",
       "related_collection": "directus_users",
@@ -16424,38 +21438,288 @@
       }
     },
     {
-      "collection": "speaker_tags",
-      "field": "speaker_id",
-      "related_collection": "speakers",
+      "collection": "profile_creation_page",
+      "field": "user_created",
+      "related_collection": "directus_users",
       "meta": {
-        "junction_field": "tag_id",
-        "many_collection": "speaker_tags",
-        "many_field": "speaker_id",
+        "junction_field": null,
+        "many_collection": "profile_creation_page",
+        "many_field": "user_created",
         "one_allowed_collections": null,
-        "one_collection": "speakers",
+        "one_collection": "directus_users",
         "one_collection_field": null,
         "one_deselect_action": "nullify",
-        "one_field": "tags",
-        "sort_field": "sort"
+        "one_field": null,
+        "sort_field": null
       },
       "schema": {
-        "table": "speaker_tags",
-        "column": "speaker_id",
-        "foreign_key_table": "speakers",
+        "table": "profile_creation_page",
+        "column": "user_created",
+        "foreign_key_table": "directus_users",
         "foreign_key_column": "id",
-        "constraint_name": "speaker_tags_speaker_id_foreign",
+        "constraint_name": "profile_creation_page_user_created_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "NO ACTION"
+      }
+    },
+    {
+      "collection": "profile_creation_page",
+      "field": "user_updated",
+      "related_collection": "directus_users",
+      "meta": {
+        "junction_field": null,
+        "many_collection": "profile_creation_page",
+        "many_field": "user_updated",
+        "one_allowed_collections": null,
+        "one_collection": "directus_users",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": null,
+        "sort_field": null
+      },
+      "schema": {
+        "table": "profile_creation_page",
+        "column": "user_updated",
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id",
+        "constraint_name": "profile_creation_page_user_updated_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "NO ACTION"
+      }
+    },
+    {
+      "collection": "profiles",
+      "field": "user_created",
+      "related_collection": "directus_users",
+      "meta": {
+        "junction_field": null,
+        "many_collection": "profiles",
+        "many_field": "user_created",
+        "one_allowed_collections": null,
+        "one_collection": "directus_users",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": null,
+        "sort_field": null
+      },
+      "schema": {
+        "table": "profiles",
+        "column": "user_created",
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id",
+        "constraint_name": "profiles_user_created_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "NO ACTION"
+      }
+    },
+    {
+      "collection": "profiles",
+      "field": "user_updated",
+      "related_collection": "directus_users",
+      "meta": {
+        "junction_field": null,
+        "many_collection": "profiles",
+        "many_field": "user_updated",
+        "one_allowed_collections": null,
+        "one_collection": "directus_users",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": null,
+        "sort_field": null
+      },
+      "schema": {
+        "table": "profiles",
+        "column": "user_updated",
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id",
+        "constraint_name": "profiles_user_updated_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "NO ACTION"
+      }
+    },
+    {
+      "collection": "profiles",
+      "field": "profile_image",
+      "related_collection": "directus_files",
+      "meta": {
+        "junction_field": null,
+        "many_collection": "profiles",
+        "many_field": "profile_image",
+        "one_allowed_collections": null,
+        "one_collection": "directus_files",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": null,
+        "sort_field": null
+      },
+      "schema": {
+        "table": "profiles",
+        "column": "profile_image",
+        "foreign_key_table": "directus_files",
+        "foreign_key_column": "id",
+        "constraint_name": "profiles_profile_image_foreign",
         "on_update": "NO ACTION",
         "on_delete": "SET NULL"
       }
     },
     {
-      "collection": "speaker_tags",
-      "field": "tag_id",
+      "collection": "profiles_emojis",
+      "field": "emojis_id",
+      "related_collection": "emojis",
+      "meta": {
+        "junction_field": "profiles_id",
+        "many_collection": "profiles_emojis",
+        "many_field": "emojis_id",
+        "one_allowed_collections": null,
+        "one_collection": "emojis",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": null,
+        "sort_field": null
+      },
+      "schema": {
+        "table": "profiles_emojis",
+        "column": "emojis_id",
+        "foreign_key_table": "emojis",
+        "foreign_key_column": "id",
+        "constraint_name": "profiles_emojis_emojis_id_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "SET NULL"
+      }
+    },
+    {
+      "collection": "profiles_emojis",
+      "field": "profiles_id",
+      "related_collection": "profiles",
+      "meta": {
+        "junction_field": "emojis_id",
+        "many_collection": "profiles_emojis",
+        "many_field": "profiles_id",
+        "one_allowed_collections": null,
+        "one_collection": "profiles",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": "emojis",
+        "sort_field": null
+      },
+      "schema": {
+        "table": "profiles_emojis",
+        "column": "profiles_id",
+        "foreign_key_table": "profiles",
+        "foreign_key_column": "id",
+        "constraint_name": "profiles_emojis_profiles_id_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "SET NULL"
+      }
+    },
+    {
+      "collection": "profiles_tags",
+      "field": "tags_id",
       "related_collection": "tags",
       "meta": {
-        "junction_field": "speaker_id",
+        "junction_field": "profiles_id",
+        "many_collection": "profiles_tags",
+        "many_field": "tags_id",
+        "one_allowed_collections": null,
+        "one_collection": "tags",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": null,
+        "sort_field": null
+      },
+      "schema": {
+        "table": "profiles_tags",
+        "column": "tags_id",
+        "foreign_key_table": "tags",
+        "foreign_key_column": "id",
+        "constraint_name": "profiles_tags_tags_id_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "SET NULL"
+      }
+    },
+    {
+      "collection": "profiles_tags",
+      "field": "profiles_id",
+      "related_collection": "profiles",
+      "meta": {
+        "junction_field": "tags_id",
+        "many_collection": "profiles_tags",
+        "many_field": "profiles_id",
+        "one_allowed_collections": null,
+        "one_collection": "profiles",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": "interested_tags",
+        "sort_field": null
+      },
+      "schema": {
+        "table": "profiles_tags",
+        "column": "profiles_id",
+        "foreign_key_table": "profiles",
+        "foreign_key_column": "id",
+        "constraint_name": "profiles_tags_profiles_id_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "SET NULL"
+      }
+    },
+    {
+      "collection": "raffle_page",
+      "field": "user_updated",
+      "related_collection": "directus_users",
+      "meta": {
+        "junction_field": null,
+        "many_collection": "raffle_page",
+        "many_field": "user_updated",
+        "one_allowed_collections": null,
+        "one_collection": "directus_users",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": null,
+        "sort_field": null
+      },
+      "schema": {
+        "table": "raffle_page",
+        "column": "user_updated",
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id",
+        "constraint_name": "raffle_page_user_updated_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "NO ACTION"
+      }
+    },
+    {
+      "collection": "raffle_page",
+      "field": "user_created",
+      "related_collection": "directus_users",
+      "meta": {
+        "junction_field": null,
+        "many_collection": "raffle_page",
+        "many_field": "user_created",
+        "one_allowed_collections": null,
+        "one_collection": "directus_users",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": null,
+        "sort_field": null
+      },
+      "schema": {
+        "table": "raffle_page",
+        "column": "user_created",
+        "foreign_key_table": "directus_users",
+        "foreign_key_column": "id",
+        "constraint_name": "raffle_page_user_created_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "NO ACTION"
+      }
+    },
+    {
+      "collection": "speaker_tags",
+      "field": "tag",
+      "related_collection": "tags",
+      "meta": {
+        "junction_field": "speaker",
         "many_collection": "speaker_tags",
-        "many_field": "tag_id",
+        "many_field": "tag",
         "one_allowed_collections": null,
         "one_collection": "tags",
         "one_collection_field": null,
@@ -16465,10 +21729,35 @@
       },
       "schema": {
         "table": "speaker_tags",
-        "column": "tag_id",
+        "column": "tag",
         "foreign_key_table": "tags",
         "foreign_key_column": "id",
-        "constraint_name": "speaker_tags_tag_id_foreign",
+        "constraint_name": "speaker_tags_tag_foreign",
+        "on_update": "NO ACTION",
+        "on_delete": "SET NULL"
+      }
+    },
+    {
+      "collection": "speaker_tags",
+      "field": "speaker",
+      "related_collection": "speakers",
+      "meta": {
+        "junction_field": "tag",
+        "many_collection": "speaker_tags",
+        "many_field": "speaker",
+        "one_allowed_collections": null,
+        "one_collection": "speakers",
+        "one_collection_field": null,
+        "one_deselect_action": "nullify",
+        "one_field": "tags",
+        "sort_field": "sort"
+      },
+      "schema": {
+        "table": "speaker_tags",
+        "column": "speaker",
+        "foreign_key_table": "speakers",
+        "foreign_key_column": "id",
+        "constraint_name": "speaker_tags_speaker_foreign",
         "on_update": "NO ACTION",
         "on_delete": "SET NULL"
       }
@@ -16500,14 +21789,14 @@
     },
     {
       "collection": "speakers",
-      "field": "event_image",
-      "related_collection": "directus_files",
+      "field": "updated_by",
+      "related_collection": "directus_users",
       "meta": {
         "junction_field": null,
         "many_collection": "speakers",
-        "many_field": "event_image",
+        "many_field": "updated_by",
         "one_allowed_collections": null,
-        "one_collection": "directus_files",
+        "one_collection": "directus_users",
         "one_collection_field": null,
         "one_deselect_action": "nullify",
         "one_field": null,
@@ -16515,12 +21804,12 @@
       },
       "schema": {
         "table": "speakers",
-        "column": "event_image",
-        "foreign_key_table": "directus_files",
+        "column": "updated_by",
+        "foreign_key_table": "directus_users",
         "foreign_key_column": "id",
-        "constraint_name": "speakers_event_image_foreign",
+        "constraint_name": "speakers_updated_by_foreign",
         "on_update": "NO ACTION",
-        "on_delete": "SET NULL"
+        "on_delete": "NO ACTION"
       }
     },
     {
@@ -16550,14 +21839,14 @@
     },
     {
       "collection": "speakers",
-      "field": "updated_by",
-      "related_collection": "directus_users",
+      "field": "event_image",
+      "related_collection": "directus_files",
       "meta": {
         "junction_field": null,
         "many_collection": "speakers",
-        "many_field": "updated_by",
+        "many_field": "event_image",
         "one_allowed_collections": null,
-        "one_collection": "directus_users",
+        "one_collection": "directus_files",
         "one_collection_field": null,
         "one_deselect_action": "nullify",
         "one_field": null,
@@ -16565,12 +21854,12 @@
       },
       "schema": {
         "table": "speakers",
-        "column": "updated_by",
-        "foreign_key_table": "directus_users",
+        "column": "event_image",
+        "foreign_key_table": "directus_files",
         "foreign_key_column": "id",
-        "constraint_name": "speakers_updated_by_foreign",
+        "constraint_name": "speakers_event_image_foreign",
         "on_update": "NO ACTION",
-        "on_delete": "NO ACTION"
+        "on_delete": "SET NULL"
       }
     },
     {


### PR DESCRIPTION
This PR provides an up to date (2024-08-05) `/directus-cms/schema.json` file which can be applied to any (local) directus environment by running `$ npm run apply-schema`.

**Note:**
Due to a bug in directus <v10.13.0 every snapshot file has to have the entries for webhooks and default user roles removed. This has already been done here so that the schema can be directly applied.