### PR TITLE
Rebuild Algolia records with full replace, not partial merge

### DIFF
--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/cli/rebuild-index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/cli/rebuild-index.ts
@@ -70,6 +70,11 @@ for (const configurationItem of configuration) {
                 }
             });
 
+            // Transcripts (and any handler that fans an item out into a VARIABLE number of objects)
+            // must delete the item's existing entries first: when the chunk count shrinks, the
+            // now-orphaned `${id}_N` records would otherwise linger. Single-object collections
+            // (meetups, podcasts, ...) don't need this — the full-record replace below overwrites
+            // their one `${id}_0` entry in place.
             if (configurationItem.handler.requiresDistinctDeletionBeforeUpdate()) {
                 const results = await algoliaClient.browseObjects({
                     indexName: ALGOLIA_INDEX,
@@ -89,12 +94,19 @@ for (const configurationItem of configuration) {
                 });
             }
 
+            // Write each payload as a FULL-RECORD REPLACE (addOrUpdateObject = PUT), NOT a partial
+            // merge. This is a correctness fix, not a style choice: partialUpdateObject MERGES into the
+            // stored record, and Algolia refuses to merge into a record that is already over its 10 KB
+            // limit — so a stale, oversized entry (e.g. an old meetup indexed with a full raw-HTML
+            // description) could never shrink itself, however much the source text was trimmed; the
+            // write was rejected citing the EXISTING record's size. A full replace overwrites the whole
+            // record (dropping any stale attributes too) and is accepted as long as the NEW payload
+            // fits — which the handlers' size guards ensure.
             await Promise.all(payloads.map(async (payload, index) => {
-                await algoliaClient.partialUpdateObject({
+                await algoliaClient.addOrUpdateObject({
                     indexName: ALGOLIA_INDEX,
                     objectID: `${item.id}_${index}`,
-                    attributesToUpdate: payload,
-                    createIfNotExists: true,
+                    body: payload,
                 });
             }));
 


### PR DESCRIPTION
## Problem

Even after drastically reducing a meetup's source text in Directus, rebuilding still failed:

```
ApiError: Record is too big size=11078/10000 bytes.
```

Inspecting the stored record showed why: `8ebdda5a..._0` still held the **full original ~11 KB agenda** (the old Wix/CMS paste, full of HTML entities and `class="font_8"` markup). The reduced Directus text never reached it.

**Root cause:** the rebuild wrote via `partialUpdateObject`, which *merges* into the stored record. Algolia cannot apply a partial update to a record that is already over the 10 KB limit (it can't load-and-merge an oversized record), so it rejects the write — citing the **existing** record's size, not the payload's. The stale, oversized record was effectively frozen: no amount of trimming the source could shrink it, because the only operation that would fix it is the one Algolia refuses. Meetups never hit the delete-before-write path either (that was gated to transcripts), so nothing ever cleared it.

## Fix

Write each payload with **`addOrUpdateObject`** (a full PUT replace) instead of `partialUpdateObject` (a merge). A full replace overwrites the entire record — dropping stale attributes and any prior oversize — and is accepted as long as the *new* payload fits, which the handlers' size guards already ensure.

The delete-before-write step stays gated to transcripts (`requiresDistinctDeletionBeforeUpdate()`), which genuinely need it to clear orphaned `_N` chunk records when a transcript's chunk count shrinks. Single-object collections (meetups, podcasts, …) need no prior delete — their one `_0` entry is overwritten in place.

## Verification

- `directus-extension build` passes.
- Confirmed `addOrUpdateObject({ indexName, objectID, body })` exists in the installed client (`@algolia/client-search` 5.52.1) and is documented as "the existing record is replaced".

## After merge

Rebuild the extension / redeploy the Directus container, then:

```
npm run algolia-index-rebuild meetups
```

## Follow-up worth considering

The live hook (`index.ts`) and `repair-index.ts` still write via `partialUpdateObject`, so they carry the same latent fragility (can't shrink/replace an oversized or stale record). After a full rebuild every record is clean, so it isn't urgent — but switching those to the same replace semantics would close the gap. Happy to do it in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)