### PR TITLE
Fix 404 on ticket purchase page refresh

### DIFF
--- a/nuxt-app/nuxt.config.ts
+++ b/nuxt-app/nuxt.config.ts
@@ -174,6 +174,7 @@ export default defineNuxtConfig({
     routeRules: {
         '/**': { isr: true },
 
+        '/konferenz/*/tickets': { isr: false },
         '/konferenz/*/tickets/**': { isr: false },
         '/ticket-portal': { isr: false },
         '/speaker-portal': { isr: false },


### PR DESCRIPTION
## Summary
- Add an explicit `isr: false` rule for `/konferenz/*/tickets` alongside the existing `/konferenz/*/tickets/**` rule.
- The Nitro Vercel preset compiles `/konferenz/*/tickets/**` to a regex that requires a trailing `/` after `tickets`, so the bare ticket-purchase URL fell back to the catch-all `/**` (`isr: true`) and was rewritten to `/[...]-isr`, producing a 404 on refresh.

## Test plan
- [ ] Deploy to a preview environment.
- [ ] Open `/konferenz/<slug>/tickets`, start the purchase flow, and refresh — page should render instead of 404.
- [ ] Verify `/konferenz/<slug>/tickets/success` and other ticket sub-routes still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)