### PR TITLE
Fix broken Algolia search entries (build index from full item, not change payload)

### DIFF
--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/cli/rebuild-index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/cli/rebuild-index.ts
@@ -40,32 +40,14 @@ const itemHandlers = getHandlers({
     PUBLIC_URL: PUBLIC_URL,
 }, {});
 
+// The fields to fetch are taken from each handler's `indexFields` (the single source of truth shared
+// with the live hook), so the CLI can never drift out of sync with what the handler actually reads.
 const configuration = [
-    {
-        collection: 'podcasts',
-        fields: ['id', 'title', 'slug', 'description', 'number', 'type', 'published_on', 'cover_image'],
-        handler: itemHandlers.podcastHandler,
-    },
-    {
-        collection: 'meetups',
-        fields: ['id', 'title', 'slug', 'description', 'published_on', 'cover_image'],
-        handler: itemHandlers.meetupHandler,
-    },
-    {
-        collection: 'speakers',
-        fields: ['id', 'first_name', 'last_name', 'academic_title', 'description', 'published_on', 'slug', 'profile_image'],
-        handler: itemHandlers.speakerHandler,
-    },
-    {
-        collection: 'picks_of_the_day',
-        fields: ['id', 'name', 'website_url', 'description', 'published_on', 'image'],
-        handler: itemHandlers.pickOfTheDayHandler,
-    },
-    {
-        collection: 'transcripts',
-        fields: ['id', 'podcast.*', 'speakers.*', 'service', 'supported_features', 'raw_response'],
-        handler: itemHandlers.transcriptHandler,
-    },
+    { collection: 'podcasts', handler: itemHandlers.podcastHandler },
+    { collection: 'meetups', handler: itemHandlers.meetupHandler },
+    { collection: 'speakers', handler: itemHandlers.speakerHandler },
+    { collection: 'picks_of_the_day', handler: itemHandlers.pickOfTheDayHandler },
+    { collection: 'transcripts', handler: itemHandlers.transcriptHandler },
 ]
 
 for (const configurationItem of configuration) {
@@ -74,7 +56,7 @@ for (const configurationItem of configuration) {
 
         const items = await directusClient.request(
             readItems(configurationItem.collection, {
-                fields: configurationItem.fields,
+                fields: configurationItem.handler.indexFields,
                 limit: -1,
             })
         );

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/cli/repair-index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/cli/repair-index.ts
@@ -44,32 +44,14 @@ const itemHandlers = getHandlers({
     PUBLIC_URL: PUBLIC_URL,
 }, {});
 
+// The fields to fetch are taken from each handler's `indexFields` (the single source of truth shared
+// with the live hook), so the CLI can never drift out of sync with what the handler actually reads.
 const configuration = [
-    {
-        collection: 'podcasts',
-        fields: ['id', 'title', 'slug', 'description', 'number', 'type', 'published_on', 'cover_image'],
-        handler: itemHandlers.podcastHandler,
-    },
-    {
-        collection: 'meetups',
-        fields: ['id', 'title', 'slug', 'description', 'published_on', 'cover_image'],
-        handler: itemHandlers.meetupHandler,
-    },
-    {
-        collection: 'speakers',
-        fields: ['id', 'first_name', 'last_name', 'academic_title', 'description', 'published_on', 'slug', 'profile_image'],
-        handler: itemHandlers.speakerHandler,
-    },
-    {
-        collection: 'picks_of_the_day',
-        fields: ['id', 'name', 'website_url', 'description', 'published_on', 'image'],
-        handler: itemHandlers.pickOfTheDayHandler,
-    },
-    {
-        collection: 'transcripts',
-        fields: ['id', 'podcast.*', 'speakers.*', 'service', 'supported_features', 'raw_response'],
-        handler: itemHandlers.transcriptHandler,
-    },
+    { collection: 'podcasts', handler: itemHandlers.podcastHandler },
+    { collection: 'meetups', handler: itemHandlers.meetupHandler },
+    { collection: 'speakers', handler: itemHandlers.speakerHandler },
+    { collection: 'picks_of_the_day', handler: itemHandlers.pickOfTheDayHandler },
+    { collection: 'transcripts', handler: itemHandlers.transcriptHandler },
 ];
 
 interface RepairStats {
@@ -98,7 +80,7 @@ async function repairCollection(configItem: typeof configuration[0]): Promise<Re
     // Get all items from Directus
     const dbItems = await directusClient.request(
         readItems(configItem.collection, {
-            fields: configItem.fields,
+            fields: configItem.handler.indexFields,
             limit: -1,
         })
     );
@@ -153,6 +135,11 @@ async function repairCollection(configItem: typeof configuration[0]): Promise<Re
     }
 
     // Find stale items (different data)
+    //
+    // LIMITATION: this only compares the *number* of entries, not their content. It catches a
+    // transcript whose chunk count changed, but NOT a present-but-incomplete entry (e.g. a podcast
+    // that exists with only a description and no title/cover). To heal those, run the full
+    // `algolia:rebuild-index <collection>` instead — it re-pushes every field for every item.
     const staleItems = [];
     for (const [itemId, dbItem] of dbItemsMap) {
         const indexHits = indexItemsMap.get(itemId);

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/handlers/ItemHandler.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/handlers/ItemHandler.ts
@@ -1,5 +1,13 @@
 export interface ItemHandler {
     collectionName: string;
+    /**
+     * The Directus fields required to build this handler's index entries — the single source of
+     * truth shared by the live hook (which re-reads the full item) and the rebuild/repair CLIs
+     * (which fetch items in bulk). MUST list every field that `updateRequired` and `buildAttributes`
+     * read, including relational fields with their nested paths (e.g. `podcast.*`). If a field is
+     * missing here it will silently be absent from the index.
+     */
+    indexFields: string[];
     updateRequired(item: any): boolean;
     buildAttributes(item: any): Record<string, any>[];
     requiresDistinctDeletionBeforeUpdate(): boolean;

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/handlers/MeetupHandler.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/handlers/MeetupHandler.ts
@@ -1,4 +1,9 @@
 import { AbstractItemHandler } from './ItemHandler.ts';
+import { sanitize, sanitizeFull } from '../util/sanitizer.ts';
+
+// Keep meetup records comfortably below Algolia's per-record size limit. Mirrors the podcast handler:
+// once the sanitized talk text grows past this, we fall back to fully stripped (tag-less) text.
+const MAX_TALK_TEXT_LENGTH = 2500;
 
 export class MeetupHandler extends AbstractItemHandler{
 
@@ -7,10 +12,20 @@ export class MeetupHandler extends AbstractItemHandler{
     }
 
     // Every field read by updateRequired() and buildAttributes(). `status` is added by the hook.
+    //
     // NOTE: `intro` is required by buildAttributes() but was historically missing from the CLI field
     // list, so rebuilt meetups silently lost their intro text. It is included here now.
+    //
+    // Newer meetups carry much of their content in dedicated `talks` (each talk has its own title and
+    // abstract) rather than in the meetup-level description, so we read the linked talks' text too.
+    // `talks` is the meetup's M2M field via the `meetups_talks` junction, hence the `talks.talk.*`
+    // path. Talk text edited directly on the `talks` collection is kept fresh by the hook's
+    // `talks.items.update` handler.
     get indexFields(): string[] {
-        return ['id', 'title', 'slug', 'intro', 'description', 'published_on', 'cover_image'];
+        return [
+            'id', 'title', 'slug', 'intro', 'description', 'published_on', 'cover_image',
+            'talks.talk.title', 'talks.talk.abstract',
+        ];
     }
 
     updateRequired(item: any): boolean {
@@ -20,18 +35,49 @@ export class MeetupHandler extends AbstractItemHandler{
             item.intro ||
             item.description ||
             item.published_on ||
-            item.cover_image
+            item.cover_image ||
+            // Linking/unlinking a talk changes the meetup's `talks` field; reindex so talk text stays
+            // current. (Edits to a talk's own text arrive via the talks.items.update hook instead.)
+            item.talks
         )
     }
 
     buildAttributes(item: any): Record<string, any>[] {
+        // Talk text lives in its own searchable `talks` attribute rather than in `description`: the
+        // search result card displays `description`, and we don't want to bury the meetup summary
+        // under the concatenated talk abstracts. The index defines no explicit searchableAttributes,
+        // so every attribute — including this one — is searchable by default.
+        let talks = this.buildTalkText(item, sanitize);
+        if (talks.length > MAX_TALK_TEXT_LENGTH) {
+            talks = this.buildTalkText(item, sanitizeFull);
+        }
+
         return [{
             _type : 'meetup',
             title: item.title,
             description: [item.intro, item.description].filter(Boolean).join(' '),
+            talks: talks || undefined,
             published_on: item.published_on,
             image: item.cover_image ? `${this.env.PUBLIC_URL}assets/${item.cover_image}` : undefined,
             slug: item.slug,
         }]
+    }
+
+    // Concatenates every linked talk's title + abstract into one searchable string. Each `item.talks`
+    // entry is a `meetups_talks` junction row of shape `{ talk: { title, abstract }, ... }`.
+    private buildTalkText(item: any, sanitizer: (input: string) => string): string {
+        if (!Array.isArray(item.talks)) {
+            return '';
+        }
+
+        return item.talks
+            .map((entry: any) => entry?.talk)
+            .filter(Boolean)
+            .map((talk: any) => [talk.title, talk.abstract ? sanitizer(talk.abstract) : '']
+                .filter(Boolean)
+                .join(' ')
+                .trim())
+            .filter(Boolean)
+            .join(' ');
     }
 }

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/handlers/MeetupHandler.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/handlers/MeetupHandler.ts
@@ -6,6 +6,13 @@ export class MeetupHandler extends AbstractItemHandler{
         return 'meetups';
     }
 
+    // Every field read by updateRequired() and buildAttributes(). `status` is added by the hook.
+    // NOTE: `intro` is required by buildAttributes() but was historically missing from the CLI field
+    // list, so rebuilt meetups silently lost their intro text. It is included here now.
+    get indexFields(): string[] {
+        return ['id', 'title', 'slug', 'intro', 'description', 'published_on', 'cover_image'];
+    }
+
     updateRequired(item: any): boolean {
         return (
             item.title ||

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/handlers/PickOfTheDayHandler.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/handlers/PickOfTheDayHandler.ts
@@ -6,6 +6,11 @@ export class PickOfTheDayHandler extends AbstractItemHandler {
         return 'picks_of_the_day';
     }
 
+    // Every field read by updateRequired() and buildAttributes(). `status` is added by the hook.
+    get indexFields(): string[] {
+        return ['id', 'name', 'website_url', 'description', 'published_on', 'image'];
+    }
+
     updateRequired(item: any): boolean {
         return (
             item.name ||

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/handlers/PodcastHandler.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/handlers/PodcastHandler.ts
@@ -7,6 +7,11 @@ export class PodcastHandler extends AbstractItemHandler {
         return 'podcasts';
     }
 
+    // Every field read by updateRequired() and buildAttributes(). `status` is added by the hook.
+    get indexFields(): string[] {
+        return ['id', 'title', 'slug', 'description', 'number', 'type', 'published_on', 'cover_image'];
+    }
+
     buildDistinctKey(item: any): string {
         return `podcast-${item.id}`;
     }

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/handlers/SpeakerHandler.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/handlers/SpeakerHandler.ts
@@ -6,6 +6,11 @@ export class SpeakerHandler extends AbstractItemHandler {
         return 'speakers';
     }
 
+    // Every field read by updateRequired() and buildAttributes(). `status` is added by the hook.
+    get indexFields(): string[] {
+        return ['id', 'first_name', 'last_name', 'academic_title', 'description', 'published_on', 'slug', 'profile_image'];
+    }
+
     updateRequired(item: any): boolean {
         return (
             item.first_name ||

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/handlers/TranscriptHandler.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/handlers/TranscriptHandler.ts
@@ -8,6 +8,14 @@ export class TranscriptHandler extends AbstractItemHandler {
         return 'transcripts';
     }
 
+    // Every field read by updateRequired(), buildAttributes() and buildDistinctKey(). `status` is
+    // added by the hook. The deep `podcast.*` read is CRITICAL: the related podcast supplies the
+    // entry's title/number/date/cover/slug AND its id for the distinct key. Without it the hook
+    // builds metadata-less entries and crashes on `item.podcast.id`.
+    get indexFields(): string[] {
+        return ['id', 'podcast.*', 'speakers.*', 'service', 'supported_features', 'raw_response'];
+    }
+
     updateRequired(item: any): boolean {
         return (
             item.podcast ||
@@ -23,6 +31,9 @@ export class TranscriptHandler extends AbstractItemHandler {
     }
 
     buildDistinctKey(item: any): string {
+        // Depends on `podcast` being loaded (see indexFields). The hook and CLIs always read
+        // `podcast.*`, so this is safe; it would throw for a transcript with no podcast linked, which
+        // is not a valid state for an indexable transcript.
         return `podcast-${item.podcast.id}`;
     }
 

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/index.ts
@@ -178,80 +178,78 @@ async function handleUpdateAction(metadata, eventContext, dependencies: {
 
     const {handler, ItemsService, client, logger, env} = dependencies;
 
-    // Ensure metadata.key or metadata.keys[0] is not undefined
+    // Directus passes `key` for single-item operations and `keys[]` for batch operations.
     const itemKey = metadata.key || (metadata.keys && metadata.keys[0])
     if (!itemKey) {
         logger.error(`${HOOK_NAME} hook: Error: Invalid item key`)
         return
     }
 
-    // Get fields of collection
-    const { fields } = eventContext.schema.collections[metadata.collection]
+    const { fields: collectionFields } = eventContext.schema.collections[metadata.collection]
 
-    if (fields.status) {
-        // Create items service instance
-        const itemsService = new ItemsService(metadata.collection, {
-            accountability: eventContext.accountability,
-            schema: eventContext.schema,
-        }) as ItemsServiceType;
+    // ---------------------------------------------------------------------------------------------
+    // Re-read the FULL item from the database and build the index entry from *that*.
+    //
+    // This is the heart of the fix. `metadata.payload` only contains the fields that changed in this
+    // one save (the diff). Editors save title, cover, description and (for transcripts) the raw
+    // transcript independently and in no fixed order, so any single save's payload is usually a tiny
+    // subset of the item. Building the index entry from that subset used to:
+    //   - create sparse podcast entries missing title/cover/date (only the changed field made it in),
+    //     because `buildAttributes` reads `item.<field>` and missing fields serialize to `undefined`;
+    //   - for transcripts, omit the related `podcast` metadata entirely and crash in
+    //     `buildDistinctKey` (`item.podcast.id`) whenever the save didn't include the relation.
+    //
+    // Reading the full item via the handler's declared `indexFields` is exactly what the rebuild /
+    // repair CLIs do, so the live hook and the CLIs now produce identical entries. `indexFields` is
+    // the single source of truth for "what does this handler need to build an entry".
+    const itemsService = new ItemsService(metadata.collection, {
+        accountability: eventContext.accountability,
+        schema: eventContext.schema,
+    }) as ItemsServiceType;
 
-        // Get item from item service by key
-        const item = await itemsService.readOne(itemKey)
+    // `status` is requested only when the collection actually has the field — asking Directus for a
+    // non-existent field throws.
+    const fieldsToRead = collectionFields.status
+        ? [...handler.indexFields, 'status']
+        : [...handler.indexFields]
 
-        if ((item.status !== 'published' && metadata.payload.status !== 'published')) {
-            logger.info(`${HOOK_NAME} hook: No search index update necessary, item is not published yet.`)
+    const item = await itemsService.readOne(itemKey, { fields: fieldsToRead })
 
-            if (metadata.payload.status === 'draft' || metadata.payload.status === 'archived') {
-                logger.info(`${HOOK_NAME} hook: Item has been depublished. Removing it from search index.`)
-                client.deleteObject({
-                    indexName: env.ALGOLIA_INDEX,
-                    objectID: itemKey,
-                });
-            } else {
-                // logger.warm(`${HOOK_NAME} hook: Encountered unknown item status`)
-                //throw new Error('Encountered unknown item status.')
-            }
-
-            return
-        }
+    // Only published items belong in the index. Action hooks run *after* the write, so the item we
+    // just read already reflects the new status; there is no need to also inspect metadata.payload.
+    if (collectionFields.status && item.status !== 'published') {
+        logger.info(`${HOOK_NAME} hook: Item "${itemKey}" is not published (status: "${item.status}"). Ensuring it is absent from the search index.`)
+        // Always issue the delete (it is idempotent): this covers depublishing as well as items that
+        // were never indexed. We delete by the handler's deletion filter, NOT by a single objectID —
+        // entries are stored as `<id>_0`, `<id>_1`, … (transcripts produce many chunks), so deleting
+        // `objectID: itemKey` would have matched nothing.
+        await deleteFromIndex({ handler, client, env, itemKey })
+        return
     }
 
+    // `updateRequired` is intentionally evaluated against the diff (metadata.payload): it answers
+    // "did a field we index actually change in this save?" and lets us skip needless reindexing when
+    // an unrelated field was touched. The index *content* is always built from the full item above.
     if (!handler.updateRequired(metadata.payload)) {
         logger.info(`${HOOK_NAME} hook: No search index update necessary`)
         return
     }
 
-    const payloads = handler.buildAttributes(metadata.payload).map((payload) => {
+    const payloads = handler.buildAttributes(item).map((payload) => {
         return {
             ...payload,
-            distinct: handler.buildDistinctKey({
-                ...metadata.payload,
-                id: itemKey
-            }),
-            _directus_reference: handler.buildDirectusReference({
-                ...metadata.payload,
-                id: itemKey
-            }),
+            distinct: handler.buildDistinctKey(item),
+            _directus_reference: handler.buildDirectusReference(item),
         }
     });
 
+    // Some handlers (transcripts) expand one item into many chunk entries, and the number of chunks
+    // can change between saves, so we delete the previous entries before re-creating them. Building
+    // from the full item above is what makes this safe: previously a save without `service` +
+    // `raw_response` produced zero chunks here, so this delete wiped the transcript and recreated
+    // nothing.
     if (handler.requiresDistinctDeletionBeforeUpdate()) {
-        const results = await client.browseObjects({
-            indexName: env.ALGOLIA_INDEX,
-            query: '',
-            attributesToRetrieve: [
-                'objectID',
-            ],
-            browseParams: {
-                filters:  handler.buildDeletionFilter({id: itemKey}),
-            }
-        });
-
-        const IdsForDeletion = results.hits.map((hit: any) => hit.objectID);
-        await client.deleteObjects({
-            indexName: env.ALGOLIA_INDEX,
-            objectIDs: IdsForDeletion,
-        });
+        await deleteFromIndex({ handler, client, env, itemKey })
     }
 
     try {
@@ -286,24 +284,46 @@ async function handleDeleteAction(metadata, eventContext, dependencies: {
         return
     }
 
-    const item = {id: itemKey};
+    const deletedIds = await deleteFromIndex({ handler, client, env, itemKey })
+
+    logger.info(`${HOOK_NAME} hook: Removed item(s) "${JSON.stringify(deletedIds)}" from search index via filter ${handler.buildDeletionFilter({ id: itemKey })}`)
+}
+
+/**
+ * Removes every Algolia entry belonging to a single Directus item.
+ *
+ * Index entries are keyed `<id>_0`, `<id>_1`, … and one item (a transcript in particular) can map to
+ * many of them, so we can't delete by a guessed objectID. Instead we look the entries up via the
+ * handler's deletion filter (`_directus_reference:<id>`) and delete exactly those. Returns the list
+ * of deleted objectIDs (empty when nothing matched). Shared by the depublish, distinct-rebuild and
+ * delete paths so deletion behaves identically everywhere.
+ */
+async function deleteFromIndex(dependencies: {
+    handler: ItemHandler,
+    client: SearchClient,
+    env,
+    itemKey,
+}): Promise<string[]> {
+    const { handler, client, env, itemKey } = dependencies;
 
     const results = await client.browseObjects({
         indexName: env.ALGOLIA_INDEX,
         query: '',
-        attributesToRetrieve: [
-            'objectID',
-        ],
+        attributesToRetrieve: ['objectID'],
         browseParams: {
-            filters: handler.buildDeletionFilter(item),
+            filters: handler.buildDeletionFilter({ id: itemKey }),
         }
     });
 
-    const IdsForDeletion = results.hits.map((hit: any) => hit.objectID);
+    const idsForDeletion = results.hits.map((hit: any) => hit.objectID);
+    if (idsForDeletion.length === 0) {
+        return [];
+    }
+
     await client.deleteObjects({
         indexName: env.ALGOLIA_INDEX,
-        objectIDs: IdsForDeletion,
+        objectIDs: idsForDeletion,
     });
 
-    logger.info(`${HOOK_NAME} hook: Removed item(s) "${JSON.stringify(IdsForDeletion)}" from search index via filter ${handler.buildDeletionFilter(item)}`)
+    return idsForDeletion;
 }

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/index.ts
@@ -80,6 +80,19 @@ export default defineHook(({ action }, hookContext) => {
         })
     })
 
+    // Talks are their own collection embedded into meetups (see MeetupHandler). Editing a talk's
+    // title/abstract must refresh the meetup entries that embed it — see handleRelatedTalkChange for
+    // why only `update` is wired up (create/delete are covered by the accompanying meetup update).
+    action('talks.items.update', async function (metadata, eventContext) {
+        handleRelatedTalkChange(metadata, eventContext, {
+            meetupHandler: handlers.meetupHandler,
+            client,
+            ItemsService,
+            logger,
+            env
+        });
+    })
+
     action('speakers.items.create', async function (metadata, eventContext) {
         handleUpdateAction(metadata, eventContext, {
             handler: handlers.speakerHandler,
@@ -185,24 +198,57 @@ async function handleUpdateAction(metadata, eventContext, dependencies: {
         return
     }
 
-    const { fields: collectionFields } = eventContext.schema.collections[metadata.collection]
+    // The actual reindex lives in reindexByKey (shared with the talk-change path). We pass the change
+    // payload so it can skip needless work when no indexed field changed.
+    await reindexByKey({
+        handler,
+        collection: metadata.collection,
+        itemKey,
+        eventContext,
+        ItemsService,
+        client,
+        logger,
+        env,
+        changedPayload: metadata.payload,
+    })
+}
 
-    // ---------------------------------------------------------------------------------------------
-    // Re-read the FULL item from the database and build the index entry from *that*.
-    //
-    // This is the heart of the fix. `metadata.payload` only contains the fields that changed in this
-    // one save (the diff). Editors save title, cover, description and (for transcripts) the raw
-    // transcript independently and in no fixed order, so any single save's payload is usually a tiny
-    // subset of the item. Building the index entry from that subset used to:
-    //   - create sparse podcast entries missing title/cover/date (only the changed field made it in),
-    //     because `buildAttributes` reads `item.<field>` and missing fields serialize to `undefined`;
-    //   - for transcripts, omit the related `podcast` metadata entirely and crash in
-    //     `buildDistinctKey` (`item.podcast.id`) whenever the save didn't include the relation.
-    //
-    // Reading the full item via the handler's declared `indexFields` is exactly what the rebuild /
-    // repair CLIs do, so the live hook and the CLIs now produce identical entries. `indexFields` is
-    // the single source of truth for "what does this handler need to build an entry".
-    const itemsService = new ItemsService(metadata.collection, {
+/**
+ * Reads the FULL item from the database and (re)builds its Algolia entry from *that* item.
+ *
+ * This is the heart of the indexing fix. `metadata.payload` only contains the fields that changed in
+ * a single save (the diff). Editors save title, cover, description and (for transcripts) the raw
+ * transcript independently and in no fixed order, so any one save's payload is usually a tiny subset
+ * of the item. Building the entry from that subset used to:
+ *   - create sparse podcast entries missing title/cover/date (only the changed field made it in),
+ *     because `buildAttributes` reads `item.<field>` and missing fields serialize to `undefined`;
+ *   - for transcripts, omit the related `podcast` metadata entirely and crash in `buildDistinctKey`
+ *     (`item.podcast.id`) whenever the save didn't include the relation.
+ *
+ * Reading the full item via the handler's declared `indexFields` is exactly what the rebuild / repair
+ * CLIs do, so the live hook and the CLIs produce identical entries. `indexFields` is the single
+ * source of truth for "what does this handler need to build an entry".
+ *
+ * `changedPayload` is the diff that triggered the reindex, used only to gate needless work. Callers
+ * that can't supply a meaningful diff (e.g. a meetup reindexed because one of its talks changed)
+ * omit it, which forces a rebuild.
+ */
+async function reindexByKey(dependencies: {
+    handler: ItemHandler,
+    collection: string,
+    itemKey: any,
+    eventContext: any,
+    ItemsService,
+    client: SearchClient,
+    logger,
+    env,
+    changedPayload?: any,
+}): Promise<void> {
+    const { handler, collection, itemKey, eventContext, ItemsService, client, logger, env, changedPayload } = dependencies;
+
+    const { fields: collectionFields } = eventContext.schema.collections[collection]
+
+    const itemsService = new ItemsService(collection, {
         accountability: eventContext.accountability,
         schema: eventContext.schema,
     }) as ItemsServiceType;
@@ -216,7 +262,7 @@ async function handleUpdateAction(metadata, eventContext, dependencies: {
     const item = await itemsService.readOne(itemKey, { fields: fieldsToRead })
 
     // Only published items belong in the index. Action hooks run *after* the write, so the item we
-    // just read already reflects the new status; there is no need to also inspect metadata.payload.
+    // just read already reflects the new status; there is no need to also inspect the diff.
     if (collectionFields.status && item.status !== 'published') {
         logger.info(`${HOOK_NAME} hook: Item "${itemKey}" is not published (status: "${item.status}"). Ensuring it is absent from the search index.`)
         // Always issue the delete (it is idempotent): this covers depublishing as well as items that
@@ -227,10 +273,11 @@ async function handleUpdateAction(metadata, eventContext, dependencies: {
         return
     }
 
-    // `updateRequired` is intentionally evaluated against the diff (metadata.payload): it answers
-    // "did a field we index actually change in this save?" and lets us skip needless reindexing when
-    // an unrelated field was touched. The index *content* is always built from the full item above.
-    if (!handler.updateRequired(metadata.payload)) {
+    // When triggered by a direct edit we gate on the diff: `updateRequired` answers "did a field we
+    // index actually change in this save?" and lets us skip needless reindexing when an unrelated
+    // field was touched. Talk-driven reindexes pass no diff and always rebuild (the meetup row itself
+    // may not have changed at all, only the related talk's text).
+    if (changedPayload !== undefined && !handler.updateRequired(changedPayload)) {
         logger.info(`${HOOK_NAME} hook: No search index update necessary`)
         return
     }
@@ -268,6 +315,77 @@ async function handleUpdateAction(metadata, eventContext, dependencies: {
     }
 
     logger.info(`${HOOK_NAME} hook: Updated search index "${env.ALGOLIA_INDEX}" for "${handler.collectionName}" item "${itemKey}"`)
+}
+
+/**
+ * Reindexes the meetups that embed a talk whose content just changed.
+ *
+ * Talk title/abstract live in the standalone `talks` collection (shared by meetups and conferences),
+ * so editing a talk fires `talks.items.*` — NOT `meetups.items.*`. Without this handler, a talk edit
+ * would never refresh the meetup entries that embed its text. We resolve every meetup linked to the
+ * changed talk via the talk's reverse `meetups` alias (the `meetups_talks` junction) and rebuild each.
+ *
+ * Scope: wired to `talks.items.update` only.
+ *   - create: a brand-new talk isn't linked to a meetup yet; linking happens through a meetup save
+ *     (`meetups.items.update` with `talks` in the payload), already handled via updateRequired.
+ *   - delete: the talk can no longer be read to find its meetups; Directus removes the junction rows,
+ *     which updates the meetups' `talks` field and triggers `meetups.items.update` to refresh them.
+ */
+async function handleRelatedTalkChange(metadata, eventContext, dependencies: {
+    meetupHandler: ItemHandler,
+    client: SearchClient,
+    ItemsService,
+    logger,
+    env
+}) {
+    const { meetupHandler, client, ItemsService, logger, env } = dependencies;
+
+    const talkKey = metadata.key || (metadata.keys && metadata.keys[0])
+    if (!talkKey) {
+        logger.error(`${HOOK_NAME} hook: Error: Invalid talk key`)
+        return
+    }
+
+    // Skip talk saves that don't touch indexed talk fields (e.g. only the video URL or thumbnail
+    // changed) — those can't affect any meetup entry.
+    const payload = metadata.payload || {}
+    if (payload.title === undefined && payload.abstract === undefined) {
+        logger.info(`${HOOK_NAME} hook: Talk "${talkKey}" change does not affect indexed fields; skipping.`)
+        return
+    }
+
+    const talksService = new ItemsService('talks', {
+        accountability: eventContext.accountability,
+        schema: eventContext.schema,
+    }) as ItemsServiceType;
+
+    // `meetups` is the talk's reverse M2M alias → rows of the `meetups_talks` junction, each with a
+    // `meetup` id.
+    const talk = await talksService.readOne(talkKey, { fields: ['meetups.meetup'] })
+    const meetupIds = (talk?.meetups ?? [])
+        .map((row: any) => row?.meetup)
+        .filter(Boolean)
+
+    if (meetupIds.length === 0) {
+        logger.info(`${HOOK_NAME} hook: Talk "${talkKey}" is not linked to any meetup; nothing to reindex.`)
+        return
+    }
+
+    logger.info(`${HOOK_NAME} hook: Talk "${talkKey}" changed; reindexing ${meetupIds.length} linked meetup(s).`)
+
+    for (const meetupId of meetupIds) {
+        // No changedPayload → always rebuild: the meetup row itself hasn't changed, only the talk text.
+        await reindexByKey({
+            handler: meetupHandler,
+            collection: 'meetups',
+            itemKey: meetupId,
+            eventContext,
+            ItemsService,
+            client,
+            logger,
+            env,
+        })
+    }
 }
 
 async function handleDeleteAction(metadata, eventContext, dependencies: {


### PR DESCRIPTION
## Problem

Some search results on `/suche` render with only a description — no title, cover, or date (e.g. `?search=fable`). The broken objects in the prod index literally contain only `{ _type, description, distinct, _directus_reference }`. Separately, newer **meetups** moved most of their content into dedicated *talks*, which the index never captured.

**Root cause (sparse entries):** the `algolia-index` hook built each entry from `metadata.payload` — the *diff* of a single save — instead of the full item. The full item was read, but only to check `status`. Because editors save title/cover/description (and transcripts' raw text) independently and in no fixed order, any one save's payload is usually a tiny subset of fields. Combined with `partialUpdateObject({ createIfNotExists: true })`, the first content edit after publishing could *create* a sparse entry missing everything except the one field that changed. Fields set during the draft phase were never re-pushed, so the gap was permanent — which is why only some entries break.

**Transcripts were worse:** their payload almost never carries the nested `podcast` object, so the hook would either build metadata-less entries, crash in `buildDistinctKey` (`item.podcast.id`), or — because transcripts delete-then-recreate — wipe all chunks and recreate nothing when a save lacked `service` + `raw_response`. The prod index had no new transcript entries since the last manual rebuild (~Feb 2025).

**Meetups:** content increasingly lives in `talks` (title + abstract per talk, via the `meetups_talks` junction) rather than the meetup-level description, so meetup search missed it.

## Fix

### Build entries from the full item (the core fix)
- Entries are always built from the full DB item, never the change payload. `updateRequired(payload)` is kept only as a gate deciding *whether* to reindex.
- `indexFields` on each handler is the single source of truth for the fields needed to build an entry, reused by the hook (re-reading the item) and the rebuild/repair CLIs (bulk fetch), so they can't drift apart.
- Extracted the read-full-item-and-rebuild flow into a shared `reindexByKey`.

### Meetup talks
- `MeetupHandler` folds linked talks' title + abstract into a separate, searchable `talks` attribute (kept out of `description`, which the result card displays; all attributes are searchable by default). Same size guard as podcasts. `indexFields` gains `talks.talk.title`/`talks.talk.abstract`; `updateRequired` gains `item.talks`.
- Talk text is edited on the standalone `talks` collection (`talks.items.*`, not `meetups.items.*`). Added a `talks.items.update` listener that resolves the meetups embedding the changed talk (reverse `meetups_talks` junction) and reindexes each. Create/delete are covered by the accompanying meetup update.

### Other fixes found along the way
- **MeetupHandler** now includes `intro` (read by `buildAttributes` but missing from the old CLI field list).
- **Depublish deletion fixed:** the old path called `deleteObject({ objectID: itemKey })`, which never matched the `<id>_<index>` objectIDs. Deletion now goes through a shared `deleteFromIndex` helper that deletes by `_directus_reference` filter (also used by the delete and transcript distinct-rebuild paths).
- Heavy comments throughout, since this part of the CMS is tricky and rarely revisited.

## Verification

- `directus-extension build` succeeds; the algolia-index sources type-check clean.
- Sparse-entry diagnosis confirmed against the live prod index via the Algolia API; meetup/talk data model confirmed against `directus-cms/schema.json` (`meetups.talks` and reverse `talks.meetups` junction).

## After merge / deploy

Heal existing data with a full rebuild:

```
npm run algolia-index-rebuild podcasts
npm run algolia-index-rebuild transcripts
npm run algolia-index-rebuild meetups
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)