### PR TITLE
Refine German copy across ticket purchase and completion flow

### DIFF
--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/wallet-pass-generator.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/wallet-pass-generator.ts
@@ -134,7 +134,7 @@ export async function generateAppleWalletPass(
     pass.secondaryFields.push(
         {
             key: 'attendee',
-            label: 'TEILNEHMER',
+            label: 'TEILNEHMER:IN',
             value: input.attendeeName,
         },
         {

--- a/nuxt-app/components/tickets/TicketPricingSummary.vue
+++ b/nuxt-app/components/tickets/TicketPricingSummary.vue
@@ -20,7 +20,7 @@ const store = useTicketCheckoutStore()
 
         <div class="space-y-2 text-sm">
             <div class="flex justify-between text-gray-300">
-                <span>{{ store.ticketCount }}x Ticket</span>
+                <span>{{ store.ticketCount }}× Ticket</span>
                 <span>{{ store.formatPrice(store.unitPriceCents) }}</span>
             </div>
 
@@ -29,7 +29,7 @@ const store = useTicketCheckoutStore()
             </div>
 
             <div v-if="store.discountValid && (store.isEmployeeCode || !store.isEarlyBird)" class="flex justify-between text-lime">
-                <span>{{ store.isEmployeeCode ? 'Mitarbeiter-Code' : `Rabatt (${store.discountCode})` }}</span>
+                <span>{{ store.isEmployeeCode ? 'Team-Code' : `Rabatt (${store.discountCode})` }}</span>
                 <span>-{{ store.formatPrice(store.discountAmountCents) }}</span>
             </div>
 
@@ -42,7 +42,7 @@ const store = useTicketCheckoutStore()
                     <span>{{ store.formatPrice(store.totalCents) }}</span>
                 </div>
 
-                <p class="mt-2 text-xs text-[#848a98]">Alle Preise netto zzgl. {{ VAT_RATE_PERCENT }}% MwSt.</p>
+                <p class="mt-2 text-xs text-[#848a98]">Alle Preise netto zzgl. {{ VAT_RATE_PERCENT }} % MwSt.</p>
             </template>
 
             <!-- VAT breakdown view (Steps 3-4) -->
@@ -55,7 +55,7 @@ const store = useTicketCheckoutStore()
                 </div>
 
                 <div class="flex justify-between text-gray-300">
-                    <span>zzgl. {{ VAT_RATE_PERCENT }}% MwSt.</span>
+                    <span>zzgl. {{ VAT_RATE_PERCENT }} % MwSt.</span>
                     <span>{{ store.formatPrice(store.vatAmountCents) }}</span>
                 </div>
 
@@ -66,7 +66,7 @@ const store = useTicketCheckoutStore()
                     <span>{{ store.formatPrice(store.totalWithVatCents) }}</span>
                 </div>
 
-                <p class="mt-2 text-xs text-[#848a98]">Bruttopreis inkl. {{ VAT_RATE_PERCENT }}% MwSt.</p>
+                <p class="mt-2 text-xs text-[#848a98]">Bruttopreis inkl. {{ VAT_RATE_PERCENT }} % MwSt.</p>
             </template>
         </div>
     </div>

--- a/nuxt-app/components/tickets/TicketStepAttendees.vue
+++ b/nuxt-app/components/tickets/TicketStepAttendees.vue
@@ -45,9 +45,9 @@ function copyPurchaserInfo(index: number) {
 
 <template>
     <div class="ticket-step-attendees">
-        <h2 class="mb-2 text-3xl font-bold text-white md:text-4xl">Teilnehmerdaten</h2>
+        <h2 class="mb-2 text-3xl font-bold text-white md:text-4xl">Teilnehmenden-Daten</h2>
         <p class="mb-8 text-lg text-gray-300">
-            Bitte gib die Daten für {{ store.ticketCount === 1 ? 'den Teilnehmer' : 'alle Teilnehmer' }} ein.
+            Bitte gib die Daten aller Teilnehmenden ein.
         </p>
 
         <!-- Attendee forms -->
@@ -70,7 +70,7 @@ function copyPurchaserInfo(index: number) {
                         class="text-sm text-lime hover:underline"
                         @click="copyPurchaserInfo(index)"
                     >
-                        Käuferdaten übernehmen
+                        Käufer:innen-Daten übernehmen
                     </button>
                 </div>
 
@@ -82,7 +82,7 @@ function copyPurchaserInfo(index: number) {
                         <input
                             :value="attendee.firstName"
                             type="text"
-                            placeholder="Max"
+                            placeholder="Mika"
                             class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 text-white placeholder-gray-500 focus:border-lime focus:outline-none"
                             @input="updateAttendee(index, 'firstName', ($event.target as HTMLInputElement).value)"
                         />
@@ -95,7 +95,7 @@ function copyPurchaserInfo(index: number) {
                         <input
                             :value="attendee.lastName"
                             type="text"
-                            placeholder="Mustermann"
+                            placeholder="Muster"
                             class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 text-white placeholder-gray-500 focus:border-lime focus:outline-none"
                             @input="updateAttendee(index, 'lastName', ($event.target as HTMLInputElement).value)"
                         />
@@ -108,7 +108,7 @@ function copyPurchaserInfo(index: number) {
                         <input
                             :value="attendee.email"
                             type="email"
-                            placeholder="max@beispiel.de"
+                            placeholder="mika@beispiel.de"
                             class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 text-white placeholder-gray-500 focus:border-lime focus:outline-none"
                             @input="updateAttendee(index, 'email', ($event.target as HTMLInputElement).value)"
                         />

--- a/nuxt-app/components/tickets/TicketStepBilling.vue
+++ b/nuxt-app/components/tickets/TicketStepBilling.vue
@@ -91,7 +91,7 @@ function updatePersonalAddressField(field: keyof NonNullable<typeof store.person
 <template>
     <div class="ticket-step-billing">
         <h2 class="mb-2 text-3xl font-bold text-white md:text-4xl">Rechnungsdaten</h2>
-        <p class="mb-8 text-lg text-gray-300">Wer bezahlt die Tickets?</p>
+        <p class="mb-8 text-lg text-gray-300">Bitte gib die Daten ein, die auf der Rechnung stehen sollen.</p>
 
         <!-- Purchase type toggle -->
         <div class="mb-8">
@@ -125,7 +125,7 @@ function updatePersonalAddressField(field: keyof NonNullable<typeof store.person
 
         <!-- Purchaser info -->
         <div class="mb-8 rounded-lg border border-gray-700 bg-gray-800/50 p-6">
-            <h3 class="mb-4 text-lg font-bold text-white">Käufer</h3>
+            <h3 class="mb-4 text-lg font-bold text-white">Käufer:in</h3>
 
             <div class="grid gap-4 md:grid-cols-2">
                 <div>
@@ -135,7 +135,7 @@ function updatePersonalAddressField(field: keyof NonNullable<typeof store.person
                     <input
                         :value="store.purchaser.firstName"
                         type="text"
-                        placeholder="Max"
+                        placeholder="Mika"
                         class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 text-white placeholder-gray-500 focus:border-lime focus:outline-none"
                         @input="updatePurchaser('firstName', ($event.target as HTMLInputElement).value)"
                     />
@@ -148,7 +148,7 @@ function updatePersonalAddressField(field: keyof NonNullable<typeof store.person
                     <input
                         :value="store.purchaser.lastName"
                         type="text"
-                        placeholder="Mustermann"
+                        placeholder="Muster"
                         class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 text-white placeholder-gray-500 focus:border-lime focus:outline-none"
                         @input="updatePurchaser('lastName', ($event.target as HTMLInputElement).value)"
                     />
@@ -161,12 +161,12 @@ function updatePersonalAddressField(field: keyof NonNullable<typeof store.person
                     <input
                         :value="store.purchaser.email"
                         type="email"
-                        placeholder="max@beispiel.de"
+                        placeholder="mika@beispiel.de"
                         class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 text-white placeholder-gray-500 focus:border-lime focus:outline-none"
                         @input="updatePurchaser('email', ($event.target as HTMLInputElement).value)"
                     />
                     <p class="mt-1 text-xs text-[#848a98]">
-                        Bestellbestätigung wird an diese Adresse gesendet.
+                        Die Bestellbestätigung wird an diese Adresse gesendet.
                     </p>
                 </div>
             </div>
@@ -228,7 +228,7 @@ function updatePersonalAddressField(field: keyof NonNullable<typeof store.person
                         <input
                             :value="store.personalAddress.line2 || ''"
                             type="text"
-                            placeholder="z.B. Apartment 4, 2. Stock"
+                            placeholder="z. B. Apartment 4, 2. Stock"
                             class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 text-white placeholder-gray-500 focus:border-lime focus:outline-none"
                             @input="updatePersonalAddressField('line2', ($event.target as HTMLInputElement).value)"
                         />
@@ -237,7 +237,7 @@ function updatePersonalAddressField(field: keyof NonNullable<typeof store.person
                     <div class="grid gap-4 md:grid-cols-2">
                         <div>
                             <label class="mb-2 block text-sm font-bold text-gray-400">
-                                PLZ
+                                Postleitzahl
                             </label>
                             <input
                                 :value="store.personalAddress.postalCode || ''"
@@ -316,7 +316,7 @@ function updatePersonalAddressField(field: keyof NonNullable<typeof store.person
                     <input
                         :value="store.company.address.line2 || ''"
                         type="text"
-                        placeholder="z.B. Gebäude B, 3. Stock"
+                        placeholder="z. B. Gebäude B, 3. Stock"
                         class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 text-white placeholder-gray-500 focus:border-lime focus:outline-none"
                         @input="updateCompanyField('address.line2', ($event.target as HTMLInputElement).value)"
                     />
@@ -325,7 +325,7 @@ function updatePersonalAddressField(field: keyof NonNullable<typeof store.person
                 <div class="grid gap-4 md:grid-cols-2">
                     <div>
                         <label class="mb-2 block text-sm font-bold text-gray-400">
-                            PLZ <span class="text-lime">*</span>
+                            Postleitzahl <span class="text-lime">*</span>
                         </label>
                         <input
                             :value="store.company.address.postalCode"
@@ -388,7 +388,7 @@ function updatePersonalAddressField(field: keyof NonNullable<typeof store.person
                         @input="updateCompanyField('billingEmail', ($event.target as HTMLInputElement).value)"
                     />
                     <p class="mt-1 text-xs text-[#848a98]">
-                        Falls abweichend von der Käufer-E-Mail
+                        Falls abweichend von der Käufer:innen-E-Mail
                     </p>
                 </div>
             </div>

--- a/nuxt-app/components/tickets/TicketStepQuantity.vue
+++ b/nuxt-app/components/tickets/TicketStepQuantity.vue
@@ -51,7 +51,7 @@ function incrementTickets() {
 
 <template>
     <div class="ticket-step-quantity">
-        <h2 class="mb-2 text-3xl font-bold text-white md:text-4xl">Tickets kaufen</h2>
+        <h2 class="mb-2 text-3xl font-bold text-white md:text-4xl">Tickets sichern</h2>
         <p class="mb-8 text-lg text-gray-300">{{ conferenceTitle }}</p>
 
         <!-- Ticket count selector -->
@@ -95,18 +95,18 @@ function incrementTickets() {
             <div class="flex items-center justify-between">
                 <div>
                     <p class="text-white">
-                        <span v-if="store.isEarlyBird" class="font-bold text-lime">Early Bird Preis</span>
-                        <span v-else>Regulärer Preis</span>
+                        <span v-if="store.isEarlyBird" class="font-bold text-lime">Early Bird</span>
+                        <span v-else>Regulär</span>
                     </p>
                     <p v-if="store.isEarlyBird && formattedEarlyBirdDeadline" class="text-sm text-gray-400">
-                        Gültig bis {{ formattedEarlyBirdDeadline }}
+                        Verfügbar bis {{ formattedEarlyBirdDeadline }}
                     </p>
                 </div>
                 <p class="text-2xl font-bold text-white">
                     {{ store.formatPrice(store.unitPriceCents) }}
                 </p>
             </div>
-            <p class="mt-2 text-xs text-[#848a98]">zzgl. {{ VAT_RATE_PERCENT }}% MwSt.</p>
+            <p class="mt-2 text-xs text-[#848a98]">zzgl. {{ VAT_RATE_PERCENT }} % MwSt.</p>
         </div>
 
         <!-- Pricing summary -->

--- a/nuxt-app/components/tickets/TicketStepReview.vue
+++ b/nuxt-app/components/tickets/TicketStepReview.vue
@@ -18,10 +18,10 @@ async function applyDiscountCode() {
     const valid = await store.validateDiscountCode()
     if (valid) {
         if (store.isEmployeeCode) {
-            discountMessage.value = 'Mitarbeiter-Code erkannt — keine Zahlung nötig.'
+            discountMessage.value = 'Team-Code erkannt – keine Zahlung nötig.'
         } else {
             discountMessage.value = store.pricingSettings?.discountLabel
-                ? `Rabattcode "${store.pricingSettings.discountLabel}" angewendet!`
+                ? `Rabattcode „${store.pricingSettings.discountLabel}“ angewendet!`
                 : 'Rabattcode erfolgreich angewendet!'
         }
     } else {
@@ -77,7 +77,7 @@ async function proceedToPayment() {
 
         <!-- Attendees summary -->
         <div class="mb-6 rounded-lg border border-gray-700 bg-gray-800/50 p-6">
-            <h3 class="mb-4 text-lg font-bold text-white">Teilnehmer ({{ store.ticketCount }})</h3>
+            <h3 class="mb-4 text-lg font-bold text-white">Teilnehmende ({{ store.ticketCount }})</h3>
             <div class="space-y-3">
                 <div
                     v-for="(attendee, index) in store.attendees"
@@ -209,14 +209,14 @@ async function proceedToPayment() {
             :disabled="!termsAccepted || store.isLoading"
             @click="proceedToPayment"
         >
-            <span v-if="store.isLoading">Wird verarbeitet...</span>
+            <span v-if="store.isLoading">Wird verarbeitet…</span>
             <span v-else-if="store.isEmployeeCode">Ticket bestätigen</span>
             <span v-else>Zur Zahlung</span>
         </button>
 
         <p class="mt-4 text-center text-sm text-[#848a98]">
             <span v-if="store.isEmployeeCode">
-                Mit dem Mitarbeiter-Code ist keine Zahlung nötig.
+                Durch den Team-Code ist keine Zahlung nötig.
             </span>
             <span v-else>
                 Du wirst zur sicheren Zahlungsseite von Stripe weitergeleitet.

--- a/nuxt-app/pages/konferenzen/[slug]/tickets/index.vue
+++ b/nuxt-app/pages/konferenzen/[slug]/tickets/index.vue
@@ -43,7 +43,7 @@ useHead(() =>
               type: 'website',
               path: route.path,
               title: `Tickets - ${conference.value.title}`,
-              description: `Tickets für die ${conference.value.title} kaufen`,
+              description: `Tickets für die ${conference.value.title} sichern`,
               image: conference.value.cover_image,
           })
         : {}
@@ -70,7 +70,7 @@ const breadcrumbs = computed(() => [
             >
                 <p class="font-medium">Zahlung abgebrochen</p>
                 <p class="text-yellow-200/80 mt-1 text-sm">
-                    Die Zahlung wurde abgebrochen. Du kannst es erneut versuchen.
+                    Die Zahlung wurde abgebrochen. Bitte versuche es erneut.
                 </p>
             </div>
 
@@ -110,7 +110,7 @@ const breadcrumbs = computed(() => [
 
             <!-- Loading state -->
             <div v-else class="text-center">
-                <p class="text-gray-400">Laden...</p>
+                <p class="text-gray-400">Lädt…</p>
             </div>
         </div>
     </div>

--- a/nuxt-app/pages/konferenzen/[slug]/tickets/success.vue
+++ b/nuxt-app/pages/konferenzen/[slug]/tickets/success.vue
@@ -105,7 +105,7 @@ useHead(() =>
         ? getMetaInfo({
               type: 'website',
               path: route.path,
-              title: `Bestellung erfolgreich - ${conference.value.title}`,
+              title: `Bestellung erfolgreich – ${conference.value.title}`,
               description: `Deine Tickets für die ${conference.value.title} wurden bestellt`,
               image: conference.value.cover_image,
           })
@@ -144,7 +144,7 @@ useHead(() =>
 
                 <!-- Loading state while polling -->
                 <div v-if="!pollingDone" class="mt-8 rounded-lg bg-gray-800/50 p-6">
-                    <p class="text-gray-300">Deine Tickets werden vorbereitet...</p>
+                    <p class="text-gray-300">Deine Tickets werden vorbereitet…</p>
                 </div>
 
                 <!-- Single ticket: show button to complete ticket -->
@@ -169,11 +169,11 @@ useHead(() =>
                     <ul class="space-y-3 text-gray-300">
                         <li class="flex items-start gap-3">
                             <span class="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-lime/20 text-xs text-lime">1</span>
-                            <span>Du erhältst in Kürze eine Bestätigungs-E-Mail.</span>
+                            <span>Du erhältst in Kürze eine Bestätigungsmail.</span>
                         </li>
                         <li class="flex items-start gap-3">
                             <span class="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-lime/20 text-xs text-lime">2</span>
-                            <span>Alle Teilnehmer erhalten eine E-Mail mit einem Link zur Vervollständigung ihrer Angaben.</span>
+                            <span>Alle Teilnehmenden erhalten eine E-Mail mit einem Link zur Vervollständigung ihrer Angaben.</span>
                         </li>
                         <li class="flex items-start gap-3">
                             <span class="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-lime/20 text-xs text-lime">3</span>
@@ -188,7 +188,7 @@ useHead(() =>
                     <ul class="space-y-3 text-gray-300">
                         <li class="flex items-start gap-3">
                             <span class="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-lime/20 text-xs text-lime">1</span>
-                            <span>Alle Teilnehmer erhalten eine E-Mail mit einem Link zur Vervollständigung ihrer Angaben.</span>
+                            <span>Alle Teilnehmenden erhalten eine E-Mail mit einem Link zur Vervollständigung ihrer Angaben.</span>
                         </li>
                         <li class="flex items-start gap-3">
                             <span class="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-lime/20 text-xs text-lime">2</span>
@@ -198,10 +198,9 @@ useHead(() =>
                 </div>
 
                 <p class="mt-8 text-sm text-[#848a98]">
-                    Keine E-Mail erhalten? Prüfe deinen Spam-Ordner oder kontaktiere uns unter
+                    Keine E-Mail erhalten? Bitte prüfe deinen Spam-Ordner oder kontaktiere uns unter
                     <a href="mailto:podcast@programmier.bar" class="text-lime hover:underline">
-                        podcast@programmier.bar
-                    </a>
+                        podcast@programmier.bar</a>.
                 </p>
 
                 <div class="mt-12 flex flex-col gap-4 sm:flex-row sm:justify-center">

--- a/nuxt-app/pages/ticket-portal.vue
+++ b/nuxt-app/pages/ticket-portal.vue
@@ -5,7 +5,7 @@
 
             <!-- Loading State -->
             <div v-if="loading" class="mt-16 text-center">
-                <p class="text-xl text-white">Zugang wird überprüft...</p>
+                <p class="text-xl text-white">Zugang wird überprüft…</p>
             </div>
 
             <!-- Error State -->
@@ -56,7 +56,7 @@
                                     v-model="formData.job_title"
                                     type="text"
                                     class="form-input"
-                                    placeholder="z.B. Senior Developer, CTO, Product Manager"
+                                    placeholder="z. B. Senior Developer, CTO, Product Managerin"
                                     required
                                     maxlength="100"
                                 />
@@ -81,7 +81,7 @@
                                     v-model="formData.pronouns"
                                     type="text"
                                     class="form-input"
-                                    placeholder="z.B. sie/ihr, er/ihm, they/them"
+                                    placeholder="z. B. sie/ihr, er/ihm, they/them"
                                     maxlength="50"
                                 />
                             </div>
@@ -100,7 +100,7 @@
                                     v-model="formData.dietary_preferences"
                                     type="text"
                                     class="form-input"
-                                    placeholder="z.B. vegetarisch, vegan, glutenfrei"
+                                    placeholder="z. B. vegetarisch, vegan, glutenfrei"
                                     maxlength="200"
                                 />
                             </div>
@@ -132,7 +132,7 @@
                                     v-model="formData.last_event_visited"
                                     type="text"
                                     class="form-input"
-                                    placeholder="z.B. San Juan Conf 2025, programmier.bar Meetup #42"
+                                    placeholder="z. B. San Juan Conf 2025, programmier.bar Meetup #42"
                                     maxlength="200"
                                 />
                             </div>
@@ -144,7 +144,7 @@
                                     v-model="formData.heard_about_from"
                                     type="text"
                                     class="form-input"
-                                    placeholder="z.B. Podcast, Social Media, Empfehlung"
+                                    placeholder="z. B. Podcast, Social Media, Empfehlung"
                                     maxlength="500"
                                 />
                             </div>
@@ -175,7 +175,7 @@
                             class="h-14 w-64 rounded-full border-4 border-lime text-sm font-black uppercase tracking-widest text-lime transition-all hover:bg-lime hover:text-black disabled:cursor-not-allowed disabled:opacity-50 md:h-16 md:w-80 md:border-5 md:text-lg lg:h-20 lg:w-112 lg:border-6 lg:text-xl"
                             :disabled="formState === 'submitting'"
                         >
-                            {{ formState === 'submitting' ? 'Wird gesendet...' : 'Absenden' }}
+                            {{ formState === 'submitting' ? 'Wird gesendet…' : 'Absenden' }}
                         </button>
                     </div>
                 </form>

--- a/nuxt-app/server/api/ticket-portal/submit.post.ts
+++ b/nuxt-app/server/api/ticket-portal/submit.post.ts
@@ -74,7 +74,7 @@ export default defineEventHandler(async (event) => {
         console.error('Ticket portal submission error:', err)
         throw createError({
             statusCode: 500,
-            message: 'Ein Fehler ist beim Speichern deiner Angaben aufgetreten.',
+            message: 'Beim Speichern deiner Angaben ist ein Fehler aufgetreten.',
         })
     }
 })

--- a/nuxt-app/server/api/ticket-portal/validate.get.ts
+++ b/nuxt-app/server/api/ticket-portal/validate.get.ts
@@ -55,7 +55,7 @@ export default defineEventHandler(async (event) => {
         console.error('Ticket portal validation error:', err)
         throw createError({
             statusCode: 500,
-            message: 'Ein Fehler ist bei der Überprüfung deines Zugangs aufgetreten.',
+            message: 'Bei der Überprüfung deines Zugangs ist ein Fehler aufgetreten.',
         })
     }
 })


### PR DESCRIPTION
## Summary
- Editorial pass on user-facing German strings in the ticket purchase steps (quantity, attendees, billing, review, pricing summary, success page) and the cancelled/sold-out states on the index page.
- Updates to the ticket-portal completion form and its `validate`/`submit` API error messages, plus the Apple Wallet pass label (TEILNEHMER → TEILNEHMER:IN).
- Changes include gender-inclusive phrasing (Teilnehmende, Käufer:in, Team-Code), German typography (ellipsis …, en/em dashes, „…", `z. B.`, `{n} %`), and minor wording cleanups.

## Test plan
- [ ] Walk through `/konferenzen/[slug]/tickets` from quantity → review and verify all updated labels, placeholders, and helper texts.
- [ ] Trigger the cancelled banner via a Stripe cancel redirect and the sold-out / capacity error paths.
- [ ] Open the ticket completion link (`/ticket-portal?token=…`) and check headings, placeholders, validation, and the success/error states.
- [ ] Generate an Apple Wallet `.pkpass` and confirm the attendee label reads "TEILNEHMER:IN".