### PR TITLE
Add ticket sales stats API endpoint

### DIFF
--- a/nuxt-app/server/api/stats/ticket-sales.get.ts
+++ b/nuxt-app/server/api/stats/ticket-sales.get.ts
@@ -8,7 +8,15 @@ export default defineCachedEventHandler(
         const conference = await directus.getLatestConferenceWithTicketing()
 
         if (!conference) {
-            throw createError({ statusCode: 404, message: 'No conference with ticketing found' })
+            return {
+                conference: {
+                    id: null,
+                    title: 'No active conference',
+                    slug: null,
+                },
+                sold: 0,
+                max: 0,
+            }
         }
 
         const sold = await directus.countPaidTicketsForConference(conference.id)
@@ -20,7 +28,7 @@ export default defineCachedEventHandler(
                 slug: conference.slug,
             },
             sold,
-            max: conference.ticket_max_quantity ?? null,
+            max: conference.ticket_max_quantity ?? 0,
         }
     },
     {

--- a/nuxt-app/server/api/stats/ticket-sales.get.ts
+++ b/nuxt-app/server/api/stats/ticket-sales.get.ts
@@ -1,0 +1,31 @@
+export default defineCachedEventHandler(
+    async (event) => {
+        setHeader(event, 'Access-Control-Allow-Origin', '*')
+        setHeader(event, 'Access-Control-Allow-Methods', 'GET, OPTIONS')
+
+        const directus = useAuthenticatedDirectus()
+
+        const conference = await directus.getLatestConferenceWithTicketing()
+
+        if (!conference) {
+            throw createError({ statusCode: 404, message: 'No conference with ticketing found' })
+        }
+
+        const sold = await directus.countPaidTicketsForConference(conference.id)
+
+        return {
+            conference: {
+                id: conference.id,
+                title: conference.title,
+                slug: conference.slug,
+            },
+            sold,
+            max: conference.ticket_max_quantity ?? null,
+        }
+    },
+    {
+        maxAge: 5 * 60,
+        swr: true,
+        getKey: () => 'stats:ticket-sales:current',
+    }
+)


### PR DESCRIPTION
## Summary
This PR adds a new cached API endpoint that provides real-time ticket sales statistics for the current active conference.

## Key Changes
- Created new `server/api/stats/ticket-sales.get.ts` endpoint that:
  - Retrieves the latest conference with active ticketing
  - Counts the number of paid tickets sold for that conference
  - Returns conference details (id, title, slug), sold ticket count, and maximum ticket capacity
  - Includes CORS headers to allow cross-origin GET requests
  - Implements 5-minute caching with stale-while-revalidate strategy for performance

## Implementation Details
- Uses `defineCachedEventHandler` for automatic response caching with a 5-minute TTL
- Falls back gracefully when no active conference exists, returning zero values
- Leverages existing Directus service methods (`getLatestConferenceWithTicketing` and `countPaidTicketsForConference`)
- Configured with a consistent cache key (`stats:ticket-sales:current`) for cache management

https://claude.ai/code/session_01DzguY7mauWKtEkFVJyZ6fH