### PR TITLE
Make Algolia index rebuild robust: sanitize meetups, cap record size, paginate large collections

### DIFF
--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/cli/rebuild-index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/cli/rebuild-index.ts
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 
 import meow from 'meow';
-import { createDirectus, rest, readItems } from '@directus/sdk';
+import { createDirectus, rest } from '@directus/sdk';
 import { createFetchRequester } from '@algolia/requester-fetch';
 import { searchClient } from '@algolia/client-search';
 import 'dotenv/config'
 
 import { getHandlers } from './../handlers/index.ts';
+import { streamItems } from './../util/pagination.ts';
 
 const cli = meow(`
     Usage
@@ -54,15 +55,12 @@ for (const configurationItem of configuration) {
     if (cli.input.lastIndexOf(configurationItem.collection) !== -1) {
         console.log('Rebuilding index for collection: ' + configurationItem.collection);
 
-        const items = await directusClient.request(
-            readItems(configurationItem.collection, {
-                fields: configurationItem.handler.indexFields,
-                limit: -1,
-            })
-        );
-
+        // Stream the collection page by page (page size decided by the handler) instead of loading
+        // it all at once. Transcripts in particular cannot be read with `limit: -1` — each row holds
+        // a full hour of audio transcription. Streaming also keeps memory bounded: we process and
+        // push one item before fetching the next.
         let counter = 0;
-        for (const item of items) {
+        for await (const item of streamItems(directusClient, configurationItem.collection, configurationItem.handler)) {
             counter++;
             const payloads = configurationItem.handler.buildAttributes(item).map((payload) => {
                 return {

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/cli/repair-index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/cli/repair-index.ts
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 
 import meow from 'meow';
-import { createDirectus, rest, readItems } from '@directus/sdk';
+import { createDirectus, rest } from '@directus/sdk';
 import { createFetchRequester } from '@algolia/requester-fetch';
 import { searchClient } from '@algolia/client-search';
 import 'dotenv/config'
 
 import { getHandlers } from './../handlers/index.ts';
+import { collectItems } from './../util/pagination.ts';
 
 const cli = meow(`
     Usage
@@ -77,13 +78,10 @@ async function repairCollection(configItem: typeof configuration[0]): Promise<Re
 
     console.log(`\n🔍 Analyzing collection: ${configItem.collection}`);
 
-    // Get all items from Directus
-    const dbItems = await directusClient.request(
-        readItems(configItem.collection, {
-            fields: configItem.handler.indexFields,
-            limit: -1,
-        })
-    );
+    // Get all items from Directus. The repair pass diffs the whole collection against the index, so
+    // it genuinely needs every item in memory — but we still fetch through the handler's pagination
+    // (collectItems) so large collections like transcripts don't fail the bulk read with limit: -1.
+    const dbItems = await collectItems(directusClient, configItem.collection, configItem.handler);
 
     stats.totalDbItems = dbItems.length;
     console.log(`📊 Found ${stats.totalDbItems} items in database`);

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/handlers/ItemHandler.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/handlers/ItemHandler.ts
@@ -8,6 +8,16 @@ export interface ItemHandler {
      * missing here it will silently be absent from the index.
      */
     indexFields: string[];
+    /**
+     * Page size for the rebuild/repair CLIs' bulk reads from Directus. Most collections are small
+     * enough (in both row count AND per-row size) to fetch in a single `limit: -1` request, so the
+     * default (see {@link AbstractItemHandler}) returns `<= 0`, meaning "no pagination".
+     *
+     * Override with a small positive number for collections whose rows are individually large — e.g.
+     * transcripts, which embed a full hour of audio transcription per row. There a single bulk read
+     * overruns Directus (and would pin hundreds of MB in memory), so they must be paged through.
+     */
+    pageSize: number;
     updateRequired(item: any): boolean;
     buildAttributes(item: any): Record<string, any>[];
     requiresDistinctDeletionBeforeUpdate(): boolean;
@@ -19,6 +29,12 @@ export interface ItemHandler {
 export abstract class AbstractItemHandler {
 
     constructor(protected env, private logger) {
+    }
+
+    // No pagination by default: the whole collection is fetched in one request. Handlers with large
+    // rows (e.g. transcripts) override this with a small positive page size. See ItemHandler.pageSize.
+    get pageSize(): number {
+        return -1;
     }
 
     requiresDistinctDeletionBeforeUpdate(): boolean {

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/handlers/MeetupHandler.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/handlers/MeetupHandler.ts
@@ -1,9 +1,17 @@
 import { AbstractItemHandler } from './ItemHandler.ts';
-import { sanitize, sanitizeFull } from '../util/sanitizer.ts';
+import { sanitize, sanitizeFull, truncateToByteLimit } from '../util/sanitizer.ts';
 
 // Keep meetup records comfortably below Algolia's per-record size limit. Mirrors the podcast handler:
-// once the sanitized talk text grows past this, we fall back to fully stripped (tag-less) text.
+// once the sanitized text grows past this, we fall back to fully stripped (tag-less) text.
 const MAX_TALK_TEXT_LENGTH = 2500;
+const MAX_DESCRIPTION_LENGTH = 2500;
+
+// Algolia rejects any record over a hard 10 KB (10000-byte) limit, and a rejected record means the
+// meetup vanishes from search entirely. These byte budgets keep us safely under that ceiling even
+// for a meetup with a long description AND many talks. We give the description first claim on the
+// budget (it's what the search result card shows) and let the talk text use whatever remains.
+const MAX_RECORD_TEXT_BYTES = 9000;
+const MAX_DESCRIPTION_BYTES = 5000;
 
 export class MeetupHandler extends AbstractItemHandler{
 
@@ -43,6 +51,16 @@ export class MeetupHandler extends AbstractItemHandler{
     }
 
     buildAttributes(item: any): Record<string, any>[] {
+        // The description (intro + description) MUST be sanitized: these are rich-text fields and are
+        // sometimes pasted in from other tools (e.g. Slack), carrying kilobytes of `<div class=...>`
+        // markup that both pollutes search and blows past Algolia's record-size limit. We strip it the
+        // same way the podcast handler does — sanitize() keeps a little structure, sanitizeFull()
+        // removes everything — falling back to the harder strip once the text gets long.
+        let description = this.buildDescription(item, sanitize);
+        if (description.length > MAX_DESCRIPTION_LENGTH) {
+            description = this.buildDescription(item, sanitizeFull);
+        }
+
         // Talk text lives in its own searchable `talks` attribute rather than in `description`: the
         // search result card displays `description`, and we don't want to bury the meetup summary
         // under the concatenated talk abstracts. The index defines no explicit searchableAttributes,
@@ -52,15 +70,32 @@ export class MeetupHandler extends AbstractItemHandler{
             talks = this.buildTalkText(item, sanitizeFull);
         }
 
+        // Final byte-budget guard. Sanitizing already removes the worst offenders, but a genuinely
+        // long meetup (big description + many talks) could still exceed Algolia's 10 KB hard limit, so
+        // we cap by UTF-8 byte length. Description gets first claim; talks take whatever's left.
+        description = truncateToByteLimit(description, MAX_DESCRIPTION_BYTES);
+        const remainingTalkBytes = MAX_RECORD_TEXT_BYTES - Buffer.byteLength(description, 'utf8');
+        talks = truncateToByteLimit(talks, Math.max(0, remainingTalkBytes));
+
         return [{
             _type : 'meetup',
             title: item.title,
-            description: [item.intro, item.description].filter(Boolean).join(' '),
+            description: description || undefined,
             talks: talks || undefined,
             published_on: item.published_on,
             image: item.cover_image ? `${this.env.PUBLIC_URL}assets/${item.cover_image}` : undefined,
             slug: item.slug,
         }]
+    }
+
+    // Joins the meetup's intro and description into a single sanitized snippet. Both are rich-text
+    // fields, so each is run through the supplied sanitizer before being combined.
+    private buildDescription(item: any, sanitizer: (input: string) => string): string {
+        return [item.intro, item.description]
+            .filter(Boolean)
+            .map((text: string) => sanitizer(text).trim())
+            .filter(Boolean)
+            .join(' ');
     }
 
     // Concatenates every linked talk's title + abstract into one searchable string. Each `item.talks`

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/handlers/MeetupHandler.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/handlers/MeetupHandler.ts
@@ -80,8 +80,13 @@ export class MeetupHandler extends AbstractItemHandler{
         return [{
             _type : 'meetup',
             title: item.title,
-            description: description || undefined,
-            talks: talks || undefined,
+            // Always send a string (empty when there's no content), never `undefined`. The hook and
+            // rebuild push via partialUpdateObject, which drops `undefined` properties from the
+            // request — so an `undefined` here would leave a now-empty field showing its previous
+            // (possibly stale raw-HTML) value in the index instead of clearing it. An empty string
+            // explicitly overwrites it.
+            description: description,
+            talks: talks,
             published_on: item.published_on,
             image: item.cover_image ? `${this.env.PUBLIC_URL}assets/${item.cover_image}` : undefined,
             slug: item.slug,

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/handlers/TranscriptHandler.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/handlers/TranscriptHandler.ts
@@ -8,6 +8,14 @@ export class TranscriptHandler extends AbstractItemHandler {
         return 'transcripts';
     }
 
+    // Transcripts are the one collection that MUST be paged through. Each row embeds a full hour of
+    // audio transcription in `raw_response` (multi-MB JSON), so reading all ~170 at once with
+    // `limit: -1` overruns Directus' response and pins hundreds of MB in memory. A small page keeps
+    // each bulk read — and the rebuild's memory footprint — manageable.
+    get pageSize(): number {
+        return 10;
+    }
+
     // Every field read by updateRequired(), buildAttributes() and buildDistinctKey(). `status` is
     // added by the hook. The deep `podcast.*` read is CRITICAL: the related podcast supplies the
     // entry's title/number/date/cover/slug AND its id for the distinct key. Without it the hook

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/util/pagination.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/util/pagination.ts
@@ -1,0 +1,74 @@
+import { readItems } from '@directus/sdk';
+import { ItemHandler } from '../handlers/ItemHandler.ts';
+
+// Shared bulk-read helpers for the rebuild/repair CLIs.
+//
+// Whether and how a collection is paged is decided by the handler (handler.pageSize), so the two CLIs
+// stay in lock-step and never reimplement pagination differently. A handler returning a page size of
+// `<= 0` opts out of pagination and is read in a single `limit: -1` request; a positive page size is
+// read page by page.
+//
+// The fields fetched come from `handler.indexFields` — the same single source of truth the live hook
+// uses — so a rebuilt/repaired item is built from exactly the fields the handler expects.
+
+/**
+ * Streams a collection's items one page at a time. Prefer this over {@link collectItems} whenever the
+ * caller can process items as they arrive (e.g. the rebuild CLI pushes each item to Algolia and moves
+ * on), because it never holds more than a single page in memory. This is what makes rebuilding the
+ * transcript index — where each row carries a full hour of audio transcription — feasible.
+ */
+export async function* streamItems(
+    client: any,
+    collection: string,
+    handler: ItemHandler,
+): AsyncGenerator<any> {
+    const pageSize = handler.pageSize;
+
+    // No pagination: fetch the whole collection in one request.
+    if (pageSize <= 0) {
+        const items = await client.request(
+            readItems(collection, {
+                fields: handler.indexFields,
+                limit: -1,
+            }),
+        );
+        yield* items;
+        return;
+    }
+
+    // Paged read. Directus pages are 1-based; a short (or empty) page means we've reached the end.
+    let page = 1;
+    while (true) {
+        const batch = await client.request(
+            readItems(collection, {
+                fields: handler.indexFields,
+                limit: pageSize,
+                page,
+            }),
+        );
+
+        yield* batch;
+
+        if (batch.length < pageSize) {
+            break;
+        }
+        page++;
+    }
+}
+
+/**
+ * Eagerly collects every item via {@link streamItems}. Use only when the caller genuinely needs the
+ * whole collection in memory at once — e.g. the repair CLI, which diffs the database against the
+ * index. Otherwise prefer streamItems() to keep the memory footprint bounded.
+ */
+export async function collectItems(
+    client: any,
+    collection: string,
+    handler: ItemHandler,
+): Promise<any[]> {
+    const items: any[] = [];
+    for await (const item of streamItems(client, collection, handler)) {
+        items.push(item);
+    }
+    return items;
+}

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/util/sanitizer.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/util/sanitizer.ts
@@ -15,3 +15,31 @@ export function sanitizeFull(input: string): string {
         allowedAttributes: { }
     });
 }
+
+// Hard-trims a string so its UTF-8 byte length never exceeds `maxBytes`. Algolia measures records in
+// BYTES (not characters) and rejects any record over its hard 10 KB limit outright — a rejected
+// record means the item silently disappears from search. We measure bytes (not `.length`) because
+// umlauts/emoji in German meetup text cost 2–4 bytes each, so a character cap would under-count.
+// Trims on a word boundary where one is reasonably close, to avoid cutting mid-word.
+export function truncateToByteLimit(input: string, maxBytes: number): string {
+    if (Buffer.byteLength(input, 'utf8') <= maxBytes) {
+        return input;
+    }
+
+    // Converge from the overshoot: each pass drops roughly the number of surplus bytes, so we reach
+    // the budget in a handful of iterations regardless of how multi-byte the text is.
+    let truncated = input;
+    while (Buffer.byteLength(truncated, 'utf8') > maxBytes && truncated.length > 0) {
+        const overshootBytes = Buffer.byteLength(truncated, 'utf8') - maxBytes;
+        const charsToDrop = Math.max(1, Math.ceil(overshootBytes / 2));
+        truncated = truncated.slice(0, truncated.length - charsToDrop);
+    }
+
+    // Prefer ending at the last word boundary, but only if we don't throw away too much.
+    const lastSpace = truncated.lastIndexOf(' ');
+    if (lastSpace > truncated.length * 0.8) {
+        truncated = truncated.slice(0, lastSpace);
+    }
+
+    return truncated.trimEnd();
+}


### PR DESCRIPTION
Two fixes that surfaced while rebuilding the Algolia index after the search-index overhaul (#196).

## 1. Meetup records exceeded Algolia's 10 KB size limit

Rebuilding `meetups` failed with `Record is too big size=11503/10000 bytes`.

Meetup `intro`/`description` are rich-text fields, sometimes pasted from other tools (e.g. Slack) with kilobytes of `<div class="c-message_kit__...">` markup. They were indexed **raw** — unlike podcasts, which sanitize. That bloat both pollutes search and overflows the record. **A rejected record means the meetup silently vanishes from search.**

- **Sanitize** `intro`/`description` (`sanitize` → `sanitizeFull` fallback), mirroring the podcast handler.
- **Byte-budget guard:** new `truncateToByteLimit()` caps the record by UTF-8 byte length (German umlauts/emoji cost 2–4 bytes each), so even a long meetup with many talks stays under the limit. Description gets first claim (it's the search-card snippet); talk text takes the remainder.

## 2. Transcript rebuild failed on the bulk read

Each of the ~170 transcripts embeds a full hour of audio transcription in `raw_response`, so reading them all with `limit: -1` overruns Directus and memory.

- Handlers now declare a **`pageSize`** (default `<= 0` = no pagination, fetch all in one request — the existing behaviour for small collections). `TranscriptHandler` overrides it to page in batches of 10, the only collection whose rows are individually large.
- Shared `util/pagination.ts`: `streamItems()` yields page by page (bounded memory), `collectItems()` eagerly gathers the whole set.
- `rebuild-index` **streams** (process + push one item, then fetch the next — bounded memory). `repair-index` uses `collectItems` because it must diff the entire collection against the index.

## Verification

- `directus-extension build` passes.
- `tsc --noEmit` clean for algolia-index sources (only the pre-existing tsconfig module-config warnings remain, which the esbuild build ignores).

## After merge

```
npm run algolia-index-rebuild meetups
npm run algolia-index-rebuild transcripts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)