### PR TITLE
Fix cleared optional billing email failing validation

### DIFF
--- a/nuxt-app/server/utils/schema.ts
+++ b/nuxt-app/server/utils/schema.ts
@@ -99,11 +99,16 @@ export const CompanyBillingSchema = z.object({
         .min(1, 'Bitte trage den Firmennamen ein.')
         .max(200, 'Der Firmenname darf nicht länger als 200 Zeichen sein.'),
     address: BillingAddressSchema,
-    billingEmail: z
-        .string()
-        .email('Die Rechnungs-E-Mail-Adresse scheint ungültig zu sein.')
-        .max(200, 'Die E-Mail-Adresse darf nicht länger als 200 Zeichen sein.')
-        .optional(),
+    // Treat a cleared (empty/whitespace-only) optional field as "not provided"
+    // so it passes validation instead of failing the email check.
+    billingEmail: z.preprocess(
+        (value) => (typeof value === 'string' && value.trim() === '' ? undefined : value),
+        z
+            .string()
+            .email('Die Rechnungs-E-Mail-Adresse scheint ungültig zu sein.')
+            .max(200, 'Die E-Mail-Adresse darf nicht länger als 200 Zeichen sein.')
+            .optional()
+    ),
     vatId: z
         .string()
         .max(50, 'Die USt-IdNr. darf nicht länger als 50 Zeichen sein.')


### PR DESCRIPTION
Closes #188

## Problem

When ordering a conference ticket, the optional **Billing email** field failed validation if a value was entered and then cleared. Even though the field was empty at submission, checkout rejected the order with:

> company: Die Rechnungs-E-Mail-Adresse scheint ungültig zu sein.

## Root cause

In `nuxt-app/server/utils/schema.ts`, `billingEmail` was defined as `.string().email().optional()`. Zod's `.optional()` permits `undefined` but **not** an empty string `""`. When a user typed an email and then cleared it, the store held `""`, which was sent to the server and rejected by `.email()`.

The frontend didn't catch this because its check `if (store.company.billingEmail && !isValidEmail(...))` short-circuits on the falsy empty string and lets the form submit — so only the server rejected it.

## Fix

Wrapped the field in `z.preprocess(...)` that normalizes an empty/whitespace-only string to `undefined`, so a cleared optional field is treated as "not provided" and passes validation. Storage behavior is unchanged — `create-checkout.post.ts` already converts the value with `|| null` before persisting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)