### PR TITLE
Show pre-discount unit price on invoice line item

### DIFF
--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/ticket-order-processing/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/ticket-order-processing/index.ts
@@ -178,7 +178,10 @@ export default defineHook(({ action }, hookContext) => {
                         year: 'numeric',
                     })
 
-                    const grossPerTicket = Math.round((order.total_gross_cents || 0) / attendees.length)
+                    // Derive per-ticket price from the pre-discount subtotal so the line item reconciles with Zwischensumme; the Rabatt line takes us down to the actual total.
+                    const subtotalCents = order.subtotal_cents || order.total_cents || 0
+                    const baseUnitNetCents = Math.round(subtotalCents / attendees.length)
+                    const grossPerTicket = Math.round(baseUnitNetCents * 1.19)
 
                     const invoiceData: InvoiceData = {
                         invoiceNumber,


### PR DESCRIPTION
## Summary
- Follow-up to #180. With `subtotal_cents` now pre-discount, the invoice hook was still computing the per-ticket price from `total_gross_cents / attendees.length` (the charged amount), so the line-item total didn't reconcile with Zwischensumme.
- Derive the per-ticket gross from `subtotal_cents` so the line item matches Zwischensumme and the Rabatt line brings it down to the actual total. For non-discounted orders the value is unchanged.

## Test plan
- [ ] Buy a discounted ticket and verify the invoice line-item total equals Zwischensumme, with Rabatt + VAT producing the Rechnungsbetrag.
- [ ] Buy a regular (no discount) ticket and verify the invoice is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)