### PR TITLE
Added create-profile extension

### DIFF
--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/package.json
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/package.json
@@ -53,6 +53,11 @@
                 "type": "hook",
                 "name": "buzzsprout",
                 "source": "src/buzzsprout/index.ts"
+            },
+            {
+                "type": "hook",
+                "name": "create-profile",
+                "source": "src/create-profile/index.ts"
             }
         ],
         "host": "^10.10.0"

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/create-profile/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/create-profile/index.ts
@@ -1,0 +1,62 @@
+import { defineHook } from '@directus/extensions-sdk'
+import { createHookErrorConstructor } from '../shared/errors.ts'
+
+const HOOK_NAME = 'create-profile'
+
+export default defineHook(({ filter }, hookContext) => {
+    const logger = hookContext.logger
+    const ItemsService = hookContext.services.ItemsService
+
+    filter('users.create', (payload, metadata, context) => handleFilter( { payload, metadata, context }))
+
+    async function handleFilter(
+    {
+        payload,
+        metadata,
+        context,
+    }: {
+        payload: any
+        metadata: Record<string, any>
+        context: any
+    }) {
+        try {
+            logger.info(`${HOOK_NAME} hook: Start filter function`)
+
+            if (payload.profile) {
+                logger.info(`${HOOK_NAME} hook: User already has profile. Exiting early.`)
+                return payload
+            }
+
+            // Note that we manually set the knex/database connection here.
+            // As this called from a filter, we are within an ongoing database transaction, and the database is locked
+            // Meaning we need to manually use the existing connection, as a new one would not be available.
+            const profilesItemsService = new ItemsService('profiles', {
+                accountability: context.accountability,
+                schema: context.schema,
+                knex: context.database,
+            })
+
+            const newProfileId = await profilesItemsService.createOne({});
+
+            logger.info(`${HOOK_NAME} hook: Created profile ${newProfileId} for newly created user.`)
+
+            return {
+                ...payload,
+                // the following structure is necessary for directus to make the m2m connection
+                profiles: [
+                    {
+                        profiles_id: newProfileId,
+                    },
+                ]
+            }
+
+            // Handle unknown errors
+        } catch (error: any) {
+            logger.error(`${HOOK_NAME} hook: Error: ${error.message}`)
+            const hookError = createHookErrorConstructor(HOOK_NAME, error.message)
+            throw new hookError()
+        }
+
+        return payload
+    }
+})

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/deploy-website/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/deploy-website/index.ts
@@ -39,6 +39,14 @@ export default defineHook(({ action }, hookContext) => {
             // Log start info
             logger.info(`${HOOK_NAME} hook: Start "${metadata.collection}" action function`)
 
+            if (['profiles'].includes(metadata.collection)) {
+                logger.info(
+                    `${HOOK_NAME} hook: Updated item was in "${metadata.collection}" collection. ` +
+                    `Exiting hook early.`
+                );
+                return;
+            }
+
             // Get fields of collection
             const { fields } = context.schema.collections[metadata.collection]
 


### PR DESCRIPTION
 This PR adds a new extension to our bundle to ensure that every newly created user has a profile created and linked to as well.

This PR also modifies the existing deploy-website hook and introduces a block list of collections that do not trigger a website-redeploy. This is in order to prevent _every profile change_ from triggering a complete redeployment of the static website.