### PR TITLE
Apply discount codes during early bird period

### DIFF
--- a/nuxt-app/components/tickets/TicketPricingSummary.vue
+++ b/nuxt-app/components/tickets/TicketPricingSummary.vue
@@ -28,7 +28,7 @@ const store = useTicketCheckoutStore()
                 <span class="rounded bg-lime/20 px-2 py-0.5 text-xs font-bold">Early Bird</span>
             </div>
 
-            <div v-if="store.discountValid && (store.isEmployeeCode || !store.isEarlyBird)" class="flex justify-between text-lime">
+            <div v-if="store.discountValid" class="flex justify-between text-lime">
                 <span>{{ store.isEmployeeCode ? 'Team-Code' : `Rabatt (${store.discountCode})` }}</span>
                 <span>-{{ store.formatPrice(store.discountAmountCents) }}</span>
             </div>

--- a/nuxt-app/composables/useTicketCheckoutStore.ts
+++ b/nuxt-app/composables/useTicketCheckoutStore.ts
@@ -160,7 +160,7 @@ export const useTicketCheckoutStore = defineStore('ticketCheckout', {
             if (this.isEmployeeCode) {
                 return 0
             }
-            if (this.discountValid && !this.isEarlyBird && this.pricingSettings?.discountPriceCents !== null && this.pricingSettings?.discountPriceCents !== undefined) {
+            if (this.discountValid && this.pricingSettings?.discountPriceCents !== null && this.pricingSettings?.discountPriceCents !== undefined) {
                 return this.pricingSettings.discountPriceCents
             }
             return this.basePriceCents
@@ -173,11 +173,11 @@ export const useTicketCheckoutStore = defineStore('ticketCheckout', {
             if (this.isEmployeeCode) {
                 return 'discounted'
             }
-            if (this.isEarlyBird) {
-                return 'early_bird'
-            }
             if (this.discountValid) {
                 return 'discounted'
+            }
+            if (this.isEarlyBird) {
+                return 'early_bird'
             }
             return 'regular'
         },
@@ -196,7 +196,7 @@ export const useTicketCheckoutStore = defineStore('ticketCheckout', {
             if (this.isEmployeeCode) {
                 return this.ticketCount * this.basePriceCents
             }
-            if (!this.discountValid || this.isEarlyBird || !this.pricingSettings || this.pricingSettings.discountPriceCents === null) {
+            if (!this.discountValid || !this.pricingSettings || this.pricingSettings.discountPriceCents === null) {
                 return 0
             }
             return this.ticketCount * (this.basePriceCents - this.pricingSettings.discountPriceCents)

--- a/nuxt-app/server/api/tickets/create-checkout.post.ts
+++ b/nuxt-app/server/api/tickets/create-checkout.post.ts
@@ -25,26 +25,29 @@ function calculatePricing(
     discountPriceCents: number | null
 ) {
     const isEarlyBird = isEarlyBirdPeriod(conference.ticket_early_bird_deadline)
+    const basePriceCents =
+        isEarlyBird && conference.ticket_early_bird_price_cents
+            ? conference.ticket_early_bird_price_cents
+            : conference.ticket_regular_price_cents ?? 0
 
     let unitPriceNetCents: number
     let ticketType: TicketType
 
-    if (isEarlyBird && conference.ticket_early_bird_price_cents) {
-        unitPriceNetCents = conference.ticket_early_bird_price_cents
-        ticketType = 'early_bird'
-    } else if (discountPriceCents !== null) {
+    if (discountPriceCents !== null) {
         unitPriceNetCents = discountPriceCents
         ticketType = 'discounted'
+    } else if (isEarlyBird && conference.ticket_early_bird_price_cents) {
+        unitPriceNetCents = conference.ticket_early_bird_price_cents
+        ticketType = 'early_bird'
     } else {
         unitPriceNetCents = conference.ticket_regular_price_cents ?? 0
         ticketType = 'regular'
     }
 
     const subtotalNetCents = ticketCount * unitPriceNetCents
-    const regularPriceCents = conference.ticket_regular_price_cents ?? 0
     const discountAmountCents =
-        discountPriceCents !== null && !isEarlyBird
-            ? ticketCount * (regularPriceCents - discountPriceCents)
+        discountPriceCents !== null
+            ? ticketCount * (basePriceCents - discountPriceCents)
             : 0
     const totalNetCents = subtotalNetCents
 


### PR DESCRIPTION
## Summary
- During the early-bird window, the early-bird price overrode any non-employee discount code, so coupons silently had no effect while the validation endpoint still reported them as applied.
- Reorders pricing logic on the server (`create-checkout.post.ts`) and in the checkout store so a valid discount code always wins, computing the discount amount against whatever base price would otherwise apply (early bird or regular).
- Removes the matching `!isEarlyBird` gate on the "Rabatt" line in `TicketPricingSummary.vue` so the discount is shown whenever a valid code is active.

## Test plan
- [ ] During an active early-bird window, apply a regular (non-employee) discount code and verify checkout charges the discount price and the summary shows the "Rabatt" line.
- [ ] Apply an employee code during early bird and verify the order is still free.
- [ ] Outside the early-bird window, verify regular + discounted flows still behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)