### PR TITLE
Fix Apple & Google Wallet links broken in confirmation email

### DIFF
--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/wallet-pass-generator.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/wallet-pass-generator.ts
@@ -306,7 +306,11 @@ export function generateGoogleWalletUrl(
         aud: 'google',
         typ: 'savetowallet',
         iat: now,
-        origins: [input.websiteUrl],
+        // No `origins`: this link is delivered by email and opened directly
+        // (Gmail / Wallet app), not from a button hosted on our domain. With
+        // `origins` set, Google only redeems the JWT when the save is initiated
+        // from one of those domains, so an email link fails with a generic
+        // "something went wrong" error.
         payload: {
             eventTicketClasses: [eventTicketClass],
             eventTicketObjects: [eventTicketObject],

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/speaker-portal-notifications/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/speaker-portal-notifications/index.ts
@@ -30,7 +30,7 @@ export default defineHook(({ action, schedule }, hookContext) => {
      * Build the portal URL for a speaker token.
      */
     async function buildPortalUrl(token: string, context: EmailServiceContext): Promise<string> {
-        const websiteUrl = (await getSetting('website_url', context)) || 'https://programmier.bar'
+        const websiteUrl = (await getSetting('website_url', context)) || 'https://www.programmier.bar'
         return `${websiteUrl}/speaker-portal?token=${encodeURIComponent(token)}`
     }
 
@@ -283,7 +283,7 @@ export default defineHook(({ action, schedule }, hookContext) => {
             })
 
             const settings = await getSettings(['website_url'], context)
-            const websiteUrl = settings.website_url || 'https://programmier.bar'
+            const websiteUrl = settings.website_url || 'https://www.programmier.bar'
 
             const now = new Date()
             const oneDayFromNow = new Date(now.getTime() + 24 * 60 * 60 * 1000)

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/ticket-order-processing/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/ticket-order-processing/index.ts
@@ -64,7 +64,7 @@ export default defineHook(({ action }, hookContext) => {
                 accountability: { admin: true },
             })
 
-            const websiteUrl = (await getSetting('website_url', context)) || 'https://programmier.bar'
+            const websiteUrl = (await getSetting('website_url', context)) || 'https://www.programmier.bar'
 
             for (const orderId of keys) {
                 logger.info(`${HOOK_NAME}: Processing paid order ${orderId}`)

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/ticket-profile-completion/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/ticket-profile-completion/index.ts
@@ -52,7 +52,7 @@ export default defineHook(({ action }, hookContext) => {
                 accountability: { admin: true },
             })
 
-            const websiteUrl = (await getSetting('website_url', context)) || 'https://programmier.bar'
+            const websiteUrl = (await getSetting('website_url', context)) || 'https://www.programmier.bar'
             const venueName = await getSetting('conference_venue_name', context)
             const venueAddress = await getSetting('conference_venue_address', context)
 

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/ticket-profile-completion/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/ticket-profile-completion/index.ts
@@ -123,9 +123,17 @@ export default defineHook(({ action }, hookContext) => {
                             contentType: 'application/vnd.apple.pkpass',
                             cid: '',
                         })
-                        const directusUrl = (env.PUBLIC_URL || '').replace(/\/+$/, '')
-                        const tokenParam = encodeURIComponent(ticket.profile_token)
-                        appleWalletUrl = `${directusUrl}/ticket-wallet/apple/${ticket.ticket_code}?token=${tokenParam}`
+                        // Only emit a re-download link when we actually have a token to
+                        // authenticate it with; otherwise the URL would carry "token=null".
+                        if (ticket.profile_token) {
+                            const directusUrl = (env.PUBLIC_URL || '').replace(/\/+$/, '')
+                            const tokenParam = encodeURIComponent(ticket.profile_token)
+                            appleWalletUrl = `${directusUrl}/ticket-wallet/apple/${ticket.ticket_code}?token=${tokenParam}`
+                        } else {
+                            logger.warn(
+                                `${HOOK_NAME}: Ticket ${ticket.ticket_code} has no profile_token; skipping Apple Wallet re-download link`
+                            )
+                        }
                     }
                 } catch (err: any) {
                     logger.warn(`${HOOK_NAME}: Apple Wallet pass generation failed: ${err?.message || err}`)

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/ticket-wallet/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/ticket-wallet/index.ts
@@ -23,6 +23,14 @@ export default defineEndpoint(async (router: SandboxEndpointRouter, context) => 
             return
         }
 
+        // profile_token is a UUID column; reject anything that isn't one (e.g. the
+        // literal string "null") before it reaches the DB and triggers a 500.
+        const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+        if (!UUID_RE.test(token)) {
+            res.status(400).send({ error: 'Invalid token' })
+            return
+        }
+
         try {
             const schema = await context.getSchema()
 

--- a/nuxt-app/server/api/ticket-portal/submit.post.ts
+++ b/nuxt-app/server/api/ticket-portal/submit.post.ts
@@ -60,7 +60,11 @@ export default defineEventHandler(async (event) => {
             heard_about_from: data.heard_about_from || null,
             additional_notes: data.additional_notes || null,
             profile_status: 'completed',
-            profile_token: null, // Invalidate token after submission
+            // Keep profile_token valid: it doubles as the access secret for the
+            // Apple Wallet download endpoint (/ticket-wallet/apple/:code?token=),
+            // and the final ticket email with that link is only sent *after*
+            // completion. Re-submission is already prevented by the
+            // profile_status === 'completed' guards in this handler and validate.get.ts.
         })
 
         return {


### PR DESCRIPTION
Fixes the "wallet link from the confirmation email doesn't work" reports for **both** Apple and Google Wallet. Two independent root causes, same symptom.

## 1. Apple Wallet — `?token=null` → 500

The Apple re-download endpoint (`/ticket-wallet/apple/:code?token=`) authenticates via `profile_token`, but the ticket portal **nulled `profile_token` on profile completion** — and the final ticket email carrying the link is only sent *after* completion (the `ticket-profile-completion` hook).

So when the email is generated, the hook re-reads the ticket where `profile_token` is now `null`. `encodeURIComponent(null)` → the literal string `"null"` → the link becomes `?token=null` → Postgres throws `invalid input syntax for type uuid: "null"` → 500 "Failed to generate wallet pass". Even a valid token couldn't match, since the row's token is already null.

Affected **every** ticket completing its profile, not just internal/free ones (single completion path in `submit.post.ts`).

**Fix**
- `submit.post.ts`: stop nulling `profile_token` on completion — it's the wallet endpoint's access secret. Re-submission is already blocked by the `profile_status === 'completed'` guards in this handler and `validate.get.ts`.
- `ticket-profile-completion`: only emit the link when a token exists; otherwise warn instead of producing `token=null`.
- `ticket-wallet`: reject non-UUID tokens with `400` before they hit the DB.

## 2. Google Wallet — generic "Ein Problem ist aufgetreten"

The "Save to Google Wallet" JWT set `origins: [websiteUrl]`, which restricts redemption to saves **initiated from that domain**. The link is delivered by email and opened directly (Gmail / Wallet app), not from a button on `programmier.bar`, so Google rejected it generically for every recipient.

**Fix**: drop the `origins` claim so the email-delivered JWT is redeemable from any context.

## ⚠️ Notes

- **Apple Bestandstickets**: tickets completed *before* this fix already have `profile_token = null`, so their re-download link stays broken (the `.pkpass` is still attached to their original email). Restoring the link would need a backfill assigning a fresh UUID `profile_token` — not included here.
- **Google**: if it still fails after this, the remaining suspects are console-side and can't be fixed in code — verify the issuer is in **production mode** (a demo/sandbox issuer only lets allowlisted test accounts save passes) and that the service-account key + issuer ID are correctly linked.

## Testing
- `directus-extension build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
