### PR TITLE
Added initial content for conference sub-pages

### DIFF
--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/set-slug/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/set-slug/index.ts
@@ -53,6 +53,7 @@ export default defineHook(({ filter }, hookContext) => {
                         (metadata.collection === 'speakers' && (payload.academic_title || payload.first_name || payload.last_name)) ||
                         (metadata.collection === 'podcasts' && (payload.type || payload.number || payload.title)) ||
                         (metadata.collection === 'meetups' && payload.title) ||
+                        (metadata.collection === 'conferences' && payload.title) ||
                         (metadata.collection === 'profiles' && (payload.first_name || payload.last_name))
                     )
                 ) {
@@ -131,6 +132,16 @@ export default defineHook(({ filter }, hookContext) => {
         // If collection name is "podcasts" and "title" is set,
         // log info and return payload with meetup slug
         if (metadata.collection === 'meetups' && futureItem.title) {
+            logInfo()
+            return {
+                ...payload,
+                slug: getUrlSlug(futureItem.title),
+            }
+        }
+
+        // If collection name is "conferences" and "title" is set,
+        // log info and return payload with meetup slug
+        if (metadata.collection === 'conferences' && futureItem.title) {
             logInfo()
             return {
                 ...payload,

--- a/nuxt-app/components/ConferenceCard.vue
+++ b/nuxt-app/components/ConferenceCard.vue
@@ -1,0 +1,66 @@
+<template>
+    <div class="lg:flex lg:items-center lg:space-x-14">
+        <!-- Cover -->
+        <NuxtLink class="block lg:w-1/2 xl:w-5/12" :to="href" data-cursor-more>
+            <ConferenceCover :conference="conference" />
+        </NuxtLink>
+
+        <div class="lg:w-1/2 xl:w-7/12">
+            <MeetupStartAndEnd
+                class="mt-8 text-xs font-light italic text-white md:text-sm lg:text-base"
+                :meetup="conference"
+            />
+
+            <!-- Title -->
+            <h3 class="mt-4 text-xl font-black text-white md:text-2xl lg:text-3xl">
+                {{ conference.title }}
+            </h3>
+
+            <!-- Description -->
+            <p
+                class="mt-6 line-clamp-4 space-y-8 text-base font-light leading-normal text-white md:text-xl lg:text-2xl"
+                v-html="description"
+            />
+
+            <!-- Likes -->
+            <LinkButton class="mt-6" :href="href">Mehr Infos</LinkButton>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import type { PropType } from 'vue'
+import { computed, defineComponent } from 'vue'
+import type { ConferenceItem, MeetupItem } from '../types';
+import LinkButton from './LinkButton.vue'
+import ConferenceCover from './ConferenceCover.vue'
+import MeetupStartAndEnd from './MeetupStartAndEnd.vue'
+
+export default defineComponent({
+    components: {
+        LinkButton,
+        ConferenceCover,
+        MeetupStartAndEnd,
+    },
+    props: {
+        conference: {
+            type: Object as PropType<
+                Pick<ConferenceItem, 'slug' | 'start_on' | 'end_on' | 'title' | 'text_1' | 'cover_image' | 'poster'>
+            >,
+            required: true,
+        },
+    },
+    setup(props) {
+        // Create href to meetup subpage
+        const href = computed(() => `/konferenzen/${props.conference.slug}`)
+
+        // Create plain description text
+        const description = computed(() => props.conference.text_1?.replace(/<[^<>]+>/g, ''))
+
+        return {
+            href,
+            description,
+        }
+    },
+})
+</script>

--- a/nuxt-app/components/ConferenceCover.vue
+++ b/nuxt-app/components/ConferenceCover.vue
@@ -1,0 +1,87 @@
+<template>
+    <div class="group relative overflow-hidden">
+        <!-- Image -->
+        <DirectusImage
+            class="w-full transition-transform duration-300 group-hover:scale-105"
+            :image="conference.poster"
+            :alt="conference.title"
+            :sizes="'xs:90vw sm:90vw md:70vw lg:70vw xl:50vw 2xl:875px'"
+            :loading="'lazy'"
+        />
+
+        <!-- Calendar -->
+        <div
+            v-if="calendar.isVisible"
+            class="absolute right-0 top-0 flex h-16 w-16 flex-col items-center justify-center bg-lime text-black lg:h-20 lg:w-20"
+        >
+            <div class="text-sm font-light lg:text-base">
+                {{ calendar.nameOfMonth }}
+            </div>
+            <div class="text-3xl font-black lg:text-4xl">
+                {{ calendar.dayOfMonth }}
+            </div>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import type { PropType } from 'vue'
+import { defineComponent, onMounted, reactive } from 'vue'
+import type { ConferenceItem } from '../types';
+import DirectusImage from './DirectusImage.vue'
+
+export default defineComponent({
+    components: {
+        DirectusImage,
+    },
+    props: {
+      conference: {
+            type: Object as PropType<Pick<ConferenceItem, 'start_on' | 'end_on' | 'title' | 'poster'>>,
+            required: true,
+        },
+    },
+    setup(props) {
+        // Create show calendar reference
+        const calendar = reactive({
+            isVisible: false,
+            nameOfMonth: '',
+            dayOfMonth: '',
+        })
+
+        // Show calendar if meetup is not over yet
+        onMounted(() => {
+            // Check if meetup is not over yet
+            if (new Date(props.conference.end_on) > new Date()) {
+                // Create start at date
+                const startAt = new Date(props.conference.start_on)
+
+                // Add name of month to calendar
+                calendar.nameOfMonth = [
+                    'Januar',
+                    'Febr.',
+                    'März',
+                    'April',
+                    'Mai',
+                    'Juni',
+                    'Juli',
+                    'August',
+                    'Sept.',
+                    'Okt.',
+                    'Nov.',
+                    'Dez.',
+                ][startAt.getMonth()]
+
+                // Add day of month to calendar
+                calendar.dayOfMonth = startAt.getDate().toString().padStart(2, '0')
+
+                // Set calendar to visible
+                calendar.isVisible = true
+            }
+        })
+
+        return {
+            calendar,
+        }
+    },
+})
+</script>

--- a/nuxt-app/components/ConferenceSection.vue
+++ b/nuxt-app/components/ConferenceSection.vue
@@ -1,0 +1,54 @@
+<template>
+  <section class="relative mb-14 mt-12 md:mb-32 md:mt-28 lg:mb-52 lg:mt-40">
+    <div class="container px-6 md:pl-48 lg:pr-8 3xl:px-8">
+      <SectionHeading element="h2">
+        {{ heading }}
+      </SectionHeading>
+      <LazyList class="mt-10" :items="conferences" direction="vertical">
+        <template #default="{ item, index, viewportItems, addViewportItem }">
+          <LazyListItem
+            :key="item.id"
+            :class="index > 0 && 'mt-14 md:mt-20 lg:mt-28'"
+            :item="item"
+            :viewport-items="viewportItems"
+            :add-viewport-item="addViewportItem"
+          >
+            <template #default="{ isNewToViewport }">
+              <FadeAnimation :fade-in="isNewToViewport ? 'from_right' : 'none'">
+                <ConferenceCard :conference="item" />
+              </FadeAnimation>
+            </template>
+          </LazyListItem>
+        </template>
+      </LazyList>
+    </div>
+  </section>
+</template>
+
+<script lang="ts">
+import type { PropType } from 'vue'
+import { defineComponent } from 'vue'
+import GenericListItem from '~/components/GenericListItem.vue';
+import GenericLazyList from '~/components/GenericLazyList.vue';
+import ConferenceCard from '~/components/ConferenceCard.vue';
+import SectionHeading from './SectionHeading.vue';
+import type { ConferenceItem } from '~/types';
+
+export default defineComponent({
+    components: {
+      SectionHeading,
+      LazyList: GenericLazyList,
+      LazyListItem: GenericListItem,
+      ConferenceCard,
+    },
+    props: {
+        conferences: {
+          type: Array as PropType<Pick<ConferenceItem, 'start_on' | 'end_on' | 'title' | 'cover_image' | 'text_1'>[]>,
+          required: true,
+        },
+        heading: {
+            type: String,
+        },
+    },
+})
+</script>

--- a/nuxt-app/components/ConferenceSpeaker.vue
+++ b/nuxt-app/components/ConferenceSpeaker.vue
@@ -1,0 +1,120 @@
+<template>
+  <div class='w-72 speaker-box'>
+    <DirectusImage
+      v-if="speaker.profile_image"
+      class="object-cover aspect-square"
+      :image="speaker.profile_image"
+      :alt="fullName"
+      sizes="lg:300px"
+      loading="lazy"
+    />
+    <div class='mt-12 text-3xl p-9'>
+      <p>{{ fullName }}</p>
+      <p class='text-xl italic'>{{ speaker.occupation }}</p>
+      <InnerHtml
+        class="mt-7 text-xl"
+        :html="speaker.description"
+      />
+      <ul v-if="platforms.length" class="mt-6 flex space-x-6">
+        <li v-for="platform of platforms" :key="platform.name">
+          <a
+            class="block h-7 text-white md:h-8 lg:h-10"
+            :href="platform.url"
+            target="_blank"
+            rel="noreferrer"
+            data-cursor-hover
+            @click="() => trackGoal(platform.eventId)"
+          >
+            <component :is="platform.icon" />
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script setup lang='ts'>
+import type { SpeakerPreviewItem } from '~/types';
+import { computed } from 'vue';
+import { getFullSpeakerName } from 'shared-code';
+import { trackGoal } from '~/helpers';
+import BlueskyIcon from '~/assets/logos/bluesky-color.svg'
+import GithubIcon from '~/assets/logos/github.svg'
+import InstagramIcon from '~/assets/logos/instagram-color.svg'
+import LinkedinIcon from '~/assets/logos/linkedin-color.svg'
+import TwitterIcon from '~/assets/logos/twitter-color.svg'
+import WebsiteIcon from '~/assets/logos/website-color.svg'
+import YoutubeIcon from '~/assets/logos/youtube-color.svg'
+import {
+  OPEN_SPEAKER_BLUESKY_EVENT_ID, OPEN_SPEAKER_GITHUB_EVENT_ID,
+  OPEN_SPEAKER_INSTAGRAM_EVENT_ID,
+  OPEN_SPEAKER_LINKEDIN_EVENT_ID,
+  OPEN_SPEAKER_TWITTER_EVENT_ID, OPEN_SPEAKER_WEBSITE_EVENT_ID, OPEN_SPEAKER_YOUTUBE_EVENT_ID,
+} from '~/config';
+const props = defineProps<{
+  speaker: SpeakerPreviewItem;
+}>();
+
+const fullName = computed(() => getFullSpeakerName(props.speaker))
+
+
+// Create platform list
+const platforms = computed(
+  () =>
+    [
+      {
+        name: 'Twitter',
+        icon: TwitterIcon,
+        url: props.speaker.twitter_url,
+        eventId: OPEN_SPEAKER_TWITTER_EVENT_ID,
+      },
+      {
+        name: 'Bluesky',
+        icon: BlueskyIcon,
+        url: props.speaker.bluesky_url,
+        eventId: OPEN_SPEAKER_BLUESKY_EVENT_ID,
+      },
+      {
+        name: 'LinkedIn',
+        icon: LinkedinIcon,
+        url: props.speaker.linkedin_url,
+        eventId: OPEN_SPEAKER_LINKEDIN_EVENT_ID,
+      },
+      {
+        name: 'Instagram',
+        icon: InstagramIcon,
+        url: props.speaker.instagram_url,
+        eventId: OPEN_SPEAKER_INSTAGRAM_EVENT_ID,
+      },
+      {
+        name: 'GitHub',
+        icon: GithubIcon,
+        url: props.speaker.github_url,
+        eventId: OPEN_SPEAKER_GITHUB_EVENT_ID,
+      },
+      {
+        name: 'YouTube',
+        icon: YoutubeIcon,
+        url: props.speaker.youtube_url,
+        eventId: OPEN_SPEAKER_YOUTUBE_EVENT_ID,
+      },
+      {
+        name: 'Website',
+        icon: WebsiteIcon,
+        url: props.speaker.website_url,
+        eventId: OPEN_SPEAKER_WEBSITE_EVENT_ID,
+      },
+    ].filter((platform) => platform.url) as {
+      name: string
+      icon: string
+      url: string
+      eventId: string
+    }[]
+)
+</script>
+
+<style scoped>
+.speaker-box {
+  background: var(--Grey, #131415);
+}
+</style>

--- a/nuxt-app/components/ConferenceSpeakersSlider.vue
+++ b/nuxt-app/components/ConferenceSpeakersSlider.vue
@@ -1,0 +1,190 @@
+<template>
+    <div class="relative">
+        <!-- Scroll box -->
+        <div
+            ref="scrollBoxElement"
+            class="scroll-box flex items-center overflow-x-auto overflow-y-hidden"
+            @mousedown="changeScrollPosition"
+            @scroll="detectScrollState"
+        >
+            <!-- Podcast list -->
+            <GenericLazyList class="flex" :items="speakers" direction="horizontal" :scroll-element="scrollBoxElement">
+                <template #default="{ item, index, viewportItems, addViewportItem }">
+                    <GenericListItem
+                        :key="item.id"
+                        :class="index > 0 && 'ml-10 md:ml-16 lg:ml-20 xl:ml-24 2xl:ml-28 3xl:ml-32'"
+                        :item="item"
+                        :viewport-items="viewportItems"
+                        :add-viewport-item="addViewportItem"
+                    >
+                        <template #default="{ isNewToViewport }">
+                            <FadeAnimation :fade-in="isNewToViewport ? 'from_bottom' : 'none'" :threshold="0">
+                                <ConferenceSpeaker :speaker="item" />
+                            </FadeAnimation>
+                        </template>
+                    </GenericListItem>
+                </template>
+            </GenericLazyList>
+        </div>
+
+        <!-- Scroll buttons -->
+        <button
+            v-for="index of 2"
+            :key="index"
+            class="hidden md:absolute md:top-0 md:block md:h-full md:w-40 md:from-black md:to-transparent md:transition-opacity md:duration-500 3xl:w-80"
+            :class="[
+                index === 1 ? 'md:left-0 md:bg-gradient-to-r' : 'md:right-0 md:bg-gradient-to-l',
+                ((index === 1 && scrollStartReached) || (index === 2 && scrollEndReached)) &&
+                    'pointer-events-none invisible opacity-0',
+            ]"
+            :style="
+                ((index === 1 && scrollStartReached) || (index === 2 && scrollEndReached) || undefined) &&
+                'transition: visibility 0s .2s, opacity .2s'
+            "
+            type="button"
+            :title="index === 1 ? 'Scroll left' : 'Scroll right'"
+            :data-cursor-arrow-left="index === 1 && !scrollStartReached"
+            :data-cursor-arrow-right="index === 2 && !scrollEndReached"
+            @click="() => scrollTo(index === 1 ? 'left' : 'right')"
+        />
+    </div>
+</template>
+
+<script setup lang="ts">
+import AngleRightIcon from '~/assets/icons/angle-right.svg'
+import PodcastFigureIcon from '~/assets/images/podcast-figure.svg'
+import { CLICK_SCROLL_LEFT_ARROW_EVENT_ID, CLICK_SCROLL_RIGHT_ARROW_EVENT_ID } from '~/config'
+import { trackGoal } from '~/helpers'
+import type { PodcastItem, SpeakerPreviewItem } from '~/types';
+import smoothscroll from 'smoothscroll-polyfill'
+import { onMounted, ref } from 'vue'
+import FadeAnimation from './FadeAnimation.vue'
+import GenericLazyList from './GenericLazyList.vue'
+import GenericListItem from './GenericListItem.vue'
+import PodcastCard from './PodcastCard.vue'
+
+defineProps<{
+  speakers: SpeakerPreviewItem[]
+}>()
+
+// Create scroll box element reference
+const scrollBoxElement = ref<HTMLDivElement>()
+
+// Create scroll start and end reached reference
+const scrollStartReached = ref(true)
+const scrollEndReached = ref(true)
+
+// Add smooth scroll polyfill
+onMounted(smoothscroll.polyfill)
+
+/**
+ * It detects whether the start or the end of the scrolling area
+ * has been reached, depending on the scrolling position.
+ */
+const detectScrollState = () => {
+    const { innerWidth } = window
+    const { scrollLeft, scrollWidth } = scrollBoxElement.value!
+    scrollStartReached.value = scrollLeft < 64
+    scrollEndReached.value = scrollLeft > scrollWidth - innerWidth - 64
+}
+
+// Update scroll state on mounted
+onMounted(detectScrollState)
+
+/**
+ * It programmatically scrolls the slider
+ * a little to the left or right.
+ */
+const scrollTo = (direction: 'left' | 'right') => {
+    if (direction === 'left') {
+        trackGoal(CLICK_SCROLL_LEFT_ARROW_EVENT_ID)
+    } else {
+        trackGoal(CLICK_SCROLL_RIGHT_ARROW_EVENT_ID)
+    }
+    const { innerWidth } = window
+    const { scrollLeft } = scrollBoxElement.value!
+    scrollBoxElement.value!.scrollTo({
+        left: scrollLeft + innerWidth * 0.4 * (direction === 'left' ? -1 : 1),
+        behavior: 'smooth',
+    })
+}
+
+/**
+ * It changes the scroll position of the scroll box
+ * element when the user drags its content.
+ */
+const changeScrollPosition = () => {
+    // Create last client X variable
+    let lastClientX: number
+
+    /**
+     * It changes the scroll position when the mouse
+     * moves and disables pointer events.
+     *
+     * @param event Mouse event object.
+     */
+    const handleScrollMove = (event: MouseEvent) => {
+        if (lastClientX) {
+            scrollBoxElement.value!.scrollLeft += lastClientX - event.clientX
+        } else {
+            scrollBoxElement.value!.style.pointerEvents = 'none'
+            scrollBoxElement.value!.style.userSelect = 'none'
+        }
+        lastClientX = event.clientX
+    }
+
+    /**
+     * It removes the event listener and resets the style attribute.
+     */
+    const handleScrollStop = () => {
+        window.removeEventListener('mousemove', handleScrollMove)
+        window.removeEventListener('mouseup', handleScrollStop, true)
+        scrollBoxElement.value!.style.pointerEvents = ''
+        scrollBoxElement.value!.style.userSelect = ''
+    }
+
+    // Add mousemove and mouseup event listener
+    window.addEventListener('mousemove', handleScrollMove)
+    window.addEventListener('mouseup', handleScrollStop, true)
+}
+</script>
+
+<style lang="postcss" scoped>
+.scroll-box {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+}
+.scroll-box::-webkit-scrollbar {
+    @apply hidden;
+}
+@media (min-width: 1536px) {
+    .scroll-box::before {
+        width: calc((100vw - 1536px) / 2 + 12rem);
+    }
+    .scroll-box::after {
+        width: calc((100vw - 1536px) / 2 + 2rem);
+    }
+}
+@media (min-width: 2000px) {
+    .scroll-box::before {
+        width: calc((100vw - 1536px) / 2 + 2rem);
+    }
+}
+@keyframes fade-in {
+    0% {
+        opacity: 0;
+    }
+    25% {
+        opacity: 1;
+    }
+    80% {
+        opacity: 0;
+    }
+    100% {
+        opacity: 0;
+    }
+}
+.podcast-link:hover .angle-right {
+    animation: fade-in 0.8s ease infinite forwards;
+}
+</style>

--- a/nuxt-app/components/FaqItem.vue
+++ b/nuxt-app/components/FaqItem.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class='flex justify-between py-3' v-on:click='toggle' data-cursor-hover>
+    <p class='text-white font-bold'>
+      {{ faq.question }}
+    </p>
+    <div class='text-white w-6'>
+      <AngleDownIcon class='stroke-white fill-white'/>
+    </div>
+  </div>
+  <div
+    class="text-white transition-all duration-500 ease-in-out opacity-0 max-h-0 overflow-hidden"
+    :class="{ 'opacity-100 max-h-full mb-3': isOpened }"
+  >
+    <InnerHtml
+      class=' text-white mb-3'
+      :html='faq.answer'
+    />
+  </div>
+</template>
+
+<script setup lang='ts'>
+import AngleDownIcon from 'assets/icons/angle-down.svg';
+
+defineProps<{
+  faq: {
+    question: string;
+    answer: string;
+  };
+}>();
+
+const isOpened = ref( false);
+
+function toggle() {
+  isOpened.value = !isOpened.value;
+}
+</script>

--- a/nuxt-app/components/FaqItem.vue
+++ b/nuxt-app/components/FaqItem.vue
@@ -4,7 +4,10 @@
       {{ faq.question }}
     </p>
     <div class='text-white w-6'>
-      <AngleDownIcon class='stroke-white fill-white'/>
+      <AngleDownIcon
+        class='stroke-white fill-white transition-all duration-500'
+        :class="{ 'rotate-180': isOpened }"
+      />
     </div>
   </div>
   <div

--- a/nuxt-app/components/FaqList.vue
+++ b/nuxt-app/components/FaqList.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class='mt-16 mb-16'>
+    <div v-for="faq of faqs" :key="faq.question">
+      <hr class='border-white' />
+      <FaqItem :faq='faq' />
+    </div>
+  </div>
+</template>
+
+<script setup lang='ts'>
+import FaqItem from '~/components/FaqItem.vue';
+
+defineProps<{
+  faqs: {
+    question: string;
+    answer: string;
+  }[];
+}>();
+</script>

--- a/nuxt-app/composables/useDirectus.ts
+++ b/nuxt-app/composables/useDirectus.ts
@@ -372,39 +372,46 @@ export function useDirectus() {
             'text_1',
             'cover_image.*',
             'cover_image',
+            'poster',
+            'poster.*',
             'gallery_images',
+            'faqs',
             'speakers',
-            'speakers.speaker.id',
-            'speakers.speaker.slug',
-            'speakers.speaker.academic_title',
-            'speakers.speaker.first_name',
-            'speakers.speaker.last_name',
-            'speakers.speaker.description',
-            'speakers.speaker.event_image.*',
+            'speakers.*',
+            'speakers.speakers_id.*',
+            'speakers.speakers_id.profile_image.*',
           ],
           filter: { slug: { _eq: slug } },
           limit: 1,
         })
       )
-      .then(
-        (result) =>
-          result
-            .map((meetup) => ({
-              ...meetup,
-              speakersPrepared: meetup.speakers.map((speaker: any) => {
-                return {
-                  first_name: speaker.speaker.first_name,
-                  last_name: speaker.speaker.last_name,
-                  profile_image: speaker.speaker.profile_image,
-                  slug: speaker.speaker.slug,
-                  description: speaker.speaker.description,
-                  event_image: speaker.speaker.event_image,
-                  academic_title: speaker.speaker.academic_title,
-                }
-              }) as SpeakerPreviewItem[],
-            }))
-            .pop() as ConferenceItem
-      )
+      .then((result) => {
+        const singleResult = result.pop() as unknown as ConferenceItem
+        const speakersPrepared = singleResult.speakers.map((speaker: any) => {
+              return {
+                first_name: speaker.speakers_id.first_name,
+                last_name: speaker.speakers_id.last_name,
+                profile_image: speaker.speakers_id.profile_image,
+                occupation: speaker.speakers_id.occupation,
+                slug: speaker.speakers_id.slug,
+                description: speaker.speakers_id.description,
+                event_image: speaker.speakers_id.event_image,
+                academic_title: speaker.speakers_id.academic_title,
+                website_url: speaker.speakers_id.website_url,
+                twitter_url: speaker.speakers_id.twitter_url,
+                bluesky_url: speaker.speakers_id.bluesky_url,
+                linkedin_url: speaker.speakers_id.linkedin_url,
+                github_url: speaker.speakers_id.github_url,
+                instagram_url: speaker.speakers_id.instagram_url,
+                youtube_url: speaker.speakers_id.youtube_url,
+              } as SpeakerPreviewItem
+          });
+
+        return {
+          ...singleResult,
+          speakersPrepared
+        };
+      })
   }
 
     async function getSpeakerBySlug(slug: string) {

--- a/nuxt-app/composables/useDirectus.ts
+++ b/nuxt-app/composables/useDirectus.ts
@@ -9,6 +9,7 @@ import {
     type QueryFilter,
 } from '@directus/sdk'
 import type {
+  ConferenceItem,
   DirectusMemberItem,
   DirectusPickOfTheDayItem,
   DirectusProfileItem,
@@ -356,6 +357,56 @@ export function useDirectus() {
             )
     }
 
+  async function getConferenceBySlug(slug: string) {
+    return await directus
+      .request(
+        readItems('conferences', {
+          fields: [
+            'id',
+            'slug',
+            'published_on',
+            'start_on',
+            'end_on',
+            'title',
+            'headline_1',
+            'text_1',
+            'cover_image.*',
+            'cover_image',
+            'gallery_images',
+            'speakers',
+            'speakers.speaker.id',
+            'speakers.speaker.slug',
+            'speakers.speaker.academic_title',
+            'speakers.speaker.first_name',
+            'speakers.speaker.last_name',
+            'speakers.speaker.description',
+            'speakers.speaker.event_image.*',
+          ],
+          filter: { slug: { _eq: slug } },
+          limit: 1,
+        })
+      )
+      .then(
+        (result) =>
+          result
+            .map((meetup) => ({
+              ...meetup,
+              speakersPrepared: meetup.speakers.map((speaker: any) => {
+                return {
+                  first_name: speaker.speaker.first_name,
+                  last_name: speaker.speaker.last_name,
+                  profile_image: speaker.speaker.profile_image,
+                  slug: speaker.speaker.slug,
+                  description: speaker.speaker.description,
+                  event_image: speaker.speaker.event_image,
+                  academic_title: speaker.speaker.academic_title,
+                }
+              }) as SpeakerPreviewItem[],
+            }))
+            .pop() as ConferenceItem
+      )
+  }
+
     async function getSpeakerBySlug(slug: string) {
         return await directus
             .request(
@@ -462,6 +513,25 @@ export function useDirectus() {
                 limit: -1,
             })
         )
+    }
+
+    async function getConferences() {
+      return await directus.request(
+        readItems('conferences', {
+          fields: [
+            'id',
+            'published_on',
+            'slug',
+            'start_on',
+            'end_on',
+            'title',
+            'text_1',
+            'poster.*',
+          ],
+          sort: ['-start_on'],
+          limit: -1,
+        })
+      )
     }
 
     async function getSpeakers() {
@@ -685,6 +755,7 @@ export function useDirectus() {
         getLatestPodcasts,
         getPodcasts,
         getMeetups,
+        getConferences,
         getSpeakers,
         getPodcastCount,
         getPickOfTheDayCount,
@@ -694,6 +765,7 @@ export function useDirectus() {
         getTopTagsForCollection,
         getPodcastBySlug,
         getMeetupBySlug,
+        getConferenceBySlug,
         getSpeakerBySlug,
         getRelatedPodcasts,
         getTranscriptForPodcast,

--- a/nuxt-app/pages/konferenzen/[slug].vue
+++ b/nuxt-app/pages/konferenzen/[slug].vue
@@ -1,0 +1,127 @@
+<template>
+    <div v-if="conference && conferencePage" class='text-white'>
+      <article class="relative">
+        <section class="relative">
+          <PageCoverImage :cover-image="conference.cover_image" v-if="conference.cover_image" />
+          <div class="container mt-16 px-6 md:mt-28 md:pl-48 lg:mt-32 lg:pr-8 3xl:px-8">
+            <SectionHeading class="mt-8 md:mt-0 md:pt-2/5-screen lg:pt-1/2-screen" element="h1">
+              {{ conference.title }}
+            </SectionHeading>
+            <InnerHtml
+              class="mt-2 text-2xl font-light leading-normal text-white"
+              :html="conference.text_1"
+            />
+          </div>
+        </section>
+
+        <section class="relative">
+          <div class="container mt-16 px-6 md:mt-28 md:pl-48 lg:mt-32 lg:pr-8 3xl:px-8">
+            <SectionHeading class="mt-8 md:mt-0 md:pt-2/5-screen lg:pt-1/2-screen" element="h2">
+              Speaker
+            </SectionHeading>
+            <ConferenceSpeakersSlider :speakers='conference.speakersPrepared' />
+          </div>
+        </section>
+
+        <section class="relative">
+          <div class="container mt-16 px-6 md:mt-28 md:pl-48 lg:mt-32 lg:pr-8 3xl:px-8">
+            <InnerHtml
+              class="mt-8 text-5xl font-black leading-normal text-white"
+              :html="conferencePage.faqs_heading"
+            />
+            <InnerHtml
+              class="mt-2 text-2xl font-light leading-normal text-white"
+              :html="conferencePage.faqs_text_1"
+            />
+            <FaqList :faqs='combinedFaqs' />
+          </div>
+        </section>
+
+        <section class="relative">
+          <div class="container mt-16 px-6 md:mt-28 md:pl-48 lg:mt-32 lg:pr-8 3xl:px-8">
+            <p class="text-base font-light leading-normal text-white md:mt-14 md:text-xl lg:text-2xl">
+              Bitte beachte auch unsere
+              <NuxtLink class="text-lime font-bold hover:underline" data-cursor-hover :to="'/verhaltensregeln'">
+                Verhaltensregeln
+              </NuxtLink>
+              und den
+              <NuxtLink class="text-lime font-bold hover:underline" data-cursor-hover :to="'/aufnahmen'">
+                Hinweis zu Foto- und Videoaufnahmen.
+              </NuxtLink>
+            </p>
+          </div>
+        </section>
+      </article>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { useLoadingScreen } from '~/composables'
+import { useDirectus } from '~/composables/useDirectus'
+import { getMetaInfo, trackGoal } from '~/helpers';
+import type { ConferenceItem, DirectusConferencePage, TagItem } from '~/types';
+import { computed, type ComputedRef } from 'vue'
+import ConferenceSpeakersSlider from '~/components/ConferenceSpeakersSlider.vue';
+
+// Add route and router
+const route = useRoute()
+
+const directus = useDirectus()
+
+// Query conference and page
+const { data: pageData } = useAsyncData(route.fullPath, async () => {
+    // Query conference and page async
+    const [conference, conferencePage] = await Promise.all([
+        await directus.getConferenceBySlug(route.params.slug as string),
+        await directus.getConferencePage(),
+    ])
+
+    // Throw error if meetup does not exist
+    if (!conference) {
+        throw new Error('The conference was not found.')
+    }
+
+  // Throw error if meetup does not exist
+  if (!conferencePage) {
+    throw new Error('Could not access conference page.')
+  }
+
+    // Return conference and page
+    return { conference, conferencePage }
+})
+
+// Extract conference and page from page data
+const conference: ComputedRef<ConferenceItem | undefined> = computed(() => pageData.value?.conference)
+const conferencePage: ComputedRef<DirectusConferencePage | undefined> = computed(() => pageData.value?.conferencePage)
+
+const combinedFaqs: ComputedRef<any | undefined> = computed(() => {
+  let faqs = [];
+  if (pageData.value?.conference?.faqs) {
+    faqs = [...pageData.value.conference.faqs];
+  }
+  if (pageData.value?.conferencePage?.faqs) {
+    faqs = [...faqs, ...pageData.value.conferencePage.faqs];
+  }
+  return faqs;
+})
+
+// Set loading screen
+useLoadingScreen(conference, conferencePage)
+
+// Set page meta data
+useHead(() =>
+  conference.value
+        ? getMetaInfo({
+              type: 'article',
+              path: route.path,
+              title: conference.value.title,
+              description: conference.value.text_1,
+              image: conference.value.cover_image,
+              publishedAt: conference.value.published_on.split('T')[0],
+          })
+        : {}
+)
+
+// Create breadcrumb list
+const breadcrumbs = computed(() => [{ label: 'Konferenz', href: '/konferenzen' }, { label: conference.value?.title || '' }])
+</script>

--- a/nuxt-app/pages/konferenzen/index.vue
+++ b/nuxt-app/pages/konferenzen/index.vue
@@ -12,15 +12,53 @@
                 </SectionHeading>
 
                 <InnerHtml
-                    class="mt-8 text-lg font-bold leading-normal text-white md:mt-16 md:text-2xl md:leading-normal lg:text-3xl lg:leading-normal"
+                  class="mt-8 text-5xl font-black leading-normal text-white"
+                  :html="conferencePage.intro_heading"
+                />
+
+                <InnerHtml
+                    class="mt-2 text-2xl font-light leading-normal text-white"
                     :html="conferencePage.intro_text_1"
                 />
+
+                <InnerHtml
+                  class="mt-8 text-5xl font-black leading-normal text-white"
+                  :html="conferencePage.faqs_heading"
+                />
+
+                <InnerHtml
+                  class="mt-2 text-2xl font-light leading-normal text-white"
+                  :html="conferencePage.faqs_text_1"
+                />
+
+              <FaqList :faqs='conferencePage.faqs' />
+
+              <!--<div class='mt-16'>
+                <div v-for='faq in conferencePage.faqs'>
+                  <hr class='border-white' />
+                  <div class='flex justify-between py-3'>
+                    <p class='text-white'>
+                      {{ faq.question}}
+                    </p>
+                    <div class='text-white w-6'>
+                      <AngleDownIcon class='stroke-white fill-white'/>
+                    </div>
+                  </div>
+                  <InnerHtml
+                    class=" text-white"
+                    :html="faq.answer"
+                  />
+                </div>
+              </div>-->
+
             </div>
         </section>
     </div>
 </template>
 
 <script setup lang="ts">
+import AngleDownIcon from '~/assets/icons/angle-down.svg'
+
 import { useLoadingScreen, usePageMeta } from '~/composables'
 import { useDirectus } from '~/composables/useDirectus'
 import type { DirectusConferencePage } from '~/types';

--- a/nuxt-app/pages/konferenzen/index.vue
+++ b/nuxt-app/pages/konferenzen/index.vue
@@ -1,81 +1,59 @@
 <template>
     <div v-if="conferencePage">
         <section class="relative">
-            <!-- Page cover -->
             <PageCoverImage :cover-image="conferencePage.cover_image" v-if="conferencePage.cover_image" />
             <div class="container mt-16 px-6 md:mt-28 md:pl-48 lg:mt-32 lg:pr-8 3xl:px-8">
                 <Breadcrumbs :breadcrumbs="breadcrumbs" />
-
-                <!-- Page intro -->
-                <SectionHeading class="mt-8 md:mt-0 md:pt-2/5-screen lg:pt-1/2-screen" element="h1">
+               <SectionHeading class="mt-8 md:mt-0 md:pt-2/5-screen lg:pt-1/2-screen" element="h1">
                     {{ conferencePage.conference_heading }}
                 </SectionHeading>
-
                 <InnerHtml
                   class="mt-8 text-5xl font-black leading-normal text-white"
                   :html="conferencePage.intro_heading"
                 />
-
                 <InnerHtml
                     class="mt-2 text-2xl font-light leading-normal text-white"
                     :html="conferencePage.intro_text_1"
                 />
-
-                <InnerHtml
-                  class="mt-8 text-5xl font-black leading-normal text-white"
-                  :html="conferencePage.faqs_heading"
-                />
-
-                <InnerHtml
-                  class="mt-2 text-2xl font-light leading-normal text-white"
-                  :html="conferencePage.faqs_text_1"
-                />
-
-              <FaqList :faqs='conferencePage.faqs' />
-
-              <!--<div class='mt-16'>
-                <div v-for='faq in conferencePage.faqs'>
-                  <hr class='border-white' />
-                  <div class='flex justify-between py-3'>
-                    <p class='text-white'>
-                      {{ faq.question}}
-                    </p>
-                    <div class='text-white w-6'>
-                      <AngleDownIcon class='stroke-white fill-white'/>
-                    </div>
-                  </div>
-                  <InnerHtml
-                    class=" text-white"
-                    :html="faq.answer"
-                  />
-                </div>
-              </div>-->
-
             </div>
+        </section>
+        <section class="relative">
+          <ConferenceSection :heading='"Termine"' :conferences="conferences" />
+          <div class="container mt-16 px-6 md:mt-28 md:pl-48 lg:mt-32 lg:pr-8 3xl:px-8">
+            <InnerHtml
+              class="mt-8 text-5xl font-black leading-normal text-white"
+              :html="conferencePage.faqs_heading"
+            />
+            <InnerHtml
+              class="mt-2 text-2xl font-light leading-normal text-white"
+              :html="conferencePage.faqs_text_1"
+            />
+            <FaqList :faqs='conferencePage.faqs' />
+          </div>
         </section>
     </div>
 </template>
 
 <script setup lang="ts">
-import AngleDownIcon from '~/assets/icons/angle-down.svg'
-
 import { useLoadingScreen, usePageMeta } from '~/composables'
 import { useDirectus } from '~/composables/useDirectus'
-import type { DirectusConferencePage } from '~/types';
+import type { DirectusConferenceItem, DirectusConferencePage } from '~/types';
 import { computed, type ComputedRef } from 'vue'
 
 const breadcrumbs = [{ label: 'Konferenzen' }]
 const directus = useDirectus()
 
-// Query meetup page and meetups
 const { data: pageData } = useAsyncData(async () => {
-    const [conferencePage] = await Promise.all([directus.getConferencePage()])
+    const [conferencePage, conferences] = await Promise.all([
+      directus.getConferencePage(),
+      directus.getConferences(),
+    ])
 
-    return { conferencePage }
+    return { conferencePage, conferences }
 })
 
-// Extract about page and members from page data
 const conferencePage: ComputedRef<DirectusConferencePage | undefined> = computed(() => pageData.value?.conferencePage)
+const conferences: ComputedRef<DirectusConferenceItem[]> = computed(() => pageData.value?.conferences || [])
 
 // Set loading screen
 useLoadingScreen(conferencePage)

--- a/nuxt-app/services/directus.ts
+++ b/nuxt-app/services/directus.ts
@@ -10,6 +10,7 @@ import type {
     DirectusImprintPage,
     DirectusLoginPage,
     DirectusMeetupItem,
+    DirectusConferenceItem,
     DirectusMeetupPage,
     DirectusMemberItem,
     DirectusPickOfTheDayItem,
@@ -44,6 +45,7 @@ export type Collections = {
     recordings_page: DirectusRecordingsPage
     podcasts: DirectusPodcastItem[]
     meetups: DirectusMeetupItem[]
+    conferences: DirectusConferenceItem[]
     members: DirectusMemberItem[]
     speakers: DirectusSpeakerItem[]
     picks_of_the_day: DirectusPickOfTheDayItem[]

--- a/nuxt-app/types/directus.ts
+++ b/nuxt-app/types/directus.ts
@@ -112,6 +112,10 @@ export interface DirectusConferenceItem {
         speaker: DirectusSpeakerItem
         sort: number
     }[]
+    faqs: {
+      question: string
+      answer: string
+    }[]
 }
 
 export interface DirectusMemberItem {

--- a/nuxt-app/types/directus.ts
+++ b/nuxt-app/types/directus.ts
@@ -83,6 +83,36 @@ export interface DirectusMeetupItem {
         sort: number
     }[]
 }
+export interface DirectusConferenceItem {
+    id: string
+    slug: string
+    published_on: string
+    start_on: string
+    end_on: string
+    cover_image: DirectusFileItem
+    poster: DirectusFileItem
+    title: string
+    headline_1: string
+    text_1: string
+    gallery_images: {
+        id: number
+        meetup: DirectusMeetupItem
+        image: DirectusFileItem
+        sort: number
+    }[]
+    members: {
+        id: number
+        meetup: DirectusMeetupItem
+        member: DirectusMemberItem
+        sort: number
+    }[]
+    speakers: {
+        id: number
+        meetup: DirectusMeetupItem
+        speaker: DirectusSpeakerItem
+        sort: number
+    }[]
+}
 
 export interface DirectusMemberItem {
     id: string

--- a/nuxt-app/types/items.ts
+++ b/nuxt-app/types/items.ts
@@ -52,9 +52,17 @@ export interface SpeakerPreviewItem {
     academic_title: string
     first_name: string
     last_name: string
+    occupation: string
     profile_image: FileItem
     description: string
     event_image: FileItem
+    website_url: string | null
+    twitter_url: string | null
+    bluesky_url: string | null
+    linkedin_url: string | null
+    github_url: string | null
+    instagram_url: string | null
+    youtube_url: string | null
 }
 
 export interface PickOfTheDayItem extends PreparedTagsItem {

--- a/nuxt-app/types/items.ts
+++ b/nuxt-app/types/items.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-use-before-define */
 
-import type { DirectusMeetupItem, DirectusPodcastItem, DirectusSpeakerItem } from '~/types/directus'
+import type { DirectusMeetupItem, DirectusPodcastItem, DirectusConferenceItem, DirectusSpeakerItem } from '~/types/directus'
 
 export type LatestPodcastItem = Pick<
     DirectusPodcastItem,
@@ -28,6 +28,7 @@ interface PreparedPodcastsItems {
 
 export interface PodcastItem extends DirectusPodcastItem, PreparedTagsItem, PreparedSpeakersItem {}
 export interface MeetupItem extends DirectusMeetupItem, PreparedTagsItem, PreparedSpeakersItem {}
+export interface ConferenceItem extends DirectusConferenceItem, PreparedSpeakersItem {}
 export interface SpeakerItem extends DirectusSpeakerItem, PreparedTagsItem, PreparedPodcastsItems {}
 
 export interface MemberItem {


### PR DESCRIPTION
Design and architecture can be found here: https://www.figma.com/design/vNlQuCIZKsK2AGLvo5GSLg/Programmier.bar-Website

This PR adds a basic conference sub-page and introduces the necessary data models and loading logic.

⚠️ It does not yet implement any design requirements - these will follow later. For now, we are only trying to get the basics set up in a few smaller PRs.


