### PR TITLE
Record pre-discount subtotal on discounted orders

### DIFF
--- a/nuxt-app/server/api/tickets/create-checkout.post.ts
+++ b/nuxt-app/server/api/tickets/create-checkout.post.ts
@@ -44,12 +44,15 @@ function calculatePricing(
         ticketType = 'regular'
     }
 
-    const subtotalNetCents = ticketCount * unitPriceNetCents
     const discountAmountCents =
         discountPriceCents !== null
             ? ticketCount * (basePriceCents - discountPriceCents)
             : 0
-    const totalNetCents = subtotalNetCents
+    const subtotalNetCents =
+        discountPriceCents !== null
+            ? ticketCount * basePriceCents
+            : ticketCount * unitPriceNetCents
+    const totalNetCents = subtotalNetCents - discountAmountCents
 
     // Calculate gross unit price for Stripe line items (round per-ticket for consistency)
     const unitPriceGrossCents = Math.round(unitPriceNetCents * (1 + VAT_RATE))


### PR DESCRIPTION
## Summary
- Follow-up to #179. The server was storing `subtotal_cents` net of the discount while `discount_amount_cents` was positive, so the Directus invoice hook would subtract the discount a second time when rendering the PDF.
- Compute the subtotal from the base price (early bird or regular) whenever a discount applies, and derive `total_cents` as subtotal minus discount. Charged Stripe total and VAT amount are unchanged.

## Test plan
- [ ] Buy a discounted ticket during the early-bird window and verify the invoice PDF shows Zwischensumme (pre-discount) − Rabatt + MwSt = Rechnungsbetrag.
- [ ] Buy a discounted ticket outside the early-bird window and verify the same invoice math.
- [ ] Buy a regular (no discount, no early bird) ticket and verify the invoice is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)