### PR TITLE
Update nuxt-app @directus/sdk from 17 to 21

### DIFF
--- a/nuxt-app/package-lock.json
+++ b/nuxt-app/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.0.0",
             "hasInstallScript": true,
             "dependencies": {
-                "@directus/sdk": "^17.0.0",
+                "@directus/sdk": "^21.3.0",
                 "@google/generative-ai": "^0.24.1",
                 "@nuxtjs/tailwindcss": "^6.11.4",
                 "@pinia/nuxt": "^0.5.1",
@@ -822,11 +822,12 @@
             }
         },
         "node_modules/@directus/sdk": {
-            "version": "17.0.2",
-            "resolved": "https://registry.npmjs.org/@directus/sdk/-/sdk-17.0.2.tgz",
-            "integrity": "sha512-gKfWH6oQKnHw6mUl5lM32PTjtWrmSF6f09/zfN/74FKGPD853srCwip6rGif2R0GfdcrPHXwGHc7vTMXNDlniw==",
+            "version": "21.3.0",
+            "resolved": "https://registry.npmjs.org/@directus/sdk/-/sdk-21.3.0.tgz",
+            "integrity": "sha512-ozK2OmlaBiCuP5RuL046CaGGqEnlOdl4Rg690qaOgbC0C45XnDZVeBlb+NDLTUqEj88iSX8Cv74G3qh0L2i7Yw==",
+            "license": "MIT",
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=22"
             },
             "funding": {
                 "url": "https://github.com/directus/directus?sponsor=1"

--- a/nuxt-app/package.json
+++ b/nuxt-app/package.json
@@ -12,7 +12,7 @@
         "prettier": "prettier . --write"
     },
     "dependencies": {
-        "@directus/sdk": "^17.0.0",
+        "@directus/sdk": "^21.3.0",
         "@google/generative-ai": "^0.24.1",
         "@nuxtjs/tailwindcss": "^6.11.4",
         "@pinia/nuxt": "^0.5.1",

--- a/nuxt-app/types/directus.ts
+++ b/nuxt-app/types/directus.ts
@@ -327,7 +327,7 @@ export interface DirectusHomePage {
     intro_heading: string
     highlights_heading: string
     meetup_heading: string
-    highlights: any[],
+    highlights: { id: number; collection: string; item: any }[],
     video: DirectusFileItem
     news: { text: string }[]
     podcast_heading: string


### PR DESCRIPTION
## Summary
- Bumps `nuxt-app/@directus/sdk` from `^17.0.0` to `^21.3.0`, aligning with the version used in `directus-cms`.
- Tightens `DirectusHomePage.highlights` from `any[]` to its actual junction shape so the new SDK's stricter field-selection inference can resolve `highlights.item.*`.
- The only behaviour-relevant SDK breaking change (login/refresh/logout moved to options-object signatures in v20) does not affect this app — the sole call site is `directus.refresh()` with no arguments, which remains compatible.

## Test plan
- [x] `npm install` clean
- [x] `npx nuxt typecheck`: error count back to baseline (no new errors introduced by the bump)
- [x] `npm run build` succeeds
- [ ] Smoke-test the homepage and login flow on a deployed preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)