### PR TITLE
Stop crawlers registering votes: decouple GET from the DB write

### DIFF
--- a/nuxt-app/components/PodcastRating.vue
+++ b/nuxt-app/components/PodcastRating.vue
@@ -89,25 +89,44 @@ const formError = ref('');
 
 const comment = ref('');
 
-let ratingId = ref(message.value?.payload?.id || '');
+const ratingId = ref(message.value?.payload?.id || '');
 
 const rate = async function(upOrDown: 'up' | 'down') {
   if (istActive.value) return;
   istActive.value = true;
   try {
     trigger(defaultPatterns.buzz);
-    const result = await $fetch<{ success: boolean; message: string, payload: any }>(`/podcast/${props.podcast.slug}/${upOrDown}`, {
-      headers: {
-        Accept: 'application/json',
+    const result = await $fetch<{ id?: string }>('/api/vote', {
+      method: 'POST',
+      body: {
+        slug: props.podcast.slug,
+        direction: upOrDown,
       },
     });
-    setMessage(result.message, 'rating', {});
-    ratingId.value = result.payload?.id;
+    setMessage('Vielen Dank für dein Feedback!', 'rating', {});
+    ratingId.value = result?.id ?? '';
   } catch {
     setMessage('Leider trat ein Fehler auf.', 'rating', {});
   }
   istActive.value = false;
 };
+
+// Show-note links (/podcast/[slug]/[up|down]) redirect here with ?vote=…
+// instead of writing on GET. Cast the vote client-side so crawlers, which
+// don't run this, never register one.
+const route = useRoute();
+const router = useRouter();
+
+onMounted(() => {
+  const vote = route.query.vote;
+  if ((vote === 'up' || vote === 'down') && !message.value) {
+    rate(vote);
+    // Drop the query param so a refresh or back-navigation doesn't re-vote.
+    const query = { ...route.query };
+    delete query.vote;
+    router.replace({ query });
+  }
+});
 
 const submitForm = async (event: Event) => {
   try {

--- a/nuxt-app/server/api/vote.post.ts
+++ b/nuxt-app/server/api/vote.post.ts
@@ -1,0 +1,58 @@
+import { VoteSchema } from '../utils'
+import { useDirectus } from '~/composables/useDirectus'
+
+// The only path that writes a vote. The GET /podcast/[slug]/[up|down] links that
+// ship in RSS show notes no longer write — they redirect to the podcast page,
+// whose client-side script POSTs here. Crawlers follow the redirect but don't run
+// JS, so they never reach this handler.
+export default defineEventHandler(async (event) => {
+    const rawBody = await readBody(event)
+
+    const parseResult = VoteSchema.safeParse(rawBody)
+    if (!parseResult.success) {
+        const issue = parseResult.error.issues[0]
+        const key = issue?.path?.[0] ?? 'input'
+        const message = issue?.message ?? 'Validation error'
+        throw createError({ statusCode: 400, message: `${key}: ${message}` })
+    }
+    const { slug, direction } = parseResult.data
+
+    const directus = useDirectus()
+
+    const podcast = await directus.getPodcastBySlug(slug)
+    if (!podcast) {
+        throw createError({ statusCode: 404, message: 'Podcast not found' })
+    }
+
+    const metadata: Record<string, string> = {}
+
+    // Split x-forwarded-for on comma and take the first entry (the client IP)
+    const xForwardedFor = event.node.req.headers['x-forwarded-for'] as string | undefined
+    const rawIP = xForwardedFor
+        ? xForwardedFor.split(',')[0].trim()
+        : event.node.req.socket.remoteAddress
+    const userAgent = event.node.req.headers['user-agent']
+    const referrer = event.node.req.headers['referer']
+
+    if (rawIP) {
+        metadata['ip'] = rawIP
+    }
+    if (userAgent) {
+        metadata['user_agent'] = userAgent
+    }
+    if (referrer) {
+        metadata['referer_url'] = referrer
+    }
+
+    try {
+        const rating = await directus.createRating(direction, podcast, metadata)
+        // Return the id so the page can attach an optional comment to this rating.
+        return { id: rating?.id }
+    } catch (error) {
+        console.error('Failed to create rating for podcast', podcast.slug, error)
+        throw createError({
+            statusCode: 500,
+            message: 'Dein Feedback konnte leider nicht gespeichert werden. Bitte versuche es später erneut.',
+        })
+    }
+})

--- a/nuxt-app/server/middleware/rating.ts
+++ b/nuxt-app/server/middleware/rating.ts
@@ -1,99 +1,22 @@
-import { getHeader } from 'h3'
-import { useDirectus } from '~/composables/useDirectus'
-
-export default eventHandler(async function(event) {
-  const requestPath = event.path;
+// The /podcast/[slug]/[up|down] links ship in RSS show notes (Spotify, Apple
+// Podcasts, Pocket Casts, …), where only plain GET links work. GET must stay
+// safe and idempotent, so this no longer writes a vote — it redirects to the
+// podcast page, whose client-side script POSTs /api/vote. Crawlers follow the
+// redirect but don't run JS, so they never register a vote.
+export default eventHandler(function (event) {
+  const requestPath = event.path
   if (!requestPath.startsWith('/podcast/')) {
-    return;
+    return
   }
 
   // Path pattern "/podcast/[slug]/[up|down]"
-  const regex = /^\/podcast\/([^/]+)\/(up|down)$/;
-  const match = requestPath.match(regex);
+  const match = requestPath.match(/^\/podcast\/([^/]+)\/(up|down)$/)
   if (!match) {
-    return;
+    return
   }
 
-  const slug = match[1];
-  const voteString = match[2];
+  const slug = match[1]
+  const direction = match[2]
 
-  // Type narrowing: the regex already validated this is "up" or "down"
-  // We use a type guard to make TypeScript aware of this
-  if (voteString !== 'up' && voteString !== 'down') {
-    // This should never happen due to regex validation, but satisfies TypeScript
-    throw createError({ statusCode: 400, message: 'Invalid vote value' });
-  }
-  const vote = voteString;
-
-  const directus = useDirectus();
-
-  const podcast = await directus.getPodcastBySlug(slug);
-
-  if (!podcast) {
-    throw createError({ statusCode: 404, message: 'Podcast not found' });
-  }
-
-  // Content negotiation: detect if the client wants JSON
-  const accept = (getHeader(event, 'accept') || '').toLowerCase()
-  const wantsJson = accept.includes('application/json') && !accept.includes('text/html')
-
-  let success = false;
-  let message = '';
-  let rating: {id: string} | null = null;
-
-  try {
-    const metadata: Record<string, string> = {};
-
-    // Fix: split x-forwarded-for on comma and take first entry
-    const xForwardedFor = event.node.req.headers['x-forwarded-for'] as string | undefined;
-    const rawIP = xForwardedFor
-      ? xForwardedFor.split(',')[0].trim()
-      : event.node.req.socket.remoteAddress;
-
-    const userAgent = event.node.req.headers['user-agent'];
-    const referrer = event.node.req.headers['referer'];
-
-    if (rawIP) {
-      metadata['ip'] = rawIP;
-    }
-    if (userAgent) {
-      metadata['user_agent'] = userAgent;
-    }
-    if (referrer) {
-      metadata['referer_url'] = referrer;
-    }
-
-    rating = await directus.createRating(vote, podcast, metadata);
-    success = true;
-    message = 'Vielen Dank für dein Feedback!';
-  } catch (error) {
-    // Log the error and set an error flash message
-    console.error('Failed to create rating for podcast', podcast.slug, error);
-    success = false;
-    message = 'Dein Feedback konnte leider nicht gespeichert werden. Bitte versuche es später erneut.';
-  }
-
-  // Content negotiation: JSON response for fetch() calls
-  if (wantsJson) {
-    event.node.res.setHeader('Vary', 'Accept')
-    return { success, message, payload: {id: rating?.id} };
-  }
-
-  // Redirect response for direct browser navigation
-  setCookie(event, 'flash-message', JSON.stringify({
-    text: message,
-    type: 'rating',
-    payload: {
-      id: rating?.id
-    }
-  }), {
-    maxAge: 60, // 60 seconds
-    path: '/'
-  });
-
-  event.node.res.writeHead(302, {
-    Location: '/podcast/' + podcast.slug,
-  });
-
-  event.node.res.end();
-});
+  return sendRedirect(event, `/podcast/${slug}?vote=${direction}`, 302)
+})

--- a/nuxt-app/server/utils/schema.ts
+++ b/nuxt-app/server/utils/schema.ts
@@ -15,6 +15,13 @@ export const EmailSchema = z.object({
         .max(1000, 'Deine Nachricht darf nicht länger als 1.000 Zeichen lang sein.'),
 })
 
+// Podcast vote (rating)
+
+export const VoteSchema = z.object({
+    slug: z.string().min(1, 'Slug ist erforderlich.'),
+    direction: z.enum(['up', 'down']),
+})
+
 // Speaker portal submission
 
 export const SpeakerSubmissionSchema = z.object({


### PR DESCRIPTION
## Why

`GET /podcast/:slug/up|down` writes a vote directly to the DB. That's wrong on two counts:

1. **HTTP semantics** — GET should be safe/idempotent; a state-changing write on GET is what makes the rest of this possible, since every well-behaved crawler treats GET as fair game.
2. **Empirical impact** — ~63% of votes in April's export come from self-identifying bots (Googlebot, GPTBot, ClaudeBot, Ahrefs, Baiduspider, Meta-externalagent, Bingbot, …) hitting these links as part of normal RSS/page indexing. The up/down split inside the bot group is ~50/50, confirming it's crawler traffic accidentally registering as votes, not manipulation.

We can't change the URL shape (these links ship in RSS show notes to Spotify, Apple Podcasts, Pocket Casts, … where only plain GET links work) and can't switch them to POST (podcast players render show-note HTML, they don't issue POSTs from a link tap). So we split the flow: the GET URL stays but stops writing — only a same-origin POST that crawlers won't execute writes the vote.

## Changes

- **`server/middleware/rating.ts`** — no longer writes. Now a pure `302` redirect `/podcast/:slug/:direction` → `/podcast/:slug?vote=:direction`. The Directus lookup is gone too, so crawler GETs don't even touch the DB.
- **`server/api/vote.post.ts`** (new) — the only write path. Validates the body with `VoteSchema` (Zod), resolves the slug to a real podcast (404 otherwise), extracts IP/UA/referer, writes via the existing `createRating`, and returns `{ id }` so the page can attach an optional comment.
- **`server/utils/schema.ts`** — adds `VoteSchema` (`{ slug, direction: 'up' | 'down' }`).
- **`components/PodcastRating.vue`** — `rate()` now POSTs `/api/vote`; an `onMounted` hook reads `?vote=` (set by the redirect), casts the vote client-side, then strips the param so refresh/back doesn't re-vote. Reuses the existing "Vielen Dank für dein Feedback!" UI — no separate confirmation page.

## Why this stops the crawlers

Every bot in the export issues a GET and doesn't run JS. Under the new flow they get a `302` + HTML and stop there — the script that POSTs `/api/vote` never runs, so no row is written. No UA sniffing, no IP heuristics, zero false positives on real listeners.

## Design note: no token

An earlier draft added a short-lived HMAC token to the GET page as a second layer. We dropped it: it's no real barrier (any actor can GET the page to mint one, then POST), CORS doesn't stop a scripted non-browser client either, and votes are anonymous so there's no CSRF surface to protect. A tokenless POST is exactly as open as today's GET — while still fully closing the bot problem. Actual abuse control (rate-limit / dedup on the hashed IP we already store) is an independent decision for later.

## Testing checklist

- [x] `curl GET /podcast/:slug/up` → `302`, no row written
- [x] `curl POST /api/vote` with no/invalid body → `4xx`, no row
- [x] `curl POST /api/vote` with `{ slug, direction }` → row written, `{ id }` returned
- [x] Real-device: tap show-note link in Spotify / Apple Podcasts / Pocket Casts / Overcast → vote registered
- [ ] Headless / JS-disabled fetch → no row written

## Notes

- `referer_url` for show-note votes now records the podcast page (POST fires from there) rather than the originating app — minor, arguably cleaner.
- GET (`302` on `/podcast/*/up`) vs write (`POST /api/vote` → 200) are separable in Vercel access logs by method/status, so the GET:POST ratio can be watched post-deploy without custom logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
