### PR TITLE
Add basic conference page and menu item

### DIFF
--- a/nuxt-app/components/Header.vue
+++ b/nuxt-app/components/Header.vue
@@ -146,6 +146,7 @@ import { trackGoal } from '../helpers'
 import SocialNetworks from './SocialNetworks.vue'
 
 const FLAG_SHOW_LOGIN = useRuntimeConfig().public.FLAG_SHOW_LOGIN
+const FLAG_SHOW_CONFERENCE_PAGE = useRuntimeConfig().public.FLAG_SHOW_CONFERENCE_PAGE
 
 const mainMenuItems = [
     { label: 'Home', href: '/' },
@@ -155,6 +156,11 @@ const mainMenuItems = [
     { label: 'Pick of the Day', href: '/pick-of-the-day' },
     { label: 'Über uns', href: '/ueber-uns' },
 ]
+
+if (FLAG_SHOW_CONFERENCE_PAGE) {
+  mainMenuItems.splice(3, 0, { label: 'Konferenzen', href: '/konferenzen' });
+}
+
 const subMenuItems = [
     { label: 'Kontakt', href: '/kontakt' },
     { label: 'Impressum', href: '/impressum' },

--- a/nuxt-app/composables/useDirectus.ts
+++ b/nuxt-app/composables/useDirectus.ts
@@ -57,6 +57,14 @@ export function useDirectus() {
         )
     }
 
+  async function getConferencePage() {
+    return await directus.request(
+      readSingleton('conference_page', {
+        fields: ['*', 'cover_image.*'],
+      })
+    )
+  }
+
     async function getHallOfFamePage() {
         return await directus.request(
             readSingleton('hall_of_fame_page', {
@@ -661,6 +669,7 @@ export function useDirectus() {
         getHomepage,
         getPodcastPage,
         getMeetupPage,
+        getConferencePage,
         getHallOfFamePage,
         getPicksOfTheDayPage,
         getAboutPage,

--- a/nuxt-app/config.ts
+++ b/nuxt-app/config.ts
@@ -1,5 +1,6 @@
 // Feature Flags
 export const FLAG_SHOW_LOGIN = Boolean(process.env.FLAG_SHOW_LOGIN?.toLowerCase() == 'true')
+export const FLAG_SHOW_CONFERENCE_PAGE = Boolean(process.env.FLAG_SHOW_CONFERENCE_PAGE?.toLowerCase() == 'true')
 
 // Website config
 export const DEVTOOLS = Boolean(process.env.DEVTOOLS?.toLowerCase() == 'true')

--- a/nuxt-app/nuxt.config.ts
+++ b/nuxt-app/nuxt.config.ts
@@ -3,7 +3,7 @@ import svgLoader from 'vite-svg-loader'
 // This import needs to be relative/file-based
 // so that it can be resolved during the nuxt build process
 import { useDirectus } from './composables/useDirectus'
-import { DIRECTUS_CMS_URL, FLAG_SHOW_LOGIN, DEVTOOLS, DEV } from './config';
+import { DIRECTUS_CMS_URL, FLAG_SHOW_LOGIN, FLAG_SHOW_CONFERENCE_PAGE, DEVTOOLS, DEV } from './config';
 
 const directus = useDirectus()
 
@@ -29,6 +29,7 @@ export default defineNuxtConfig({
       emailPassword: '',
       public: {
           FLAG_SHOW_LOGIN: FLAG_SHOW_LOGIN,
+          FLAG_SHOW_CONFERENCE_PAGE: FLAG_SHOW_CONFERENCE_PAGE,
       },
   },
 

--- a/nuxt-app/pages/konferenzen/index.vue
+++ b/nuxt-app/pages/konferenzen/index.vue
@@ -1,0 +1,47 @@
+<template>
+    <div v-if="conferencePage">
+        <section class="relative">
+            <!-- Page cover -->
+            <PageCoverImage :cover-image="conferencePage.cover_image" v-if="conferencePage.cover_image" />
+            <div class="container mt-16 px-6 md:mt-28 md:pl-48 lg:mt-32 lg:pr-8 3xl:px-8">
+                <Breadcrumbs :breadcrumbs="breadcrumbs" />
+
+                <!-- Page intro -->
+                <SectionHeading class="mt-8 md:mt-0 md:pt-2/5-screen lg:pt-1/2-screen" element="h1">
+                    {{ conferencePage.conference_heading }}
+                </SectionHeading>
+
+                <InnerHtml
+                    class="mt-8 text-lg font-bold leading-normal text-white md:mt-16 md:text-2xl md:leading-normal lg:text-3xl lg:leading-normal"
+                    :html="conferencePage.intro_text_1"
+                />
+            </div>
+        </section>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { useLoadingScreen, usePageMeta } from '~/composables'
+import { useDirectus } from '~/composables/useDirectus'
+import type { DirectusConferencePage } from '~/types';
+import { computed, type ComputedRef } from 'vue'
+
+const breadcrumbs = [{ label: 'Konferenzen' }]
+const directus = useDirectus()
+
+// Query meetup page and meetups
+const { data: pageData } = useAsyncData(async () => {
+    const [conferencePage] = await Promise.all([directus.getConferencePage()])
+
+    return { conferencePage }
+})
+
+// Extract about page and members from page data
+const conferencePage: ComputedRef<DirectusConferencePage | undefined> = computed(() => pageData.value?.conferencePage)
+
+// Set loading screen
+useLoadingScreen(conferencePage)
+
+// Set page meta data
+usePageMeta(conferencePage)
+</script>

--- a/nuxt-app/services/directus.ts
+++ b/nuxt-app/services/directus.ts
@@ -3,6 +3,7 @@ import { DIRECTUS_CMS_URL } from '../config'
 import type {
     DirectusAboutPage,
     DirectusCocPage,
+    DirectusConferencePage,
     DirectusContactPage,
     DirectusHallOfFamePage,
     DirectusHomePage,
@@ -29,6 +30,7 @@ export type Collections = {
     home_page: DirectusHomePage
     podcast_page: DirectusPodcastPage
     meetup_page: DirectusMeetupPage
+    conference_page: DirectusConferencePage
     hall_of_fame_page: DirectusHallOfFamePage
     pick_of_the_day_page: DirectusPickOfTheDayPage
     about_page: DirectusAboutPage

--- a/nuxt-app/types/directus.ts
+++ b/nuxt-app/types/directus.ts
@@ -261,6 +261,21 @@ export interface DirectusMeetupPage {
     meetup_heading_past: string
 }
 
+export interface DirectusConferencePage {
+  meta_title: string
+  meta_description: string
+  cover_image: DirectusFileItem
+  conference_heading: string
+  intro_heading: string
+  intro_text_1: string
+  faqs_heading: string
+  faqs_text_1: string
+  faqs: {
+    question: string
+    answer: string
+  }[]
+}
+
 export interface DirectusHallOfFamePage {
     meta_title: string
     meta_description: string


### PR DESCRIPTION
This PR...
* adds a new barebones page for the conference overview
* extends the directus composable to fetch the conference page from the cms
* Adds an entry to the menu, hidden behind a feature flag