### PR TITLE
San Juan v2: Per-conference tickets, discount codes & free ticket support

### DIFF
--- a/nuxt-app/server/api/tickets/create-checkout.post.ts
+++ b/nuxt-app/server/api/tickets/create-checkout.post.ts
@@ -116,7 +116,6 @@ function buildStripeSessionParams(
 
     return {
         mode: 'payment',
-        payment_method_types: ['card'],
         customer_email: purchaserEmail,
         line_items: tickets.map((ticket) => ({
             price_data: {


### PR DESCRIPTION
## Summary
- **Per-conference ticket settings**: Migrated from global `ticket_settings` singleton to per-conference pricing (early bird, regular, discount) stored directly on the conference item
- **Discount codes**: Added `ticket_discount_codes` collection with per-code pricing, max uses, active flag, and label support
- **Free ticket flow**: Skip Stripe checkout entirely for 0€ tickets, marking orders as paid directly
- **Ticket attendee profile portal**: New page for attendees to complete their profile (dietary needs, company, etc.) via secure token link
- **Invoice generation**: Auto-generate PDF invoices with QR codes, attached to confirmation emails
- **Stripe payment methods**: Removed explicit card-only restriction to allow all dashboard-configured payment methods (Apple Pay, PayPal, etc.)
- **UI improvements**: Ticket price cards on conference page with active/expired early bird styling, "Abgelaufen" badge, and highlighted current price tier
- **Shared utilities**: Extracted Gemini API, QR generation, template rendering, and Slack context fetching into shared modules
- **Directus hooks**: Added ticket-profile-completion hook and improved ticket-order-processing with invoice support

## Test plan
- [ ] Purchase a regular ticket and verify Stripe checkout completes
- [ ] Purchase a ticket during early bird period and verify early bird pricing
- [ ] Apply a discount code and verify discounted price
- [ ] Test a 0€ free ticket (discount to zero) and verify Stripe is skipped
- [ ] Verify invoice PDF is generated and attached to confirmation email
- [ ] Open ticket profile portal via token link and complete profile
- [ ] Verify expired early bird card shows "Abgelaufen" with dimmed styling
- [ ] Verify Apple Pay / PayPal appear in Stripe Checkout (if enabled in dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)