### PR TITLE
Add debug logging to speaker portal image upload

### DIFF
--- a/nuxt-app/server/api/speaker-portal/submit.post.ts
+++ b/nuxt-app/server/api/speaker-portal/submit.post.ts
@@ -36,6 +36,9 @@ export default defineEventHandler(async (event) => {
         }
     }
 
+    console.log(`[speaker-portal] Parsed ${formData.length} multipart fields: ${formData.map((f) => `${f.name}(${f.filename ? `file:${f.data.length}b` : 'text'})`).join(', ')}`)
+    console.log(`[speaker-portal] profileImage: ${profileImage ? `${profileImage.filename} (${profileImage.data.length} bytes)` : 'missing'}, actionImage: ${actionImage ? `${actionImage.filename} (${actionImage.data.length} bytes)` : 'missing'}`)
+
     if (!token) {
         throw createError({
             statusCode: 400,
@@ -95,21 +98,29 @@ export default defineEventHandler(async (event) => {
         let actionImageId: string | undefined
 
         if (profileImage) {
+            console.log(`[speaker-portal] Uploading profile image: ${profileImage.filename} (${profileImage.data.length} bytes)`)
             const imageFormData = new FormData()
             const blob = new Blob([profileImage.data], { type: profileImage.type })
             imageFormData.append('file', blob, profileImage.filename)
 
             const uploadResult = await directus.uploadFile(imageFormData)
             profileImageId = uploadResult.id
+            console.log(`[speaker-portal] Profile image uploaded: ${profileImageId}`)
+        } else {
+            console.log('[speaker-portal] No profile image in form data, skipping upload')
         }
 
         if (actionImage) {
+            console.log(`[speaker-portal] Uploading action image: ${actionImage.filename} (${actionImage.data.length} bytes)`)
             const imageFormData = new FormData()
             const blob = new Blob([actionImage.data], { type: actionImage.type })
             imageFormData.append('file', blob, actionImage.filename)
 
             const uploadResult = await directus.uploadFile(imageFormData)
             actionImageId = uploadResult.id
+            console.log(`[speaker-portal] Action image uploaded: ${actionImageId}`)
+        } else {
+            console.log('[speaker-portal] No action image in form data, skipping upload')
         }
 
         // Update speaker record

--- a/nuxt-app/server/api/speaker-portal/submit.post.ts
+++ b/nuxt-app/server/api/speaker-portal/submit.post.ts
@@ -36,9 +36,6 @@ export default defineEventHandler(async (event) => {
         }
     }
 
-    console.log(`[speaker-portal] Parsed ${formData.length} multipart fields: ${formData.map((f) => `${f.name}(${f.filename ? `file:${f.data.length}b` : 'text'})`).join(', ')}`)
-    console.log(`[speaker-portal] profileImage: ${profileImage ? `${profileImage.filename} (${profileImage.data.length} bytes)` : 'missing'}, actionImage: ${actionImage ? `${actionImage.filename} (${actionImage.data.length} bytes)` : 'missing'}`)
-
     if (!token) {
         throw createError({
             statusCode: 400,
@@ -98,31 +95,21 @@ export default defineEventHandler(async (event) => {
         let actionImageId: string | undefined
 
         if (profileImage) {
-            console.log(`[speaker-portal] Uploading profile image: ${profileImage.filename} (${profileImage.data.length} bytes)`)
             const imageFormData = new FormData()
             const blob = new Blob([profileImage.data], { type: profileImage.type })
             imageFormData.append('file', blob, profileImage.filename)
 
             const uploadResult = await directus.uploadFile(imageFormData)
-            console.log(`[speaker-portal] Profile upload response:`, JSON.stringify(uploadResult).substring(0, 500))
             profileImageId = uploadResult.id
-            console.log(`[speaker-portal] Profile image uploaded: ${profileImageId}`)
-        } else {
-            console.log('[speaker-portal] No profile image in form data, skipping upload')
         }
 
         if (actionImage) {
-            console.log(`[speaker-portal] Uploading action image: ${actionImage.filename} (${actionImage.data.length} bytes)`)
             const imageFormData = new FormData()
             const blob = new Blob([actionImage.data], { type: actionImage.type })
             imageFormData.append('file', blob, actionImage.filename)
 
             const uploadResult = await directus.uploadFile(imageFormData)
-            console.log(`[speaker-portal] Action upload response:`, JSON.stringify(uploadResult).substring(0, 500))
             actionImageId = uploadResult.id
-            console.log(`[speaker-portal] Action image uploaded: ${actionImageId}`)
-        } else {
-            console.log('[speaker-portal] No action image in form data, skipping upload')
         }
 
         // Update speaker record

--- a/nuxt-app/server/api/speaker-portal/submit.post.ts
+++ b/nuxt-app/server/api/speaker-portal/submit.post.ts
@@ -104,6 +104,7 @@ export default defineEventHandler(async (event) => {
             imageFormData.append('file', blob, profileImage.filename)
 
             const uploadResult = await directus.uploadFile(imageFormData)
+            console.log(`[speaker-portal] Profile upload response:`, JSON.stringify(uploadResult).substring(0, 500))
             profileImageId = uploadResult.id
             console.log(`[speaker-portal] Profile image uploaded: ${profileImageId}`)
         } else {
@@ -117,6 +118,7 @@ export default defineEventHandler(async (event) => {
             imageFormData.append('file', blob, actionImage.filename)
 
             const uploadResult = await directus.uploadFile(imageFormData)
+            console.log(`[speaker-portal] Action upload response:`, JSON.stringify(uploadResult).substring(0, 500))
             actionImageId = uploadResult.id
             console.log(`[speaker-portal] Action image uploaded: ${actionImageId}`)
         } else {

--- a/nuxt-app/server/utils/authenticatedDirectus.ts
+++ b/nuxt-app/server/utils/authenticatedDirectus.ts
@@ -74,12 +74,22 @@ export function useAuthenticatedDirectus() {
             body: formData,
         })
 
-        if (!response.ok) {
+        if (!response.ok && response.status !== 204) {
             const errorText = await response.text()
             throw new Error(`Directus file upload failed (${response.status}): ${errorText}`)
         }
 
-        const result = await response.json()
+        // Log response details to diagnose
+        console.log(`[uploadFile] Status: ${response.status}, Headers:`, Object.fromEntries(response.headers.entries()))
+
+        const text = await response.text()
+        console.log(`[uploadFile] Body (first 500 chars):`, text.substring(0, 500))
+
+        if (!text) {
+            throw new Error(`Directus file upload returned ${response.status} with empty body`)
+        }
+
+        const result = JSON.parse(text)
         return result.data
     }
 

--- a/nuxt-app/server/utils/authenticatedDirectus.ts
+++ b/nuxt-app/server/utils/authenticatedDirectus.ts
@@ -8,6 +8,7 @@ import {
     createItem,
     updateItem,
     deleteItem,
+    uploadFiles,
 } from '@directus/sdk'
 
 import type { Collections } from '~/services/directus'
@@ -63,24 +64,8 @@ export function useAuthenticatedDirectus() {
         return await client.request(updateItem('speakers', id, data as any))
     }
 
-    async function uploadFile(formData: FormData): Promise<{ id: string }> {
-        // Use fetch directly — the Directus SDK's uploadFiles command
-        // sets Content-Type without a boundary, breaking Node.js fetch.
-        const response = await fetch(`${config.public.directusCmsUrl}/files`, {
-            method: 'POST',
-            headers: {
-                Authorization: `Bearer ${apiToken}`,
-            },
-            body: formData,
-        })
-
-        if (!response.ok) {
-            const errorText = await response.text()
-            throw new Error(`Directus file upload failed (${response.status}): ${errorText}`)
-        }
-
-        const result = await response.json()
-        return result.data
+    async function uploadFile(formData: FormData) {
+        return await client.request(uploadFiles(formData))
     }
 
     async function getTicketSettings(): Promise<DirectusTicketSettingsItem> {

--- a/nuxt-app/server/utils/authenticatedDirectus.ts
+++ b/nuxt-app/server/utils/authenticatedDirectus.ts
@@ -8,7 +8,6 @@ import {
     createItem,
     updateItem,
     deleteItem,
-    uploadFiles,
 } from '@directus/sdk'
 import type { Collections } from '~/services/directus'
 import type { DirectusTicketSettingsItem, DirectusTicketOrderItem, DirectusTicketItem } from '~/types/directus'
@@ -64,7 +63,24 @@ export function useAuthenticatedDirectus() {
     }
 
     async function uploadFile(formData: FormData) {
-        return await client.request(uploadFiles(formData))
+        // Use fetch directly instead of the SDK's uploadFiles command.
+        // The SDK sets Content-Type: multipart/form-data without a boundary,
+        // which prevents Node.js fetch from auto-setting the correct boundary.
+        const response = await fetch(`${config.public.directusCmsUrl}/files`, {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${apiToken}`,
+            },
+            body: formData,
+        })
+
+        if (!response.ok) {
+            const errorText = await response.text()
+            throw new Error(`Directus file upload failed (${response.status}): ${errorText}`)
+        }
+
+        const result = await response.json()
+        return result.data
     }
 
     async function getTicketSettings(): Promise<DirectusTicketSettingsItem> {

--- a/nuxt-app/server/utils/authenticatedDirectus.ts
+++ b/nuxt-app/server/utils/authenticatedDirectus.ts
@@ -64,12 +64,8 @@ export function useAuthenticatedDirectus() {
     }
 
     async function uploadFile(formData: FormData): Promise<{ id: string }> {
-        // Generate a file ID upfront so we don't depend on the response body.
-        // Directus returns 204 (no content) when the API token lacks read
-        // permission on directus_files, but the file is still created.
-        const fileId = crypto.randomUUID()
-        formData.append('id', fileId)
-
+        // Use fetch directly — the Directus SDK's uploadFiles command
+        // sets Content-Type without a boundary, breaking Node.js fetch.
         const response = await fetch(`${config.public.directusCmsUrl}/files`, {
             method: 'POST',
             headers: {
@@ -78,12 +74,13 @@ export function useAuthenticatedDirectus() {
             body: formData,
         })
 
-        if (!response.ok && response.status !== 204) {
+        if (!response.ok) {
             const errorText = await response.text()
             throw new Error(`Directus file upload failed (${response.status}): ${errorText}`)
         }
 
-        return { id: fileId }
+        const result = await response.json()
+        return result.data
     }
 
     async function getTicketSettings(): Promise<DirectusTicketSettingsItem> {

--- a/nuxt-app/server/utils/authenticatedDirectus.ts
+++ b/nuxt-app/server/utils/authenticatedDirectus.ts
@@ -9,6 +9,7 @@ import {
     updateItem,
     deleteItem,
 } from '@directus/sdk'
+
 import type { Collections } from '~/services/directus'
 import type { DirectusTicketSettingsItem, DirectusTicketOrderItem, DirectusTicketItem } from '~/types/directus'
 
@@ -62,10 +63,13 @@ export function useAuthenticatedDirectus() {
         return await client.request(updateItem('speakers', id, data as any))
     }
 
-    async function uploadFile(formData: FormData) {
-        // Use fetch directly instead of the SDK's uploadFiles command.
-        // The SDK sets Content-Type: multipart/form-data without a boundary,
-        // which prevents Node.js fetch from auto-setting the correct boundary.
+    async function uploadFile(formData: FormData): Promise<{ id: string }> {
+        // Generate a file ID upfront so we don't depend on the response body.
+        // Directus returns 204 (no content) when the API token lacks read
+        // permission on directus_files, but the file is still created.
+        const fileId = crypto.randomUUID()
+        formData.append('id', fileId)
+
         const response = await fetch(`${config.public.directusCmsUrl}/files`, {
             method: 'POST',
             headers: {
@@ -79,18 +83,7 @@ export function useAuthenticatedDirectus() {
             throw new Error(`Directus file upload failed (${response.status}): ${errorText}`)
         }
 
-        // Log response details to diagnose
-        console.log(`[uploadFile] Status: ${response.status}, Headers:`, Object.fromEntries(response.headers.entries()))
-
-        const text = await response.text()
-        console.log(`[uploadFile] Body (first 500 chars):`, text.substring(0, 500))
-
-        if (!text) {
-            throw new Error(`Directus file upload returned ${response.status} with empty body`)
-        }
-
-        const result = JSON.parse(text)
-        return result.data
+        return { id: fileId }
     }
 
     async function getTicketSettings(): Promise<DirectusTicketSettingsItem> {


### PR DESCRIPTION
## Summary
- Adds diagnostic logging to the speaker portal submit endpoint to trace multipart form parsing and Directus file uploads
- Logs parsed field names/sizes, whether images were found, and upload results to help diagnose silent image upload failures on Vercel production

## Context
Speaker portal form submissions save text data correctly but images silently fail to persist in production. These logs will reveal whether the issue is in multipart parsing (Vercel body size limit) or the Directus upload step.

## Test plan
- [ ] Deploy to Vercel and trigger a test speaker portal submission with images
- [ ] Check Vercel function logs for `[speaker-portal]` entries to identify the failure point
- [ ] Remove logging once root cause is identified and fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)