### PR TITLE
Skip /api/ in conference & flutterday redirect middleware

### DIFF
--- a/nuxt-app/server/middleware/conference.ts
+++ b/nuxt-app/server/middleware/conference.ts
@@ -20,6 +20,12 @@ export default eventHandler(function(event) {
     return;
   }
 
+  // Skip API routes and internal Nuxt routes so they aren't 302'd to the apex,
+  // which would break client-side $fetch calls (e.g. discount validation).
+  if (requestPath.startsWith('/api/') || requestPath.startsWith('/_')) {
+    return;
+  }
+
   if (requestPath === pathToMatch) {
 
     let redirectUrl = '';

--- a/nuxt-app/server/middleware/flutterday.ts
+++ b/nuxt-app/server/middleware/flutterday.ts
@@ -6,6 +6,12 @@ export default eventHandler(function(event) {
     return;
   }
 
+  // Skip API routes and internal Nuxt routes so they aren't 302'd to the apex,
+  // which would break client-side $fetch calls (e.g. discount validation).
+  if (event.path.startsWith('/api/') || event.path.startsWith('/_')) {
+    return;
+  }
+
   const host = 'https://programmier.bar';
   const path = '/konferenz/flutter-day-2024';
 


### PR DESCRIPTION
## Summary
- Both `conference.ts` and `flutterday.ts` middlewares 302'd **every** request from the conference subdomains (`con.`/`conference.`/`konferenz.`/`flutterday.programmier.bar`) to the apex `programmier.bar/konferenz/...` — including API POSTs.
- Users entering the ticket flow via `con.programmier.bar` had their `POST /api/tickets/validate-discount` answered with a 302 to the apex `/konferenz/...` HTML page. `$fetch` followed the redirect, received HTML, failed to JSON-parse, and the catch in `useTicketCheckoutStore.validateDiscountCode` surfaced as "code not valid".
- Reproduces only when the user enters via the conference subdomain; direct visits to `programmier.bar` are unaffected (which matches the field report from two colleagues).
- Fix: early-return from both middlewares for `/api/` and `/_` paths so API calls (and internal Nuxt routes) reach their handlers normally. Page navigations still get redirected as before.

## Test plan
- [ ] Hit `https://con.programmier.bar/...` in a browser → still redirects to `https://programmier.bar/konferenz/programmier-con-web-ai-edition-2025`.
- [ ] `curl -i -X POST https://con.programmier.bar/api/tickets/validate-discount -H 'content-type: application/json' -d '{"code":"X","conferenceId":"…"}'` → returns JSON (200/400), not 302.
- [ ] Same check against `https://flutterday.programmier.bar/api/tickets/validate-discount`.
- [ ] Affected colleagues retry the discount code via their original entry path and confirm it applies.