### PR TITLE
Add internal employee tickets via free discount codes

### DIFF
--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/ticket-order-processing/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/ticket-order-processing/index.ts
@@ -94,6 +94,7 @@ export default defineHook(({ action }, hookContext) => {
                         'vat_amount_cents',
                         'attendees_json',
                         'ticket_type',
+                        'is_internal',
                     ],
                 })
 
@@ -133,12 +134,15 @@ export default defineHook(({ action }, hookContext) => {
                     continue
                 }
 
-                // Hard limit check: verify ticket limit before creating tickets
-                if (conference.ticket_max_quantity !== null && conference.ticket_max_quantity !== undefined) {
+                const isInternal = order.is_internal === true
+
+                // Hard limit check: verify ticket limit before creating tickets (internal tickets don't count)
+                if (!isInternal && conference.ticket_max_quantity !== null && conference.ticket_max_quantity !== undefined) {
                     const existingTickets = await ticketsService.readByQuery({
                         filter: {
                             conference: { _eq: order.conference },
                             status: { _neq: 'cancelled' },
+                            is_internal: { _neq: true },
                         },
                         aggregate: { count: ['id'] },
                     })
@@ -158,68 +162,76 @@ export default defineHook(({ action }, hookContext) => {
                 const pricePerTicket = Math.round((order.total_cents || 0) / attendees.length)
                 const purchaserName = `${order.purchaser_first_name} ${order.purchaser_last_name}`
 
-                // --- Generate invoice ---
-                const conferenceYear = new Date(conference.start_on).getFullYear()
-                const invoiceNumber = await generateInvoiceNumber(ordersService, conferenceYear)
+                // --- Generate invoice (skipped for internal employee orders) ---
+                let invoiceNumber: string | null = null
+                let invoiceFileName: string | null = null
+                let pdfBuffer: Buffer | null = null
 
-                const now = new Date()
-                const invoiceDate = now.toLocaleDateString('de-DE', {
-                    day: '2-digit',
-                    month: '2-digit',
-                    year: 'numeric',
-                })
+                if (!isInternal) {
+                    const conferenceYear = new Date(conference.start_on).getFullYear()
+                    invoiceNumber = await generateInvoiceNumber(ordersService, conferenceYear)
 
-                const grossPerTicket = Math.round((order.total_gross_cents || 0) / attendees.length)
+                    const now = new Date()
+                    const invoiceDate = now.toLocaleDateString('de-DE', {
+                        day: '2-digit',
+                        month: '2-digit',
+                        year: 'numeric',
+                    })
 
-                const invoiceData: InvoiceData = {
-                    invoiceNumber,
-                    invoiceDate,
-                    purchaserName,
-                    purchaserEmail: order.purchaser_email,
-                    companyName: order.company_name,
-                    companyVatId: order.company_vat_id,
-                    billingAddressLine1: order.billing_address_line1,
-                    billingAddressLine2: order.billing_address_line2,
-                    billingCity: order.billing_city,
-                    billingPostalCode: order.billing_postal_code,
-                    billingCountry: order.billing_country,
-                    conferenceTitle: conference.title,
-                    ticketType: ticketTypeLabel(order.ticket_type),
-                    ticketCount: attendees.length,
-                    unitPriceGrossCents: grossPerTicket,
-                    subtotalCents: order.subtotal_cents || order.total_cents,
-                    discountAmountCents: order.discount_amount_cents || 0,
-                    vatAmountCents: order.vat_amount_cents || 0,
-                    totalGrossCents: order.total_gross_cents || order.total_cents,
+                    const grossPerTicket = Math.round((order.total_gross_cents || 0) / attendees.length)
+
+                    const invoiceData: InvoiceData = {
+                        invoiceNumber,
+                        invoiceDate,
+                        purchaserName,
+                        purchaserEmail: order.purchaser_email,
+                        companyName: order.company_name,
+                        companyVatId: order.company_vat_id,
+                        billingAddressLine1: order.billing_address_line1,
+                        billingAddressLine2: order.billing_address_line2,
+                        billingCity: order.billing_city,
+                        billingPostalCode: order.billing_postal_code,
+                        billingCountry: order.billing_country,
+                        conferenceTitle: conference.title,
+                        ticketType: ticketTypeLabel(order.ticket_type),
+                        ticketCount: attendees.length,
+                        unitPriceGrossCents: grossPerTicket,
+                        subtotalCents: order.subtotal_cents || order.total_cents,
+                        discountAmountCents: order.discount_amount_cents || 0,
+                        vatAmountCents: order.vat_amount_cents || 0,
+                        totalGrossCents: order.total_gross_cents || order.total_cents,
+                    }
+
+                    logger.info(`${HOOK_NAME}: Generating invoice ${invoiceNumber} for order ${order.order_number}`)
+                    pdfBuffer = await generateInvoicePdf(invoiceData)
+
+                    // Upload PDF to Directus files
+                    const filesService = new FilesService({
+                        accountability: { admin: true },
+                        schema,
+                    })
+
+                    invoiceFileName = `Rechnung-${invoiceNumber}.pdf`
+                    const storageLocation = env.STORAGE_LOCATIONS?.split(',')[0]
+
+                    const pdfStream = Readable.from([pdfBuffer])
+                    const fileId = await filesService.uploadOne(pdfStream, {
+                        type: 'application/pdf',
+                        filename_download: invoiceFileName,
+                        title: `Rechnung ${invoiceNumber}`,
+                        ...(storageLocation && { storage: storageLocation }),
+                    })
+
+                    // Update order with invoice number and file reference
+                    await ordersService.updateOne(orderId, {
+                        invoice_number: invoiceNumber,
+                        invoice_file: fileId,
+                    })
+
+                    logger.info(`${HOOK_NAME}: Invoice ${invoiceNumber} generated and stored (file: ${fileId})`)
+                } else {
+                    logger.info(`${HOOK_NAME}: Skipping invoice for internal order ${order.order_number}`)
                 }
-
-                logger.info(`${HOOK_NAME}: Generating invoice ${invoiceNumber} for order ${order.order_number}`)
-                const pdfBuffer = await generateInvoicePdf(invoiceData)
-
-                // Upload PDF to Directus files
-                const filesService = new FilesService({
-                    accountability: { admin: true },
-                    schema,
-                })
-
-                const invoiceFileName = `Rechnung-${invoiceNumber}.pdf`
-                const storageLocation = env.STORAGE_LOCATIONS?.split(',')[0]
-
-                const pdfStream = Readable.from([pdfBuffer])
-                const fileId = await filesService.uploadOne(pdfStream, {
-                    type: 'application/pdf',
-                    filename_download: invoiceFileName,
-                    title: `Rechnung ${invoiceNumber}`,
-                    ...(storageLocation && { storage: storageLocation }),
-                })
-
-                // Update order with invoice number and file reference
-                await ordersService.updateOne(orderId, {
-                    invoice_number: invoiceNumber,
-                    invoice_file: fileId,
-                })
-
-                logger.info(`${HOOK_NAME}: Invoice ${invoiceNumber} generated and stored (file: ${fileId})`)
 
                 // --- Create individual tickets with profile tokens (no QR codes yet) ---
                 const ticketRecords: Array<{
@@ -246,6 +258,7 @@ export default defineHook(({ action }, hookContext) => {
                         status: 'valid',
                         profile_token: profileToken,
                         profile_status: 'pending',
+                        is_internal: isInternal,
                     })
 
                     ticketRecords.push({
@@ -258,34 +271,36 @@ export default defineHook(({ action }, hookContext) => {
                     logger.info(`${HOOK_NAME}: Created ticket ${ticketCode} for ${attendee.email} (profile pending)`)
                 }
 
-                // --- Send purchaser confirmation email with invoice PDF ---
-                const totalAmount = formatPrice(order.total_gross_cents || order.total_cents)
+                // --- Send purchaser confirmation email with invoice PDF (skipped for internal orders) ---
+                if (!isInternal && pdfBuffer && invoiceFileName && invoiceNumber) {
+                    const totalAmount = formatPrice(order.total_gross_cents || order.total_cents)
 
-                await sendTemplatedEmail(
-                    {
-                        templateKey: 'ticket_order_confirmation',
-                        to: order.purchaser_email,
-                        cc: order.billing_email || undefined,
-                        data: {
-                            purchaser_name: purchaserName,
-                            conference_title: conference.title,
-                            order_number: order.order_number,
-                            total_amount: totalAmount,
-                            ticket_count: ticketRecords.length,
-                            invoice_number: invoiceNumber,
-                        },
-                        attachments: [
-                            {
-                                filename: invoiceFileName,
-                                content: pdfBuffer,
-                                contentType: 'application/pdf',
+                    await sendTemplatedEmail(
+                        {
+                            templateKey: 'ticket_order_confirmation',
+                            to: order.purchaser_email,
+                            cc: order.billing_email || undefined,
+                            data: {
+                                purchaser_name: purchaserName,
+                                conference_title: conference.title,
+                                order_number: order.order_number,
+                                total_amount: totalAmount,
+                                ticket_count: ticketRecords.length,
+                                invoice_number: invoiceNumber,
                             },
-                        ],
-                    },
-                    context
-                )
+                            attachments: [
+                                {
+                                    filename: invoiceFileName,
+                                    content: pdfBuffer,
+                                    contentType: 'application/pdf',
+                                },
+                            ],
+                        },
+                        context
+                    )
 
-                logger.info(`${HOOK_NAME}: Sent confirmation email with invoice to ${order.purchaser_email}`)
+                    logger.info(`${HOOK_NAME}: Sent confirmation email with invoice to ${order.purchaser_email}`)
+                }
 
                 // --- Send profile invitation email to all attendees ---
                 for (const ticket of ticketRecords) {
@@ -309,7 +324,7 @@ export default defineHook(({ action }, hookContext) => {
                 }
 
                 logger.info(
-                    `${HOOK_NAME}: Order ${order.order_number} processed with ${ticketRecords.length} tickets, invoice ${invoiceNumber}`
+                    `${HOOK_NAME}: Order ${order.order_number} processed with ${ticketRecords.length} tickets${invoiceNumber ? `, invoice ${invoiceNumber}` : ' (internal, no invoice)'}`
                 )
             }
         } catch (err: any) {

--- a/nuxt-app/components/tickets/TicketPricingSummary.vue
+++ b/nuxt-app/components/tickets/TicketPricingSummary.vue
@@ -28,8 +28,8 @@ const store = useTicketCheckoutStore()
                 <span class="rounded bg-lime/20 px-2 py-0.5 text-xs font-bold">Early Bird</span>
             </div>
 
-            <div v-if="store.discountValid && !store.isEarlyBird" class="flex justify-between text-lime">
-                <span>Rabatt ({{ store.discountCode }})</span>
+            <div v-if="store.discountValid && (store.isEmployeeCode || !store.isEarlyBird)" class="flex justify-between text-lime">
+                <span>{{ store.isEmployeeCode ? 'Mitarbeiter-Code' : `Rabatt (${store.discountCode})` }}</span>
                 <span>-{{ store.formatPrice(store.discountAmountCents) }}</span>
             </div>
 

--- a/nuxt-app/components/tickets/TicketStepReview.vue
+++ b/nuxt-app/components/tickets/TicketStepReview.vue
@@ -17,9 +17,13 @@ async function applyDiscountCode() {
     discountMessage.value = ''
     const valid = await store.validateDiscountCode()
     if (valid) {
-        discountMessage.value = store.pricingSettings?.discountLabel
-            ? `Rabattcode "${store.pricingSettings.discountLabel}" angewendet!`
-            : 'Rabattcode erfolgreich angewendet!'
+        if (store.isEmployeeCode) {
+            discountMessage.value = 'Mitarbeiter-Code erkannt — keine Zahlung nötig.'
+        } else {
+            discountMessage.value = store.pricingSettings?.discountLabel
+                ? `Rabattcode "${store.pricingSettings.discountLabel}" angewendet!`
+                : 'Rabattcode erfolgreich angewendet!'
+        }
     } else {
         discountMessage.value = store.error || 'Ungültiger Rabattcode.'
     }
@@ -32,6 +36,7 @@ function removeDiscountCode() {
     if (store.pricingSettings) {
         store.pricingSettings.discountPriceCents = null
         store.pricingSettings.discountLabel = null
+        store.pricingSettings.isEmployeeCode = false
     }
 }
 
@@ -205,11 +210,17 @@ async function proceedToPayment() {
             @click="proceedToPayment"
         >
             <span v-if="store.isLoading">Wird verarbeitet...</span>
+            <span v-else-if="store.isEmployeeCode">Ticket bestätigen</span>
             <span v-else>Zur Zahlung</span>
         </button>
 
         <p class="mt-4 text-center text-sm text-[#848a98]">
-            Du wirst zur sicheren Zahlungsseite von Stripe weitergeleitet.
+            <span v-if="store.isEmployeeCode">
+                Mit dem Mitarbeiter-Code ist keine Zahlung nötig.
+            </span>
+            <span v-else>
+                Du wirst zur sicheren Zahlungsseite von Stripe weitergeleitet.
+            </span>
         </p>
     </div>
 </template>

--- a/nuxt-app/components/tickets/TicketStepReview.vue
+++ b/nuxt-app/components/tickets/TicketStepReview.vue
@@ -135,7 +135,7 @@ async function proceedToPayment() {
         </div>
 
         <!-- Discount code -->
-        <div v-if="!store.isEarlyBird" class="mb-8 rounded-lg border border-gray-700 bg-gray-800/50 p-6">
+        <div class="mb-8 rounded-lg border border-gray-700 bg-gray-800/50 p-6">
             <h3 class="mb-3 text-sm font-bold text-white">Rabattcode</h3>
             <div v-if="store.discountValid" class="flex items-center justify-between">
                 <div>

--- a/nuxt-app/composables/useTicketCheckoutStore.ts
+++ b/nuxt-app/composables/useTicketCheckoutStore.ts
@@ -10,6 +10,7 @@ interface TicketPricingSettings {
     isEarlyBird: boolean
     discountPriceCents: number | null
     discountLabel: string | null
+    isEmployeeCode: boolean
 }
 
 interface TicketCheckoutState {
@@ -145,9 +146,20 @@ export const useTicketCheckoutStore = defineStore('ticketCheckout', {
         },
 
         /**
-         * Effective unit price per ticket in cents (after discount if applicable)
+         * Whether the validated discount code is an employee code
+         */
+        isEmployeeCode(): boolean {
+            return this.discountValid && this.pricingSettings?.isEmployeeCode === true
+        },
+
+        /**
+         * Effective unit price per ticket in cents (after discount if applicable).
+         * Employee codes override early bird and always price at zero.
          */
         unitPriceCents(): number {
+            if (this.isEmployeeCode) {
+                return 0
+            }
             if (this.discountValid && !this.isEarlyBird && this.pricingSettings?.discountPriceCents !== null && this.pricingSettings?.discountPriceCents !== undefined) {
                 return this.pricingSettings.discountPriceCents
             }
@@ -158,6 +170,9 @@ export const useTicketCheckoutStore = defineStore('ticketCheckout', {
          * Get ticket type based on current pricing
          */
         ticketType(): TicketType {
+            if (this.isEmployeeCode) {
+                return 'discounted'
+            }
             if (this.isEarlyBird) {
                 return 'early_bird'
             }
@@ -178,6 +193,9 @@ export const useTicketCheckoutStore = defineStore('ticketCheckout', {
          * Calculate discount amount in cents
          */
         discountAmountCents(): number {
+            if (this.isEmployeeCode) {
+                return this.ticketCount * this.basePriceCents
+            }
             if (!this.discountValid || this.isEarlyBird || !this.pricingSettings || this.pricingSettings.discountPriceCents === null) {
                 return 0
             }
@@ -251,6 +269,7 @@ export const useTicketCheckoutStore = defineStore('ticketCheckout', {
                 isEarlyBird,
                 discountPriceCents: null,
                 discountLabel: null,
+                isEmployeeCode: false,
             }
             this.pricingLoaded = true
             this.pricingError = false
@@ -456,12 +475,14 @@ export const useTicketCheckoutStore = defineStore('ticketCheckout', {
                     },
                 })
 
-                const result = response as { valid: boolean; discountPriceCents?: number; discountLabel?: string }
+                const result = response as { valid: boolean; discountPriceCents?: number; discountLabel?: string; isEmployeeCode?: boolean }
                 this.discountValid = result.valid
 
                 if (result.valid && this.pricingSettings) {
-                    this.pricingSettings.discountPriceCents = result.discountPriceCents ?? null
+                    const isEmployeeCode = result.isEmployeeCode === true
+                    this.pricingSettings.discountPriceCents = isEmployeeCode ? 0 : (result.discountPriceCents ?? null)
                     this.pricingSettings.discountLabel = result.discountLabel ?? null
+                    this.pricingSettings.isEmployeeCode = isEmployeeCode
                 }
 
                 this.persistState()

--- a/nuxt-app/server/api/tickets/create-checkout.post.ts
+++ b/nuxt-app/server/api/tickets/create-checkout.post.ts
@@ -71,7 +71,8 @@ function buildOrderPayload(
     input: CreateCheckoutInput,
     orderNumber: string,
     pricing: ReturnType<typeof calculatePricing>,
-    discountCodeId: string | null
+    discountCodeId: string | null,
+    isInternal: boolean
 ): Partial<DirectusTicketOrderItem> {
     const { conferenceId, purchaseType, purchaser, company, personalAddress } = input
     const billingAddress = purchaseType === 'company' ? company?.address : personalAddress
@@ -100,6 +101,7 @@ function buildOrderPayload(
         discount_code_used: discountCodeId,
         ticket_type: pricing.ticketType,
         stripe_checkout_session_id: '', // Will be updated after creating Stripe session
+        is_internal: isInternal,
     }
 }
 
@@ -165,24 +167,10 @@ export default defineEventHandler(async (event) => {
             })
         }
 
-        // Hard limit check: count existing tickets and reject if limit would be exceeded
-        if (conference.ticket_max_quantity !== null) {
-            const existingTickets = await directus.countPaidTicketsForConference(input.conferenceId)
-            if (existingTickets + input.tickets.length > conference.ticket_max_quantity) {
-                const remaining = Math.max(0, conference.ticket_max_quantity - existingTickets)
-                throw createError({
-                    statusCode: 409,
-                    message:
-                        remaining === 0
-                            ? 'Leider sind alle Tickets ausverkauft.'
-                            : `Nur noch ${remaining} Ticket(s) verfügbar. Bitte reduziere die Anzahl.`,
-                })
-            }
-        }
-
         // Validate discount code if provided
         let discountPriceCents: number | null = null
         let discountCodeId: string | null = null
+        let isInternal = false
 
         if (input.discountCode) {
             const discountCode = await directus.getDiscountCode(input.conferenceId, input.discountCode)
@@ -199,14 +187,44 @@ export default defineEventHandler(async (event) => {
                 }
                 discountPriceCents = discountCode.price_cents
                 discountCodeId = discountCode.id
+                if (discountCode.is_employee_code === true) {
+                    isInternal = true
+                    discountPriceCents = 0
+                }
             }
         }
 
-        // Calculate pricing
-        const pricing = calculatePricing(conference, input.tickets.length, discountPriceCents)
+        // Hard limit check: internal tickets don't consume capacity
+        if (!isInternal && conference.ticket_max_quantity !== null) {
+            const existingTickets = await directus.countPaidTicketsForConference(input.conferenceId)
+            if (existingTickets + input.tickets.length > conference.ticket_max_quantity) {
+                const remaining = Math.max(0, conference.ticket_max_quantity - existingTickets)
+                throw createError({
+                    statusCode: 409,
+                    message:
+                        remaining === 0
+                            ? 'Leider sind alle Tickets ausverkauft.'
+                            : `Nur noch ${remaining} Ticket(s) verfügbar. Bitte reduziere die Anzahl.`,
+                })
+            }
+        }
+
+        // Calculate pricing — internal employee orders are always free, regardless of early bird
+        const pricing = isInternal
+            ? {
+                  unitPriceNetCents: 0,
+                  unitPriceGrossCents: 0,
+                  ticketType: 'discounted' as const,
+                  subtotalNetCents: 0,
+                  discountAmountCents: 0,
+                  totalNetCents: 0,
+                  vatAmountCents: 0,
+                  totalGrossCents: 0,
+              }
+            : calculatePricing(conference, input.tickets.length, discountPriceCents)
 
         const orderNumber = generateOrderNumber()
-        const orderPayload = buildOrderPayload(input, orderNumber, pricing, discountCodeId)
+        const orderPayload = buildOrderPayload(input, orderNumber, pricing, discountCodeId, isInternal)
         const order = await directus.createTicketOrder(orderPayload)
         const orderId = order.id
         const websiteUrl = WEBSITE_URL

--- a/nuxt-app/server/api/tickets/validate-discount.post.ts
+++ b/nuxt-app/server/api/tickets/validate-discount.post.ts
@@ -56,6 +56,7 @@ export default defineEventHandler(async (event) => {
         discountPriceCents: discountCode.price_cents,
         discountLabel: discountCode.label,
         discountAmountCents,
+        isEmployeeCode: discountCode.is_employee_code === true,
         message: 'Rabattcode erfolgreich angewendet!',
     }
 })

--- a/nuxt-app/server/utils/authenticatedDirectus.ts
+++ b/nuxt-app/server/utils/authenticatedDirectus.ts
@@ -91,7 +91,7 @@ export function useAuthenticatedDirectus() {
                     conference: { _eq: conferenceId },
                     active: { _eq: true },
                 },
-                fields: ['id', 'conference', 'code', 'price_cents', 'label', 'max_uses', 'active'],
+                fields: ['id', 'conference', 'code', 'price_cents', 'label', 'max_uses', 'active', 'is_employee_code'],
             })
         )
         const upperCode = code.toUpperCase()
@@ -109,6 +109,7 @@ export function useAuthenticatedDirectus() {
                     filter: {
                         conference: { _eq: conferenceId },
                         status: { _neq: 'cancelled' },
+                        is_internal: { _neq: true },
                     },
                 },
             })
@@ -239,6 +240,7 @@ export function useAuthenticatedDirectus() {
                     filter: {
                         conference: { _eq: conferenceId },
                         status: { _eq: 'checked_in' },
+                        is_internal: { _neq: true },
                     },
                 },
             })

--- a/nuxt-app/types/directus.ts
+++ b/nuxt-app/types/directus.ts
@@ -498,6 +498,7 @@ export interface DirectusTicketOrderItem {
     total_gross_cents: number
     invoice_number: string | null
     invoice_file: string | null // Reference to directus_files ID
+    is_internal: boolean
 }
 
 export type TicketProfileStatus = 'pending' | 'completed'
@@ -525,6 +526,7 @@ export interface DirectusTicketItem {
     last_event_visited: string | null
     heard_about_from: string | null
     additional_notes: string | null
+    is_internal: boolean
 }
 
 export interface DirectusTicketDiscountCodeItem {
@@ -535,4 +537,5 @@ export interface DirectusTicketDiscountCodeItem {
     label: string | null
     max_uses: number | null
     active: boolean
+    is_employee_code: boolean
 }


### PR DESCRIPTION
## Summary
- Adds an `is_employee_code` flag on discount codes that triggers a free internal ticket flow: zero pricing, no Stripe, no invoice, no purchaser confirmation email.
- Marks resulting orders and tickets as `is_internal` so they're excluded from capacity checks, ticket-sales stats, and check-in stats.
- Updates the review step UI to show a "Mitarbeiter-Code" label, a confirmation message, and a "Ticket bestätigen" button when an employee code is applied (also overrides early bird so the discount line is shown).
- Skips invoice generation and purchaser email in the Directus order-processing hook for internal orders, while still issuing tickets and profile-invitation emails to attendees.

## Test plan
- [ ] Apply an employee discount code in the ticket flow and confirm pricing drops to €0, the review step shows the "Mitarbeiter-Code" label and "Ticket bestätigen" button, and submission succeeds without a Stripe redirect
- [ ] Verify the resulting order/tickets have `is_internal=true` in Directus, no invoice was generated, and no purchaser confirmation email was sent (profile invitations to attendees should still go out)
- [ ] Confirm internal tickets do not count toward `ticket_max_quantity`, the ticket-sales stats endpoint, or the check-in stats endpoint
- [ ] Re-test a regular discount code and a regular paid checkout to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)