### PR TITLE
Fix Stripe checkout failing for larger ticket orders

### DIFF
--- a/nuxt-app/server/api/tickets/create-checkout.post.ts
+++ b/nuxt-app/server/api/tickets/create-checkout.post.ts
@@ -108,6 +108,7 @@ function buildOrderPayload(
         ticket_type: pricing.ticketType,
         stripe_checkout_session_id: '', // Will be updated after creating Stripe session
         is_internal: isInternal,
+        attendees_json: JSON.stringify(input.tickets),
     }
 }
 
@@ -142,7 +143,6 @@ function buildStripeSessionParams(
             order_id: orderId,
             conference_id: conferenceId,
             ticket_type: pricing.ticketType,
-            attendees: JSON.stringify(tickets),
         },
     }
 }
@@ -240,7 +240,6 @@ export default defineEventHandler(async (event) => {
             await directus.updateTicketOrder(orderId, {
                 status: 'paid',
                 date_paid: new Date().toISOString(),
-                attendees_json: JSON.stringify(input.tickets),
             })
 
             return {

--- a/nuxt-app/server/api/tickets/webhook.post.ts
+++ b/nuxt-app/server/api/tickets/webhook.post.ts
@@ -35,7 +35,6 @@ export default defineEventHandler(async (event) => {
         const session = stripeEvent.data.object as Stripe.Checkout.Session
 
         const orderId = session.metadata?.order_id
-        const attendeesJson = session.metadata?.attendees
 
         if (!orderId) {
             console.error('Missing order_id in checkout session metadata')
@@ -45,15 +44,14 @@ export default defineEventHandler(async (event) => {
         const directus = useAuthenticatedDirectus()
 
         try {
+            // attendees_json is already persisted on the order at creation time
+            // (see create-checkout.post.ts), so it doesn't need to round-trip
+            // through Stripe metadata — which has a 500-char-per-value limit that
+            // larger orders would exceed.
             const updatePayload: Record<string, unknown> = {
                 status: 'paid',
                 stripe_payment_intent_id: session.payment_intent,
                 date_paid: new Date().toISOString(),
-            }
-
-            // Store attendees JSON for Directus hook to process
-            if (attendeesJson) {
-                updatePayload.attendees_json = attendeesJson
             }
 
             // Atomic idempotent update: only update if status is NOT already 'paid'.


### PR DESCRIPTION
## Problem

Users reported checkout failing with _"Fehler beim Erstellen der Zahlungssitzung"_. Confirmed in logs: `stripe.checkout.sessions.create()` was throwing because the `attendees` metadata value exceeded Stripe's **500-character-per-value limit**.

The full attendee list (up to 10 tickets, each with first/last name + email) was JSON-serialized into the session's `attendees` metadata. Larger orders — or orders with long names/emails — overflowed 500 chars, so Stripe rejected the request. Smaller orders worked, which is why it slipped through.

## Fix

Stop round-tripping the attendee list through Stripe metadata:

- Persist `attendees_json` on the Directus order at **creation time** (`buildOrderPayload`), before the Stripe session exists.
- Remove `attendees` from the Stripe session metadata (keep `order_id`, which the webhook keys off).
- The webhook no longer reads attendees from metadata — the order already carries it.

The `ticket-order-processing` Directus hook reads `attendees_json` from the order when status flips to `paid`, so behavior downstream is unchanged. Setting it at creation does not trigger the hook early (it only fires on the status→paid transition).

Also removed a now-redundant `attendees_json` re-set in the free-ticket path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)