### PR TITLE
Pin isomorphic-dompurify to 2.20 to keep dep tree CJS

### DIFF
--- a/nuxt-app/package-lock.json
+++ b/nuxt-app/package-lock.json
@@ -20,7 +20,7 @@
                 "core-js": "^3.36.0",
                 "h3-zod": "^0.5.3",
                 "html5-qrcode": "^2.3.8",
-                "isomorphic-dompurify": "^2.12.0",
+                "isomorphic-dompurify": "~2.20.0",
                 "nodemailer": "^8.0.7",
                 "nuxt-jsonld": "^2.0.8",
                 "pinia": "^2.1.7",
@@ -47,14 +47,8 @@
                 "prettier-plugin-tailwindcss": "^0.5.11"
             },
             "engines": {
-                "node": ">=22.12.0"
+                "node": "^22.12.0"
             }
-        },
-        "node_modules/@acemir/cssom": {
-            "version": "0.9.31",
-            "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
-            "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-            "license": "MIT"
         },
         "node_modules/@algolia/cache-browser-local-storage": {
             "version": "4.27.0",
@@ -272,48 +266,23 @@
             }
         },
         "node_modules/@asamuzakjp/css-color": {
-            "version": "5.1.11",
-            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
-            "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+            "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
             "license": "MIT",
             "dependencies": {
-                "@asamuzakjp/generational-cache": "^1.0.1",
-                "@csstools/css-calc": "^3.2.0",
-                "@csstools/css-color-parser": "^4.1.0",
-                "@csstools/css-parser-algorithms": "^4.0.0",
-                "@csstools/css-tokenizer": "^4.0.0"
-            },
-            "engines": {
-                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+                "@csstools/css-calc": "^2.1.3",
+                "@csstools/css-color-parser": "^3.0.9",
+                "@csstools/css-parser-algorithms": "^3.0.4",
+                "@csstools/css-tokenizer": "^3.0.3",
+                "lru-cache": "^10.4.3"
             }
         },
-        "node_modules/@asamuzakjp/dom-selector": {
-            "version": "6.8.1",
-            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
-            "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@asamuzakjp/nwsapi": "^2.3.9",
-                "bidi-js": "^1.0.3",
-                "css-tree": "^3.1.0",
-                "is-potential-custom-element-name": "^1.0.1",
-                "lru-cache": "^11.2.6"
-            }
-        },
-        "node_modules/@asamuzakjp/generational-cache": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
-            "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
-            "license": "MIT",
-            "engines": {
-                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@asamuzakjp/nwsapi": {
-            "version": "2.3.9",
-            "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
-            "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-            "license": "MIT"
+        "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "license": "ISC"
         },
         "node_modules/@babel/code-frame": {
             "version": "7.29.0",
@@ -780,18 +749,6 @@
                 }
             }
         },
-        "node_modules/@bramus/specificity": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
-            "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
-            "license": "MIT",
-            "dependencies": {
-                "css-tree": "^3.0.0"
-            },
-            "bin": {
-                "specificity": "bin/cli.js"
-            }
-        },
         "node_modules/@clack/core": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.3.0.tgz",
@@ -840,9 +797,9 @@
             "license": "MIT"
         },
         "node_modules/@csstools/color-helpers": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
-            "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+            "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
             "funding": [
                 {
                     "type": "github",
@@ -855,13 +812,13 @@
             ],
             "license": "MIT-0",
             "engines": {
-                "node": ">=20.19.0"
+                "node": ">=18"
             }
         },
         "node_modules/@csstools/css-calc": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
-            "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+            "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
             "funding": [
                 {
                     "type": "github",
@@ -874,17 +831,17 @@
             ],
             "license": "MIT",
             "engines": {
-                "node": ">=20.19.0"
+                "node": ">=18"
             },
             "peerDependencies": {
-                "@csstools/css-parser-algorithms": "^4.0.0",
-                "@csstools/css-tokenizer": "^4.0.0"
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
             }
         },
         "node_modules/@csstools/css-color-parser": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
-            "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+            "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
             "funding": [
                 {
                     "type": "github",
@@ -897,21 +854,21 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@csstools/color-helpers": "^6.0.2",
-                "@csstools/css-calc": "^3.2.0"
+                "@csstools/color-helpers": "^5.1.0",
+                "@csstools/css-calc": "^2.1.4"
             },
             "engines": {
-                "node": ">=20.19.0"
+                "node": ">=18"
             },
             "peerDependencies": {
-                "@csstools/css-parser-algorithms": "^4.0.0",
-                "@csstools/css-tokenizer": "^4.0.0"
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
             }
         },
         "node_modules/@csstools/css-parser-algorithms": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
-            "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+            "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
             "funding": [
                 {
                     "type": "github",
@@ -924,40 +881,16 @@
             ],
             "license": "MIT",
             "engines": {
-                "node": ">=20.19.0"
+                "node": ">=18"
             },
             "peerDependencies": {
-                "@csstools/css-tokenizer": "^4.0.0"
-            }
-        },
-        "node_modules/@csstools/css-syntax-patches-for-csstree": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
-            "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/csstools"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/csstools"
-                }
-            ],
-            "license": "MIT-0",
-            "peerDependencies": {
-                "css-tree": "^3.2.1"
-            },
-            "peerDependenciesMeta": {
-                "css-tree": {
-                    "optional": true
-                }
+                "@csstools/css-tokenizer": "^3.0.4"
             }
         },
         "node_modules/@csstools/css-tokenizer": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
-            "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+            "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
             "funding": [
                 {
                     "type": "github",
@@ -970,7 +903,7 @@
             ],
             "license": "MIT",
             "engines": {
-                "node": ">=20.19.0"
+                "node": ">=18"
             }
         },
         "node_modules/@directus/sdk": {
@@ -1727,23 +1660,6 @@
             },
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || >=24"
-            }
-        },
-        "node_modules/@exodus/bytes": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
-            "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
-            "license": "MIT",
-            "engines": {
-                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-            },
-            "peerDependencies": {
-                "@noble/hashes": "^1.8.0 || ^2.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@noble/hashes": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@fastify/accept-negotiator": {
@@ -6622,15 +6538,6 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/bidi-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
-            "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-            "license": "MIT",
-            "dependencies": {
-                "require-from-string": "^2.0.2"
-            }
-        },
         "node_modules/binary-extensions": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -7455,6 +7362,7 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
             "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "mdn-data": "2.27.1",
@@ -7609,18 +7517,16 @@
             "license": "CC0-1.0"
         },
         "node_modules/cssstyle": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
-            "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+            "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
             "license": "MIT",
             "dependencies": {
-                "@asamuzakjp/css-color": "^5.0.1",
-                "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
-                "css-tree": "^3.1.0",
-                "lru-cache": "^11.2.6"
+                "@asamuzakjp/css-color": "^3.2.0",
+                "rrweb-cssom": "^0.8.0"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=18"
             }
         },
         "node_modules/csstype": {
@@ -7630,16 +7536,16 @@
             "license": "MIT"
         },
         "node_modules/data-urls": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
-            "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+            "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
             "license": "MIT",
             "dependencies": {
-                "whatwg-mimetype": "^5.0.0",
-                "whatwg-url": "^16.0.0"
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.0.0"
             },
             "engines": {
-                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+                "node": ">=18"
             }
         },
         "node_modules/db0": {
@@ -9435,15 +9341,15 @@
             "license": "Apache-2.0"
         },
         "node_modules/html-encoding-sniffer": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
-            "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+            "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
             "license": "MIT",
             "dependencies": {
-                "@exodus/bytes": "^1.6.0"
+                "whatwg-encoding": "^3.1.1"
             },
             "engines": {
-                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+                "node": ">=18"
             }
         },
         "node_modules/html5-qrcode": {
@@ -9592,6 +9498,18 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=16.17.0"
+            }
+        },
+        "node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/ieee754": {
@@ -10083,16 +10001,16 @@
             "license": "ISC"
         },
         "node_modules/isomorphic-dompurify": {
-            "version": "2.36.0",
-            "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-2.36.0.tgz",
-            "integrity": "sha512-E8YkGyPY3a/U5s0WOoc8Ok+3SWL/33yn2IHCoxCFLBUUPVy9WGa++akJZFxQCcJIhI+UvYhbrbnTIFQkHKZbgA==",
+            "version": "2.20.0",
+            "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-2.20.0.tgz",
+            "integrity": "sha512-zOq12fJPtNE+4dPd2S0xpWXl8NZj0C6k2xikT1yl/Lv/5p3QLafZqlVFy4xTGU9qHSkyEENcIbp2c0oahCNRYg==",
             "license": "MIT",
             "dependencies": {
-                "dompurify": "^3.3.1",
-                "jsdom": "^28.0.0"
+                "dompurify": "^3.2.3",
+                "jsdom": "^26.0.0"
             },
             "engines": {
-                "node": ">=20.19.5"
+                "node": ">=18"
             }
         },
         "node_modules/jackspeak": {
@@ -10141,35 +10059,34 @@
             }
         },
         "node_modules/jsdom": {
-            "version": "28.1.0",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
-            "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+            "version": "26.1.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+            "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
             "license": "MIT",
             "dependencies": {
-                "@acemir/cssom": "^0.9.31",
-                "@asamuzakjp/dom-selector": "^6.8.1",
-                "@bramus/specificity": "^2.4.2",
-                "@exodus/bytes": "^1.11.0",
-                "cssstyle": "^6.0.1",
-                "data-urls": "^7.0.0",
-                "decimal.js": "^10.6.0",
-                "html-encoding-sniffer": "^6.0.0",
+                "cssstyle": "^4.2.1",
+                "data-urls": "^5.0.0",
+                "decimal.js": "^10.5.0",
+                "html-encoding-sniffer": "^4.0.0",
                 "http-proxy-agent": "^7.0.2",
                 "https-proxy-agent": "^7.0.6",
                 "is-potential-custom-element-name": "^1.0.1",
-                "parse5": "^8.0.0",
+                "nwsapi": "^2.2.16",
+                "parse5": "^7.2.1",
+                "rrweb-cssom": "^0.8.0",
                 "saxes": "^6.0.0",
                 "symbol-tree": "^3.2.4",
-                "tough-cookie": "^6.0.0",
-                "undici": "^7.21.0",
+                "tough-cookie": "^5.1.1",
                 "w3c-xmlserializer": "^5.0.0",
-                "webidl-conversions": "^8.0.1",
-                "whatwg-mimetype": "^5.0.0",
-                "whatwg-url": "^16.0.0",
+                "webidl-conversions": "^7.0.0",
+                "whatwg-encoding": "^3.1.1",
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.1.1",
+                "ws": "^8.18.0",
                 "xml-name-validator": "^5.0.0"
             },
             "engines": {
-                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+                "node": ">=18"
             },
             "peerDependencies": {
                 "canvas": "^3.0.0"
@@ -10701,6 +10618,7 @@
             "version": "11.3.6",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
             "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
@@ -10816,6 +10734,7 @@
             "version": "2.27.1",
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
             "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+            "dev": true,
             "license": "CC0-1.0"
         },
         "node_modules/media-typer": {
@@ -11705,6 +11624,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/nwsapi": {
+            "version": "2.2.23",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+            "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+            "license": "MIT"
+        },
         "node_modules/nypm": {
             "version": "0.6.6",
             "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.6.tgz",
@@ -12076,24 +12001,24 @@
             }
         },
         "node_modules/parse5": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
-            "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+            "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
             "license": "MIT",
             "dependencies": {
-                "entities": "^8.0.0"
+                "entities": "^6.0.0"
             },
             "funding": {
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
         "node_modules/parse5/node_modules/entities": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
-            "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
             "license": "BSD-2-Clause",
             "engines": {
-                "node": ">=20.19.0"
+                "node": ">=0.12"
             },
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
@@ -13703,15 +13628,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/require-from-string": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/resolve": {
             "version": "1.22.12",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -13963,6 +13879,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/rrweb-cssom": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+            "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+            "license": "MIT"
+        },
         "node_modules/run-applescript": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -14035,6 +13957,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "license": "MIT"
         },
         "node_modules/sax": {
             "version": "1.6.0",
@@ -15258,21 +15186,21 @@
             }
         },
         "node_modules/tldts": {
-            "version": "7.0.30",
-            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
-            "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+            "version": "6.1.86",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+            "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
             "license": "MIT",
             "dependencies": {
-                "tldts-core": "^7.0.30"
+                "tldts-core": "^6.1.86"
             },
             "bin": {
                 "tldts": "bin/cli.js"
             }
         },
         "node_modules/tldts-core": {
-            "version": "7.0.30",
-            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
-            "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+            "version": "6.1.86",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+            "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
             "license": "MIT"
         },
         "node_modules/to-regex-range": {
@@ -15307,27 +15235,27 @@
             }
         },
         "node_modules/tough-cookie": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
-            "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+            "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "tldts": "^7.0.5"
+                "tldts": "^6.1.32"
             },
             "engines": {
                 "node": ">=16"
             }
         },
         "node_modules/tr46": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-            "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+            "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
             "license": "MIT",
             "dependencies": {
                 "punycode": "^2.3.1"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=18"
             }
         },
         "node_modules/ts-api-utils": {
@@ -15513,15 +15441,6 @@
             },
             "engines": {
                 "node": ">=18.12.0"
-            }
-        },
-        "node_modules/undici": {
-            "version": "7.25.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-            "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=20.18.1"
             }
         },
         "node_modules/undici-types": {
@@ -16918,12 +16837,12 @@
             }
         },
         "node_modules/webidl-conversions": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-            "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
             "license": "BSD-2-Clause",
             "engines": {
-                "node": ">=20"
+                "node": ">=12"
             }
         },
         "node_modules/webpack-virtual-modules": {
@@ -16932,27 +16851,39 @@
             "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
             "license": "MIT"
         },
+        "node_modules/whatwg-encoding": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+            "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+            "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+            "license": "MIT",
+            "dependencies": {
+                "iconv-lite": "0.6.3"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/whatwg-mimetype": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
-            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
             "license": "MIT",
             "engines": {
-                "node": ">=20"
+                "node": ">=18"
             }
         },
         "node_modules/whatwg-url": {
-            "version": "16.0.1",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
-            "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+            "version": "14.2.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+            "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
             "license": "MIT",
             "dependencies": {
-                "@exodus/bytes": "^1.11.0",
-                "tr46": "^6.0.0",
-                "webidl-conversions": "^8.0.1"
+                "tr46": "^5.1.0",
+                "webidl-conversions": "^7.0.0"
             },
             "engines": {
-                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+                "node": ">=18"
             }
         },
         "node_modules/which": {
@@ -17092,7 +17023,6 @@
             "version": "8.20.0",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
             "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"

--- a/nuxt-app/package.json
+++ b/nuxt-app/package.json
@@ -3,7 +3,7 @@
     "version": "0.0.0",
     "private": true,
     "engines": {
-        "node": ">=22.12.0"
+        "node": "^22.12.0"
     },
     "scripts": {
         "build": "nuxt build",
@@ -26,7 +26,7 @@
         "core-js": "^3.36.0",
         "h3-zod": "^0.5.3",
         "html5-qrcode": "^2.3.8",
-        "isomorphic-dompurify": "^2.12.0",
+        "isomorphic-dompurify": "~2.20.0",
         "nodemailer": "^8.0.7",
         "nuxt-jsonld": "^2.0.8",
         "pinia": "^2.1.7",


### PR DESCRIPTION
## Summary
Vercel is still crashing with `ERR_REQUIRE_ESM` against `@exodus/bytes` because PR #174 was merged with **only** the first commit (the `.nvmrc` bump). The follow-up commits that contained the actual dep fix never made it to main, so the lockfile on `main` still has `isomorphic-dompurify@2.36` → `jsdom@28` → `@exodus/bytes` (ESM-only).

This PR applies that follow-up cleanly on top of current `main`:
- Pin `isomorphic-dompurify` to `~2.20.0` — the version that was deployed and working before #173's lockfile regen pulled it forward. jsdom resolves naturally to `26.1.0` (CJS, no `@exodus/bytes` dep).
- Tighten `engines.node` from `">=22.12.0"` to `"^22.12.0"` so deploys can't drift onto Node 24.

The Vercel serverless runtime (`/opt/rust/nodejs.js`) doesn't implement Node 22.12+'s `require(esm)` interop, which is why bumping Node alone wasn't enough — the dep tree itself needed to stay pure CJS.

## Verification
- All 20 oxc-parser platform bindings preserved in lockfile
- `isomorphic-dompurify@2.20.0`, `jsdom@26.1.0` (no `@exodus/bytes`)
- `npm audit`: 0 vulnerabilities

## Test plan
- [ ] Vercel build completes without ERR_REQUIRE_ESM at startup
- [ ] Live site serves pages again

🤖 Generated with [Claude Code](https://claude.com/claude-code)