### PR TITLE
Add Slack context to podcast shownotes generation

### DIFF
--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/content-generation/generateContent.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/content-generation/generateContent.ts
@@ -1,6 +1,7 @@
 import type { Logger } from 'pino'
 import { callGemini, extractJson } from '../shared/gemini.ts'
 import { renderTemplate } from '../shared/templateRenderer.ts'
+import { fetchSlackContext } from '../shared/fetchSlackContext.ts'
 
 interface HookServices {
     logger: Logger
@@ -50,7 +51,7 @@ async function fetchPrompts(
     return prompts
 }
 
-function buildShownotesPrompt(podcast: PodcastData, prompts: Map<string, string>): string {
+function buildShownotesPrompt(podcast: PodcastData, prompts: Map<string, string>, slackContext?: string | null): string {
     const episodeType = podcast.type || 'other'
 
     const hosts =
@@ -85,6 +86,7 @@ function buildShownotesPrompt(podcast: PodcastData, prompts: Map<string, string>
         guests: guests || 'Keine Gäste',
         guest_info: guestInfo,
         transcript: podcast.transcript_text || 'Kein Transkript verfügbar',
+        slack_context: slackContext || '',
     })
 }
 
@@ -175,6 +177,33 @@ export async function generateContent(hookName: string, podcastId: number, servi
 
         logger.info(`${hookName}: Generating content for podcast: ${podcast.title}`)
 
+        // Fetch Slack context for news podcasts
+        let slackContext: string | null = null
+        if (podcast.type === 'news' && env.SLACK_BOT_TOKEN) {
+            logger.info(`${hookName}: Fetching Slack context for news podcast`)
+            slackContext = await fetchSlackContext({
+                podcastType: podcast.type,
+                podcastTitle: podcast.title,
+                slackBotToken: env.SLACK_BOT_TOKEN,
+                logger,
+                getSettingValue: async (key: string) => {
+                    const settingsService = new ItemsService('automation_settings', {
+                        schema,
+                        accountability: eventContext.accountability,
+                    })
+                    const settings = await settingsService.readByQuery({
+                        filter: { key: { _eq: key } },
+                        fields: ['value'],
+                        limit: 1,
+                    })
+                    return settings?.[0]?.value || null
+                },
+            })
+            if (slackContext) {
+                logger.info(`${hookName}: Slack context fetched successfully`)
+            }
+        }
+
         // Update status to transcript_ready
         logger.info(`${hookName}: Updating status to transcript_ready`)
         await podcastsService.updateOne(podcastId, {
@@ -184,7 +213,7 @@ export async function generateContent(hookName: string, podcastId: number, servi
         logger.info(`${hookName}: Calling Gemini API for shownotes`)
 
         // Generate shownotes
-        const shownotesPrompt = buildShownotesPrompt(podcast, prompts)
+        const shownotesPrompt = buildShownotesPrompt(podcast, prompts, slackContext)
         logger.info(`${hookName}: Sending request to Gemini API`)
         const shownotesResponse = await callGemini(geminiApiKey, shownotesPrompt)
         logger.info(`${hookName}: Received response from Gemini API`)

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/fetchSlackContext.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/fetchSlackContext.ts
@@ -1,0 +1,153 @@
+import { WebClient } from '@slack/web-api'
+import type { Logger } from 'pino'
+
+interface FetchSlackContextOptions {
+    podcastType: string
+    podcastTitle: string
+    slackBotToken: string
+    logger: Logger
+    getSettingValue: (key: string) => Promise<string | null>
+}
+
+/**
+ * Format a Slack message text: decode Slack link markup, remove user/channel mentions.
+ */
+function formatSlackText(text: string): string {
+    let result = text
+    // Slack URLs: <url|label> -> label (url)
+    result = result.replace(/<(https?:\/\/[^|>]+)\|([^>]+)>/g, '$2 ($1)')
+    // Slack URLs without label: <url> -> url
+    result = result.replace(/<(https?:\/\/[^>]+)>/g, '$1')
+    // Remove user mentions <@U...>
+    result = result.replace(/<@[A-Z0-9]+>/g, '')
+    // Channel mentions <#C...|name> -> #name
+    result = result.replace(/<#[A-Z0-9]+\|([^>]+)>/g, '#$1')
+    return result.trim()
+}
+
+/**
+ * Fetch messages from a single Slack channel (last 2 weeks), including thread replies.
+ */
+async function fetchChannelMessages(
+    webClient: WebClient,
+    channelId: string,
+    oldestTimestamp: string,
+    logger: Logger
+): Promise<string[]> {
+    const result = await webClient.conversations.history({
+        channel: channelId,
+        oldest: oldestTimestamp,
+        limit: 200,
+    })
+
+    if (!result.messages || result.messages.length === 0) {
+        return []
+    }
+
+    const formattedMessages: string[] = []
+
+    // Process in chronological order (Slack returns newest first)
+    const messages = [...result.messages].reverse()
+
+    for (const msg of messages) {
+        if (!msg.text || msg.bot_id) continue
+
+        const text = formatSlackText(msg.text)
+        if (!text) continue
+
+        formattedMessages.push(text)
+
+        // Fetch thread replies if this message has a thread
+        if (msg.reply_count && msg.reply_count > 0 && msg.ts) {
+            try {
+                const threadResult = await webClient.conversations.replies({
+                    channel: channelId,
+                    ts: msg.ts,
+                    limit: 100,
+                })
+
+                if (threadResult.messages && threadResult.messages.length > 1) {
+                    // Skip first message (it's the parent, already added)
+                    for (const reply of threadResult.messages.slice(1)) {
+                        if (!reply.text || reply.bot_id) continue
+                        const replyText = formatSlackText(reply.text)
+                        if (replyText) {
+                            formattedMessages.push(`  ↳ ${replyText}`)
+                        }
+                    }
+                }
+            } catch (threadErr: any) {
+                logger.warn(`fetchSlackContext: Failed to fetch thread replies: ${threadErr?.message || threadErr}`)
+            }
+        }
+    }
+
+    return formattedMessages
+}
+
+/**
+ * Fetch recent Slack messages as context for shownotes generation.
+ * Only applies to 'news' type podcasts.
+ *
+ * The automation_settings value can contain multiple channel IDs separated by comma.
+ * Returns a formatted string of messages, or null if not applicable/available.
+ */
+export async function fetchSlackContext(options: FetchSlackContextOptions): Promise<string | null> {
+    const { podcastType, podcastTitle, slackBotToken, logger, getSettingValue } = options
+
+    if (podcastType !== 'news') {
+        return null
+    }
+
+    const isAiNews = podcastTitle.startsWith('AI')
+    const settingKey = isAiNews ? 'slack_channel_ai_news' : 'slack_channel_news'
+
+    const channelSetting = await getSettingValue(settingKey)
+
+    if (!channelSetting) {
+        logger.info(`fetchSlackContext: No Slack channel configured for setting '${settingKey}', skipping`)
+        return null
+    }
+
+    const channelIds = channelSetting
+        .split(',')
+        .map((id) => id.trim())
+        .filter(Boolean)
+
+    if (channelIds.length === 0) {
+        logger.info(`fetchSlackContext: No valid channel IDs in setting '${settingKey}', skipping`)
+        return null
+    }
+
+    try {
+        const webClient = new WebClient(slackBotToken)
+        const twoWeeksAgo = String(Math.floor((Date.now() - 14 * 24 * 60 * 60 * 1000) / 1000))
+
+        const allMessages: string[] = []
+
+        for (const channelId of channelIds) {
+            try {
+                const messages = await fetchChannelMessages(webClient, channelId, twoWeeksAgo, logger)
+                if (messages.length > 0) {
+                    allMessages.push(...messages)
+                }
+                logger.info(`fetchSlackContext: Fetched ${messages.length} messages from channel ${channelId}`)
+            } catch (channelErr: any) {
+                logger.warn(
+                    `fetchSlackContext: Failed to fetch from channel ${channelId}: ${channelErr?.message || channelErr}`
+                )
+            }
+        }
+
+        if (allMessages.length === 0) {
+            logger.info(`fetchSlackContext: No messages found in any configured channel`)
+            return null
+        }
+
+        logger.info(`fetchSlackContext: Total ${allMessages.length} messages fetched from ${channelIds.length} channel(s)`)
+        return allMessages.join('\n---\n')
+    } catch (err: any) {
+        logger.warn(`fetchSlackContext: Failed to fetch Slack messages: ${err?.message || err}`)
+        return null
+    }
+}


### PR DESCRIPTION
## Summary

Adds Slack conversation context fetching for news podcasts to improve shownotes quality. When generating shownotes for news-type podcasts, the system now queries configured Slack channels to capture recent community discussions and editorial context.

## Changes

- New `fetchSlackContext.ts` helper module to fetch messages from Slack channels
- Integrates Slack context into the shownotes generation prompt for news podcasts
- Supports separate channel configurations for AI News vs regular News
- Includes thread replies and proper message formatting (removes mentions, decodes links)

## Implementation Notes

Only applies to 'news' type podcasts. Channel IDs are fetched from `automation_settings` table (supporting multiple channels via comma-separated values). Gracefully handles missing configuration or API errors with appropriate logging.