### PR TITLE
Retry transient Directus failures during prerender

### DIFF
--- a/nuxt-app/nuxt.config.ts
+++ b/nuxt-app/nuxt.config.ts
@@ -3,6 +3,7 @@ import svgLoader from 'vite-svg-loader'
 // This import needs to be relative/file-based
 // so that it can be resolved during the nuxt build process
 import { useDirectus } from './composables/useDirectus'
+import { enableDirectusRetries } from './services'
 import { DEV, DEVTOOLS, DIRECTUS_CMS_URL, FLAG_SHOW_LOGIN, DISCORD_INVITE_LINK } from './config'
 
 const directus = useDirectus()
@@ -91,6 +92,10 @@ export default defineNuxtConfig({
             if (nitroConfig.dev) {
                 return
             }
+
+            // The route-discovery fetches below are read-only and run before
+            // prerendering, so transient Directus failures may retry safely.
+            enableDirectusRetries()
 
             const routes: string[] = [
               '/',

--- a/nuxt-app/services/directus.ts
+++ b/nuxt-app/services/directus.ts
@@ -82,13 +82,20 @@ function isTransientError(error: unknown): boolean {
     return status !== undefined ? TRANSIENT_STATUS_CODES.has(status) : error instanceof TypeError
 }
 
-// During prerender every route fetches live from Directus and a single failed
-// request aborts the whole deploy (prerender.failOnError). Nitro's own
-// prerender retry option is ineffective (it is passed to a plain fetch that
-// ignores it), so transient failures are retried here with backoff instead.
-// Scoped to prerender on purpose: prerendering only ever reads, while at
-// runtime this client also performs mutations that must not be re-sent.
-if (import.meta.prerender) {
+// Build-time fetches are all reads, and a single failed request aborts the
+// whole deploy (prerender.failOnError). Nitro's own prerender retry option is
+// ineffective (it is passed to a plain fetch that ignores it), so transient
+// failures are retried here with backoff instead. Retrying is opt-in via this
+// function on purpose: at runtime this client also performs mutations that
+// must not be re-sent.
+let retriesEnabled = false
+
+export function enableDirectusRetries(): void {
+    if (retriesEnabled) {
+        return
+    }
+    retriesEnabled = true
+
     const MAX_RETRIES = 3
     const baseRequest: typeof directus.request = directus.request.bind(directus)
     directus.request = (async (options: Parameters<typeof baseRequest>[0]) => {
@@ -108,4 +115,12 @@ if (import.meta.prerender) {
             }
         }
     }) as typeof directus.request
+}
+
+// Prerendering only ever reads. The static guard keeps the wrapper out of the
+// deployed server and client bundles. The route-discovery fetches in
+// nuxt.config.ts run before prerendering in a separate module instance and
+// opt in by calling enableDirectusRetries() themselves.
+if (import.meta.prerender) {
+    enableDirectusRetries()
 }

--- a/nuxt-app/services/directus.ts
+++ b/nuxt-app/services/directus.ts
@@ -71,3 +71,41 @@ export type Collections = {
 export const directus = createDirectus<Collections>(DIRECTUS_CMS_URL)
     .with(authentication('session', { credentials: 'include' }))
     .with(rest())
+
+// Statuses that indicate a transient upstream condition worth retrying.
+const TRANSIENT_STATUS_CODES = new Set([408, 425, 429, 500, 502, 503, 504])
+
+function isTransientError(error: unknown): boolean {
+    // Directus SDK API errors carry the raw Response; network-level failures
+    // (DNS, connection reset, timeout) surface as a TypeError without one.
+    const status = (error as { response?: { status?: number } } | null)?.response?.status
+    return status !== undefined ? TRANSIENT_STATUS_CODES.has(status) : error instanceof TypeError
+}
+
+// During prerender every route fetches live from Directus and a single failed
+// request aborts the whole deploy (prerender.failOnError). Nitro's own
+// prerender retry option is ineffective (it is passed to a plain fetch that
+// ignores it), so transient failures are retried here with backoff instead.
+// Scoped to prerender on purpose: prerendering only ever reads, while at
+// runtime this client also performs mutations that must not be re-sent.
+if (import.meta.prerender) {
+    const MAX_RETRIES = 3
+    const baseRequest: typeof directus.request = directus.request.bind(directus)
+    directus.request = (async (options: Parameters<typeof baseRequest>[0]) => {
+        for (let attempt = 0; ; attempt++) {
+            try {
+                return await baseRequest(options)
+            } catch (error) {
+                if (attempt >= MAX_RETRIES || !isTransientError(error)) {
+                    throw error
+                }
+                const delayMs = 1000 * 2 ** attempt
+                console.warn(
+                    `[directus] Transient request failure, retry ${attempt + 1}/${MAX_RETRIES} in ${delayMs}ms:`,
+                    error
+                )
+                await new Promise((resolve) => setTimeout(resolve, delayMs))
+            }
+        }
+    }) as typeof directus.request
+}


### PR DESCRIPTION
## Problem

Deploys intermittently fail with `[500] Failed to load conference page.` during prerendering. Every prerendered route fetches live from Directus, and with `prerender.failOnError` a single failed request aborts the whole deploy. Nitro's built-in prerender retry never takes effect in nitropack 2.13.4 — it passes ofetch-style `retry` options to a plain `fetch` wrapper that ignores them — so one transient Directus blip (restart, rate limit, network reset) kills the build.

## Fix

Wrap the shared Directus client's `request` method with up to 3 retries and exponential backoff (1s/2s/4s) for transient failures (HTTP 408/425/429/500/502/503/504 and network-level `TypeError`s); permanent errors still fail immediately. The wrapper is guarded by `import.meta.prerender`, which resolves statically — verified it is compiled into the prerender bundle only and absent from the deployed server and client bundles, so runtime behavior (including mutations, which must not be re-sent) is unchanged.

## Verification

Full `npm run build` with real prerender against the live CMS succeeds, all conference pages generate, and `tsc` reports no errors in the modified file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)