### PR TITLE
Update Directus SDK to latest release

### DIFF
--- a/nuxt-app/package-lock.json
+++ b/nuxt-app/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.0.0",
             "hasInstallScript": true,
             "dependencies": {
-                "@directus/sdk": "^15.0.1",
+                "@directus/sdk": "^17.0.0",
                 "@nuxtjs/tailwindcss": "^6.11.4",
                 "@pinia/nuxt": "^0.5.1",
                 "@types/google.maps": "^3.55.3",
@@ -732,23 +732,12 @@
             }
         },
         "node_modules/@directus/sdk": {
-            "version": "15.0.3",
-            "resolved": "https://registry.npmjs.org/@directus/sdk/-/sdk-15.0.3.tgz",
-            "integrity": "sha512-Z6n1YaXSMSQuYH6ENG1W4lcpyPgfwRzBpEJOXeknAnJlneLeV/+iNtCB8WxjnH8D73Sv72peRLKMQtr/SZDz7Q==",
-            "dependencies": {
-                "@directus/system-data": "1.0.1"
-            },
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/@directus/sdk/-/sdk-17.0.2.tgz",
+            "integrity": "sha512-gKfWH6oQKnHw6mUl5lM32PTjtWrmSF6f09/zfN/74FKGPD853srCwip6rGif2R0GfdcrPHXwGHc7vTMXNDlniw==",
             "engines": {
                 "node": ">=18.0.0"
             },
-            "funding": {
-                "url": "https://github.com/directus/directus?sponsor=1"
-            }
-        },
-        "node_modules/@directus/system-data": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@directus/system-data/-/system-data-1.0.1.tgz",
-            "integrity": "sha512-sm2gO9SUcRle5rCsmS4qby2K8OfvewnU9/Iao7brGyexLjXDrvfxBB2danNWVLw1qE+UrLX/R+caVrxQ4ZaMkw==",
             "funding": {
                 "url": "https://github.com/directus/directus?sponsor=1"
             }

--- a/nuxt-app/package.json
+++ b/nuxt-app/package.json
@@ -12,7 +12,7 @@
         "prettier": "prettier . --write"
     },
     "dependencies": {
-        "@directus/sdk": "^15.0.1",
+        "@directus/sdk": "^17.0.0",
         "@nuxtjs/tailwindcss": "^6.11.4",
         "@pinia/nuxt": "^0.5.1",
         "@types/google.maps": "^3.55.3",


### PR DESCRIPTION
This updated the version of the `@directus/sdk` from `15.0.1` to `17.0.2`.

There is no dedicated changelog available for the SDK, but every Directus release _can_ contain changes for the SDK and the github releases have to be manually checked for that. Apparently, no breaking changes happened between these two releases 🤞

---
E.g. see: https://github.com/directus/directus/releases/tag/v11.1.1

Where it says:

> ✨ New Features & Improvements
> @directus/extensions-sdk
> Added support for disabling terminal screen clearing on rebuild in watch mode (https://github.com/directus/directus/pull/23556 by @GuyShane)

And then lists the newly released SDK

> 📦 Published Versions
> [...]
> @directus/sdk@17.0.2