### PR TITLE
Added recordings page

### DIFF
--- a/nuxt-app/composables/useDirectus.ts
+++ b/nuxt-app/composables/useDirectus.ts
@@ -121,6 +121,14 @@ export function useDirectus() {
         )
     }
 
+    async function getRecordingsPage() {
+      return await directus.request(
+        readSingleton('recordings_page', {
+          fields: ['*'],
+        })
+      )
+    }
+
     async function getContactPage() {
         return await directus.request(
             readSingleton('contact_page', {
@@ -657,6 +665,7 @@ export function useDirectus() {
         getLoginPage,
         getProfileCreationPage,
         getCocPage,
+        getRecordingsPage,
         getImprintPage,
         getContactPage,
         getMembers,

--- a/nuxt-app/pages/aufnahmen.vue
+++ b/nuxt-app/pages/aufnahmen.vue
@@ -1,0 +1,46 @@
+<template>
+    <div v-if="recordingsPage" class="relative">
+        <div class="container px-6 pb-20 pt-32 md:pb-32 md:pl-48 md:pt-40 lg:pb-52 lg:pr-8 lg:pt-56 2xl:pt-64 3xl:px-8">
+            <Breadcrumbs :breadcrumbs="breadcrumbs" />
+
+            <!-- Heading -->
+            <SectionHeading class="mt-8 md:mt-0" element="h1">
+                {{ recordingsPage.heading }}
+            </SectionHeading>
+
+            <!-- Text -->
+            <InnerHtml
+                class="mt-8 space-y-8 break-words text-base font-light text-white md:mt-16 md:text-xl md:leading-normal lg:text-2xl lg:leading-normal"
+                :html="recordingsPage.text"
+            />
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { useDirectus } from '~/composables/useDirectus'
+import { useLoadingScreen } from '../composables'
+import { getMetaInfo } from '../helpers'
+
+const directus = useDirectus()
+
+const breadcrumbs = [{ label: 'Hinweis zu Foto- und Videoaufnahmen' }]
+// Query privacy page
+const { data: recordingsPage } = useAsyncData(() => directus.getRecordingsPage())
+
+if (recordingsPage.value && recordingsPage.value.status !== 'published') {
+  throw new Error('The page was not found.')
+}
+
+// Set loading screen
+useLoadingScreen(recordingsPage)
+
+// Set page meta data
+useHead(
+    getMetaInfo({
+        type: 'website',
+        path: '/aufnahmen',
+        title: 'Hinweis zu Foto- und Videoaufnahmen',
+    })
+)
+</script>

--- a/nuxt-app/services/directus.ts
+++ b/nuxt-app/services/directus.ts
@@ -18,6 +18,7 @@ import type {
     DirectusPrivacyPage,
     DirectusProfileCreationPage,
     DirectusRafflePage,
+    DirectusRecordingsPage,
     DirectusSpeakerItem,
     DirectusTagItem,
     DirectusProfileItem,
@@ -38,6 +39,7 @@ export type Collections = {
     login_page: DirectusLoginPage
     profile_creation_page: DirectusProfileCreationPage
     coc_page: DirectusCocPage
+    recordings_page: DirectusRecordingsPage
     podcasts: DirectusPodcastItem[]
     meetups: DirectusMeetupItem[]
     members: DirectusMemberItem[]

--- a/nuxt-app/types/directus.ts
+++ b/nuxt-app/types/directus.ts
@@ -320,6 +320,12 @@ export interface DirectusCocPage {
     text: string
 }
 
+export interface DirectusRecordingsPage {
+  status: string
+  heading: string
+  text: string
+}
+
 export interface DirectusPrivacyPage {
     heading: string
     text: string


### PR DESCRIPTION
This PR adds a page to display our legal framework for handling records (e.g. photography) during our events.