### PR TITLE
Use skinny Google Wallet JWT (lost in #187 merge conflict)

### DIFF
--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/wallet-pass-generator.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/wallet-pass-generator.ts
@@ -259,47 +259,6 @@ export function generateGoogleWalletUrl(
         },
     }
 
-    // Include class definition in the JWT so Google creates it on-the-fly if needed
-    const eventTicketClass = {
-        id: classId,
-        issuerName: 'programmier.bar',
-        logo: {
-            sourceUri: {
-                uri: `${input.websiteUrl}/wallet_google_logo.png`,
-            },
-        },
-        hexBackgroundColor: '#003F64',
-        eventName: {
-            defaultValue: {
-                language: 'de',
-                value: input.conferenceTitle,
-            },
-        },
-        ...(input.venueName && {
-            venue: {
-                name: {
-                    defaultValue: {
-                        language: 'de',
-                        value: input.venueName,
-                    },
-                },
-                ...(input.venueAddress && {
-                    address: {
-                        defaultValue: {
-                            language: 'de',
-                            value: input.venueAddress,
-                        },
-                    },
-                }),
-            },
-        }),
-        dateTime: {
-            start: input.conferenceDate,
-            ...(input.conferenceEndDate && { end: input.conferenceEndDate }),
-        },
-        reviewStatus: 'UNDER_REVIEW',
-    }
-
     const now = Math.floor(Date.now() / 1000)
     const jwtPayload = {
         iss: config.serviceAccountEmail,
@@ -311,8 +270,14 @@ export function generateGoogleWalletUrl(
         // `origins` set, Google only redeems the JWT when the save is initiated
         // from one of those domains, so an email link fails with a generic
         // "something went wrong" error.
+        //
+        // "Skinny" JWT: reference the existing, approved EventTicketClass by id
+        // (managed in the Google Pay & Wallet Console) and only send the object.
+        // We must NOT inline the class here: re-declaring an already-APPROVED
+        // class as `reviewStatus: UNDER_REVIEW` makes Google treat the save as a
+        // test/preview, so only the issuer and allowlisted test accounts can save
+        // it — everyone else gets the generic "something went wrong" error.
         payload: {
-            eventTicketClasses: [eventTicketClass],
             eventTicketObjects: [eventTicketObject],
         },
     }


### PR DESCRIPTION
The skinny-JWT change from #187 was dropped during merge-conflict resolution. main still inlines the EventTicketClass with `reviewStatus: UNDER_REVIEW` on every save JWT, which can restrict saves to the issuer + test accounts.

This references the existing **approved** class `programmiercon_ticket_v4` by id and sends only the EventTicketObject — the exact version verified to save with a normal Google account.

Note: the actual production blocker (a non-numeric `GOOGLE_WALLET_ISSUER_ID`) was already fixed in the deployed `.env` (correct numeric issuer id `3388000000023114464`). This restores the code-side cleanup so production stops sending the under-review class inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)