### PR TITLE
Change sorting in Hall of Fame

### DIFF
--- a/nuxt-app/composables/useDirectus.ts
+++ b/nuxt-app/composables/useDirectus.ts
@@ -470,9 +470,10 @@ export function useDirectus() {
                     'profile_image.*',
                     'tags.tag.id',
                     'tags.tag.name',
+                    'podcasts.podcast.type',
                 ],
                 limit: -1,
-                sort: ['sort', '-published_on'],
+                sort: ['podcasts.podcast.type', 'sort', '-published_on'],
             })
         )
     }


### PR DESCRIPTION
This PR changes the sorting on the "Hall of Fame" page, so that we first show all speakers from CTO special episodes and then all "regular" speakers. Each set of speakers is sorted by the date of the episode they appear in (or via the manual sorting integer if set).

To enable this, we had to change the speaker query to also include the type of podcast the speaker appears in.