### PR TITLE
Refactoring Transcripts

### DIFF
--- a/nuxt-app/components/PodcastTranscript.vue
+++ b/nuxt-app/components/PodcastTranscript.vue
@@ -1,42 +1,117 @@
 <template>
-    <div class="relative flex max-h-96 w-full flex-col overflow-hidden rounded-xl">
-        <div class="relative left-0 top-0 flex w-full items-center justify-center bg-gray-800 py-2">
-            <div class="absolute left-3 flex flex-row gap-1.5">
-                <div v-for="index in 3" :key="index" class="h-2.5 w-2.5 rounded-full bg-gray-600"></div>
-            </div>
-            <div
-                class="w-1/2 truncate text-ellipsis whitespace-nowrap text-center text-sm font-extralight text-white text-opacity-60 md:w-3/4 md:text-base"
-            >
-                {{ `/transkript/programmierbar/${name}`.trim() }}
-            </div>
-        </div>
-        <div class="scrollbar:!w-1.5 relative w-full overflow-auto bg-gray-900">
-            <div
-                class="whitespace-pre-line px-8 pb-32 pt-8 font-mono text-sm text-white md:px-16 md:text-base lg:text-lg"
-            >
-                {{ body.trim() }}
-            </div>
-        </div>
-        <div class="absolute bottom-0 h-24 w-full bg-gradient-to-t from-black"></div>
+  <div class='relative flex max-h-96 w-full flex-col overflow-hidden rounded-xl'>
+    <div class='relative left-0 top-0 flex w-full items-center justify-center bg-gray-800 py-2'>
+      <div class='absolute left-3 flex flex-row gap-1.5'>
+        <div v-for='index in 3' :key='index' class='h-2.5 w-2.5 rounded-full bg-gray-600'></div>
+      </div>
+      <div
+        class='w-1/2 truncate text-ellipsis whitespace-nowrap text-center text-sm font-extralight text-white text-opacity-60 md:w-3/4 md:text-base'
+      >
+        {{ `/transkript/programmierbar/${name}`.trim() }}
+      </div>
     </div>
+    <div class='scrollbar:!w-1.5 relative w-full overflow-auto bg-gray-900'>
+      <div
+        class='whitespace-pre-line px-8 pb-32 pt-8 font-mono text-sm text-white md:px-16 md:text-base lg:text-lg'
+      >
+        <dl>
+          <template v-for='paragraph in paragraphs'>
+            <dt class='font-bold'>{{ paragraph.speaker }}</dt>
+            <dd class='mb-2.5'>
+              <span v-for='wordListEntry in paragraph.wordlist'
+                    :class="[(wordListEntry.time < podcastPlayer.currentTime) ? 'text-lime' : '']"
+                    v-on:click='playPodcastAtTimestamp(wordListEntry.time)'>
+                {{ wordListEntry.word + ' ' }}
+              </span>
+            </dd>
+          </template>
+        </dl>
+      </div>
+    </div>
+    <div class='absolute bottom-0 h-24 w-full bg-gradient-to-t from-black'></div>
+  </div>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue'
+<script lang='ts'>
+import { defineComponent, computed } from 'vue';
+import type { DirectusTranscriptItem, PodcastItem } from '~/types';
+import { usePodcastPlayer } from '~/composables';
+
+function getNameForSpeaker(speakerIdentifier: string, transcript: DirectusTranscriptItem) {
+  let speakerName = '???';
+  transcript.speakers?.forEach(speaker => {
+    if (String(speaker.identifier) === String(speakerIdentifier)) {
+      speakerName = speaker.name;
+      return;
+    }
+  });
+  return speakerName;
+}
 
 export default defineComponent({
-    props: {
-        name: {
-            type: String,
-            required: true,
-        },
-        body: {
-            type: String,
-            required: true,
-        },
+  props: {
+    name: {
+      type: String,
+      required: true,
     },
-    setup() {
-        return {}
+    podcast: {
+      type: Object as PropType<PodcastItem>,
+      required: true,
     },
-})
+    transcript: {
+      type: Object as PropType<DirectusTranscriptItem>,
+      required: true,
+    },
+  },
+  setup(props) {
+    const podcastPlayer = usePodcastPlayer();
+
+    function playPodcastAtTimestamp(timestamp: number) {
+      if (podcastPlayer.podcast?.id !== props.podcast.id) {
+        podcastPlayer.setPodcast(props.podcast);
+      }
+      podcastPlayer.setCurrentTime(timestamp);
+      podcastPlayer.play();
+    }
+
+    const paragraphs = computed(() => {
+
+      let sequentialParagraphs: { speaker: string, wordlist: { word: string, time: number }[] }[] = [];
+      let currentSpeaker = '';
+      let consolidatedText = '';
+      let currentWordList: { word: string, time: number }[] = [];
+
+      props.transcript?.raw_response?.results.utterances.forEach(utterance => {
+        utterance.words.forEach(word => {
+          if (currentSpeaker === '' || currentSpeaker === word.speaker) {
+            consolidatedText += ' ' + word.punctuated_word;
+            currentWordList.push({ word: word.punctuated_word, time: word.start });
+            currentSpeaker = word.speaker;
+          } else {
+            sequentialParagraphs.push({ speaker: currentSpeaker, wordlist: currentWordList });
+            currentWordList = [];
+            currentWordList.push({ word: word.punctuated_word, time: word.start });
+            currentSpeaker = word.speaker;
+          }
+        });
+      });
+
+      sequentialParagraphs.push({ speaker: currentSpeaker, wordlist: currentWordList });
+
+      sequentialParagraphs = sequentialParagraphs.map(paragraph => {
+        paragraph.speaker = getNameForSpeaker(paragraph.speaker, props.transcript);
+
+        return paragraph;
+      });
+
+      return sequentialParagraphs;
+    });
+
+    return {
+      paragraphs,
+      playPodcastAtTimestamp,
+      podcastPlayer,
+    };
+  },
+});
 </script>

--- a/nuxt-app/components/SimplePodcastTranscript.vue
+++ b/nuxt-app/components/SimplePodcastTranscript.vue
@@ -1,0 +1,42 @@
+<template>
+    <div class="relative flex max-h-96 w-full flex-col overflow-hidden rounded-xl">
+        <div class="relative left-0 top-0 flex w-full items-center justify-center bg-gray-800 py-2">
+            <div class="absolute left-3 flex flex-row gap-1.5">
+                <div v-for="index in 3" :key="index" class="h-2.5 w-2.5 rounded-full bg-gray-600"></div>
+            </div>
+            <div
+                class="w-1/2 truncate text-ellipsis whitespace-nowrap text-center text-sm font-extralight text-white text-opacity-60 md:w-3/4 md:text-base"
+            >
+                {{ `/transkript/programmierbar/${name}`.trim() }}
+            </div>
+        </div>
+        <div class="scrollbar:!w-1.5 relative w-full overflow-auto bg-gray-900">
+            <div
+                class="whitespace-pre-line px-8 pb-32 pt-8 font-mono text-sm text-white md:px-16 md:text-base lg:text-lg"
+            >
+                {{ body.trim() }}
+            </div>
+        </div>
+        <div class="absolute bottom-0 h-24 w-full bg-gradient-to-t from-black"></div>
+    </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+    props: {
+        name: {
+            type: String,
+            required: true,
+        },
+        body: {
+            type: String,
+            required: true,
+        },
+    },
+    setup() {
+        return {}
+    },
+})
+</script>

--- a/nuxt-app/composables/useDirectus.ts
+++ b/nuxt-app/composables/useDirectus.ts
@@ -13,6 +13,7 @@ import type {
   DirectusPickOfTheDayItem,
   DirectusProfileItem,
   DirectusTagItem,
+  DirectusTranscriptItem,
   LoginProvider,
   MeetupItem,
   PodcastItem,
@@ -582,6 +583,25 @@ export function useDirectus() {
       ))?.pop() as unknown as DirectusProfileItem
   }
 
+  async function getTranscriptForPodcast(podcast: PodcastItem) {
+    return (await directus
+      .request(
+        readItems('transcripts', {
+          fields: [
+            'id',
+            'service',
+            'supported_features',
+            'speakers',
+            'raw_response',
+          ],
+          filter: {
+            podcast : { id: { _eq: podcast.id} }
+          },
+          sort: ['-date_updated']
+        })
+      ))?.pop() as unknown as DirectusTranscriptItem
+  }
+
   async function getSingleSignOnProviders() {
         const directusProviders = await directus.request(readProviders())
 
@@ -654,6 +674,7 @@ export function useDirectus() {
         getMeetupBySlug,
         getSpeakerBySlug,
         getRelatedPodcasts,
+        getTranscriptForPodcast,
         getSingleSignOnProviders,
         getCurrentUser,
         registerNewUser,

--- a/nuxt-app/pages/podcast/[slug].vue
+++ b/nuxt-app/pages/podcast/[slug].vue
@@ -60,11 +60,18 @@
                             </a>
                         </li>
                     </ul>
-                    <PodcastTranscript
+                    <SimplePodcastTranscript
                         v-if="podcast.transcript"
                         :name="podcast.slug"
                         :body="podcast.transcript"
                         class="mt-12"
+                    />
+                    <PodcastTranscript
+                      v-if="transcript"
+                      :name="podcast.slug"
+                      :podcast='podcast'
+                      :transcript="transcript"
+                      class="mt-12"
                     />
                 </div>
             </div>
@@ -152,12 +159,15 @@ const { data: pageData } = useAsyncData(route.fullPath, async () => {
         throw new Error('The podcast was not found.')
     }
 
+    // Transcript
+    const transcript = await directus.getTranscriptForPodcast(podcast);
+
     // Query related podcasts
     const relatedPodcasts = podcast.tagsPrepared.length ? await directus.getRelatedPodcasts(podcast) : []
 
     // Return podcast, pick of the day and
     // speaker count and related podcasts
-    return { podcast, pickOfTheDayCount, speakerCount, relatedPodcasts }
+    return { podcast, pickOfTheDayCount, speakerCount, relatedPodcasts, transcript }
 })
 
 // Extract podcast, pick of the day, speaker
@@ -166,6 +176,8 @@ const podcast: ComputedRef<PodcastItem | undefined> = computed(() => pageData.va
 const pickOfTheDayCount = computed(() => pageData.value?.pickOfTheDayCount)
 const speakerCount = computed(() => pageData.value?.speakerCount)
 const relatedPodcasts = computed(() => pageData.value?.relatedPodcasts)
+const transcript = computed(() => pageData.value?.transcript)
+
 // Set loading screen
 useLoadingScreen(podcast, pickOfTheDayCount, speakerCount)
 

--- a/nuxt-app/services/directus.ts
+++ b/nuxt-app/services/directus.ts
@@ -20,7 +20,8 @@ import type {
     DirectusRafflePage,
     DirectusSpeakerItem,
     DirectusTagItem,
-    DirectusProfileItem
+    DirectusProfileItem,
+    DirectusTranscriptItem
 } from '../types'
 
 export type Collections = {
@@ -44,6 +45,7 @@ export type Collections = {
     picks_of_the_day: DirectusPickOfTheDayItem[]
     profiles: DirectusProfileItem[],
     tags: DirectusTagItem[]
+    transcripts: DirectusTranscriptItem[]
 }
 
 export const directus = createDirectus<Collections>(DIRECTUS_CMS_URL)

--- a/nuxt-app/types/items.ts
+++ b/nuxt-app/types/items.ts
@@ -102,3 +102,29 @@ export interface DirectusProfileItem {
     job_employer: string
     profile_image: FileItem
 }
+
+export interface DirectusTranscriptItem {
+  id: string
+  date_updated: string
+  status: string
+  podcast: DirectusPodcastItem
+  podcast_audio_file: FileItem
+  speakers: [{name: string, identifier: string}]
+  service: string
+  supported_features: string[]
+  raw_response: null | {
+    results: {
+      utterances: [{
+        transcript: string,
+        speaker: string,
+        words: [
+          {
+            punctuated_word: string,
+            start: number,
+            speaker: string,
+          }
+        ]
+      }]
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces a new transcript component to view transcripts on a podcast episode's page. The new component is based on a new, dedicated data model supported by deepgrams audio API. It supports diarization and timestamps.

Hence, the new component can now offer speaker names and allows you to skip to a certain playback position by simply tapping on the transcript text.

Remaining work:
- [ ]  Automatically generate podcast transcripts

(The old component was renamed to `SimplePodcastTranscript` but sticks around to handle older transcripts. (And some point we could remove all old transcripts and re-create them all)