### PR TITLE
Catch hook errors so CMS extensions never crash the main thread

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -23,5 +23,8 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Run ESLint
+        run: npm run lint
+
       - name: Run tests
         run: npm test

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/eslint.config.js
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/eslint.config.js
@@ -3,7 +3,7 @@ import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
     {
-        ignores: ['**/dist/**', '**/podcast-transcription/**', '**/assets/**', 'eslint.config.js'],
+        ignores: ['**/dist/**', '**/podcast-transcription/**', '**/assets/**', 'eslint.config.js', 'jest.config.ts'],
     },
     eslint.configs.recommended,
     {
@@ -20,7 +20,25 @@ export default tseslint.config(
             },
         },
         rules: {
+            // TypeScript already reports genuinely-undefined identifiers and is aware of Node
+            // globals (Buffer, fetch, setImmediate, …). Core `no-undef` does not understand the
+            // TS lib/types, so leaving it on produces false positives. Disabling it is the
+            // typescript-eslint recommendation for type-checked projects.
+            'no-undef': 'off',
+            // Defer unused-symbol detection to the TS-aware rule, which understands type-only
+            // parameters (e.g. names in a function-type alias) and ignores `_`-prefixed args.
+            'no-unused-vars': 'off',
+            '@typescript-eslint/no-unused-vars': [
+                'error',
+                { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrors: 'none' },
+            ],
             '@typescript-eslint/consistent-type-imports': 'error',
+            // Catch unhandled promises (the buzzsprout-class bug that crashed the CMS): an
+            // async hook handler must be awaited, returned, or have a `.catch`.
+            '@typescript-eslint/no-floating-promises': 'error',
+            // `checksVoidReturn: false` avoids false positives on Directus `action('x', async () => ...)`
+            // callbacks, whose typings expect a void-returning function.
+            '@typescript-eslint/no-misused-promises': ['error', { checksVoidReturn: false }],
         },
         files: ['**/*.ts'],
     }

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/package.json
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/package.json
@@ -26,6 +26,11 @@
             },
             {
                 "type": "hook",
+                "name": "process-guard",
+                "source": "src/process-guard/index.ts"
+            },
+            {
+                "type": "hook",
                 "name": "deploy-website",
                 "source": "src/deploy-website/index.ts"
             },
@@ -133,6 +138,7 @@
         "link": "directus-extension link",
         "add": "directus-extension add",
         "eslint": "eslint --fix .",
+        "lint": "eslint .",
         "prettier": "prettier . --write",
         "algolia-index-rebuild": "tsx src/algolia-index/cli/rebuild-index.ts",
         "algolia-index-repair": "tsx src/algolia-index/cli/repair-index.ts",

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/handlers/PickOfTheDayHandler.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/handlers/PickOfTheDayHandler.ts
@@ -1,4 +1,4 @@
-import { AbstractItemHandler, ItemHandler } from './ItemHandler.ts';
+import { AbstractItemHandler } from './ItemHandler.ts';
 
 export class PickOfTheDayHandler extends AbstractItemHandler {
 

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/handlers/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/handlers/index.ts
@@ -1,5 +1,5 @@
 import { PodcastHandler } from "./PodcastHandler.ts"
-import { ItemHandler } from "./ItemHandler.ts"
+import type { ItemHandler } from "./ItemHandler.ts"
 import { MeetupHandler } from './MeetupHandler.ts';
 import { SpeakerHandler } from './SpeakerHandler.ts';
 import { PickOfTheDayHandler } from './PickOfTheDayHandler.ts';

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/index.ts
@@ -1,10 +1,11 @@
 import { defineHook } from '@directus/extensions-sdk';
 import { createFetchRequester } from '@algolia/requester-fetch';
 import { searchClient } from '@algolia/client-search';
- import { ItemHandler } from './handlers/ItemHandler.ts';
+ import type { ItemHandler } from './handlers/ItemHandler.ts';
 import { getHandlers } from './handlers/index.ts'
-import { SearchClient } from 'algoliasearch';
-import { ItemsService as ItemsServiceType } from '../buzzsprout/handlers/types.js';
+import type { SearchClient } from 'algoliasearch';
+import type { ItemsService as ItemsServiceType } from '../buzzsprout/handlers/types.js';
+import { safeAction } from '../shared/safeHook.ts';
 const HOOK_NAME = 'algolia-index'
 
 export default defineHook(({ action }, hookContext) => {
@@ -22,163 +23,50 @@ export default defineHook(({ action }, hookContext) => {
 
     const client = searchClient(env.ALGOLIA_APP_ID, env.ALGOLIA_API_KEY, { requester: createFetchRequester() });
 
-    action('podcasts.items.create', async function (metadata, eventContext) {
-        handleUpdateAction(metadata, eventContext, {
-            handler: handlers.podcastHandler,
-            client,
-            ItemsService,
-            logger,
-            env
-        });
-    })
+    // safeAction wraps each callback so a thrown error / rejected promise is caught and logged
+    // instead of becoming an unhandled rejection that crashes the CMS. The callbacks RETURN the
+    // handler promise so safeAction's `.catch` can observe it.
+    const onUpdate = (handler: ItemHandler) =>
+        safeAction(HOOK_NAME, logger, (metadata, eventContext) =>
+            handleUpdateAction(metadata, eventContext, { handler, client, ItemsService, logger, env })
+        )
+    const onDelete = (handler: ItemHandler) =>
+        safeAction(HOOK_NAME, logger, (metadata, eventContext) =>
+            handleDeleteAction(metadata, eventContext, { handler, client, logger, env })
+        )
 
-    action('podcasts.items.update', async function (metadata, eventContext) {
-        handleUpdateAction(metadata, eventContext, {
-            handler: handlers.podcastHandler,
-            client,
-            ItemsService,
-            logger,
-            env
-        });
-    })
+    action('podcasts.items.create', onUpdate(handlers.podcastHandler))
+    action('podcasts.items.update', onUpdate(handlers.podcastHandler))
+    action('podcasts.items.delete', onDelete(handlers.podcastHandler))
 
-    action('podcasts.items.delete', async function(metadata, eventContext) {
-        handleDeleteAction(metadata, eventContext, {
-            handler: handlers.podcastHandler,
-            client,
-            logger,
-            env
-        })
-    })
-
-    action('meetups.items.create', async function (metadata, eventContext) {
-        handleUpdateAction(metadata, eventContext, {
-            handler: handlers.meetupHandler,
-            client,
-            ItemsService,
-            logger,
-            env
-        });
-    })
-
-    action('meetups.items.update', async function (metadata, eventContext) {
-        handleUpdateAction(metadata, eventContext, {
-            handler: handlers.meetupHandler,
-            client,
-            ItemsService,
-            logger,
-            env
-        });
-    })
-
-    action('meetups.items.delete', async function(metadata, eventContext) {
-        handleDeleteAction(metadata, eventContext, {
-            handler: handlers.meetupHandler,
-            client,
-            logger,
-            env
-        })
-    })
+    action('meetups.items.create', onUpdate(handlers.meetupHandler))
+    action('meetups.items.update', onUpdate(handlers.meetupHandler))
+    action('meetups.items.delete', onDelete(handlers.meetupHandler))
 
     // Talks are their own collection embedded into meetups (see MeetupHandler). Editing a talk's
     // title/abstract must refresh the meetup entries that embed it — see handleRelatedTalkChange for
     // why only `update` is wired up (create/delete are covered by the accompanying meetup update).
-    action('talks.items.update', async function (metadata, eventContext) {
+    action('talks.items.update', safeAction(HOOK_NAME, logger, (metadata, eventContext) =>
         handleRelatedTalkChange(metadata, eventContext, {
             meetupHandler: handlers.meetupHandler,
             client,
             ItemsService,
             logger,
             env
-        });
-    })
-
-    action('speakers.items.create', async function (metadata, eventContext) {
-        handleUpdateAction(metadata, eventContext, {
-            handler: handlers.speakerHandler,
-            client,
-            ItemsService,
-            logger,
-            env
-        });
-    })
-
-    action('speakers.items.update', async function (metadata, eventContext) {
-        handleUpdateAction(metadata, eventContext, {
-            handler: handlers.speakerHandler,
-            client,
-            ItemsService,
-            logger,
-            env
-        });
-    })
-
-    action('speakers.items.delete', async function(metadata, eventContext) {
-        handleDeleteAction(metadata, eventContext, {
-            handler: handlers.speakerHandler,
-            client,
-            logger,
-            env
         })
-    })
+    ))
 
-    action('picks_of_the_day.items.create', async function (metadata, eventContext) {
-        handleUpdateAction(metadata, eventContext, {
-            handler: handlers.pickOfTheDayHandler,
-            client,
-            ItemsService,
-            logger,
-            env
-        });
-    })
+    action('speakers.items.create', onUpdate(handlers.speakerHandler))
+    action('speakers.items.update', onUpdate(handlers.speakerHandler))
+    action('speakers.items.delete', onDelete(handlers.speakerHandler))
 
-    action('picks_of_the_day.items.update', async function (metadata, eventContext) {
-        handleUpdateAction(metadata, eventContext, {
-            handler: handlers.pickOfTheDayHandler,
-            client,
-            ItemsService,
-            logger,
-            env
-        });
-    })
+    action('picks_of_the_day.items.create', onUpdate(handlers.pickOfTheDayHandler))
+    action('picks_of_the_day.items.update', onUpdate(handlers.pickOfTheDayHandler))
+    action('picks_of_the_day.items.delete', onDelete(handlers.pickOfTheDayHandler))
 
-    action('picks_of_the_day.items.delete', async function(metadata, eventContext) {
-        handleDeleteAction(metadata, eventContext, {
-            handler: handlers.pickOfTheDayHandler,
-            client,
-            logger,
-            env
-        })
-    })
-
-    action('transcripts.items.create', async function (metadata, eventContext) {
-        handleUpdateAction(metadata, eventContext, {
-            handler: handlers.transcriptHandler,
-            client,
-            ItemsService,
-            logger,
-            env
-        });
-    })
-
-    action('transcripts.items.update', async function (metadata, eventContext) {
-        handleUpdateAction(metadata, eventContext, {
-            handler: handlers.transcriptHandler,
-            client,
-            ItemsService,
-            logger,
-            env
-        });
-    })
-
-    action('transcripts.items.delete', async function(metadata, eventContext) {
-        handleDeleteAction(metadata, eventContext, {
-            handler: handlers.transcriptHandler,
-            client,
-            logger,
-            env
-        })
-    })
+    action('transcripts.items.create', onUpdate(handlers.transcriptHandler))
+    action('transcripts.items.update', onUpdate(handlers.transcriptHandler))
+    action('transcripts.items.delete', onDelete(handlers.transcriptHandler))
 });
 
 async function handleUpdateAction(metadata, eventContext, dependencies: {

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/util/pagination.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/algolia-index/util/pagination.ts
@@ -1,5 +1,5 @@
 import { readItems } from '@directus/sdk';
-import { ItemHandler } from '../handlers/ItemHandler.ts';
+import type { ItemHandler } from '../handlers/ItemHandler.ts';
 
 // Shared bulk-read helpers for the rebuild/repair CLIs.
 //

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/asset-generation/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/asset-generation/index.ts
@@ -1,6 +1,7 @@
 import { defineHook } from '@directus/extensions-sdk'
 import { generateAssetsForPodcast, regenerateAssets } from './generateAssets.ts'
 import { postSlackMessage } from '../shared/postSlackMessage.ts'
+import { safeAction } from '../shared/safeHook.ts'
 
 const HOOK_NAME = 'asset-generation'
 
@@ -16,7 +17,7 @@ export default defineHook(({ action }, hookContext) => {
      * Trigger asset generation when a speaker's portal submission is approved.
      * This indicates the speaker has submitted their info and images, and an admin approved them.
      */
-    action('speakers.items.update', async ({ payload, keys }, context) => {
+    action('speakers.items.update', safeAction(HOOK_NAME, logger, async ({ payload, keys }, context) => {
         // Only trigger when portal_submission_status changes to 'approved'
         if (payload.portal_submission_status !== 'approved') {
             return
@@ -87,12 +88,12 @@ export default defineHook(({ action }, hookContext) => {
         } catch (err: any) {
             logger.error(`${HOOK_NAME}: Error processing speaker approval: ${err.message}`)
         }
-    })
+    }))
 
     /**
      * Trigger asset regeneration when regenerate_assets is set to true on a podcast.
      */
-    action('podcasts.items.update', async ({ payload, keys }, context) => {
+    action('podcasts.items.update', safeAction(HOOK_NAME, logger, async ({ payload, keys }, context) => {
         // Only trigger when regenerate_assets is set to true
         if (payload.regenerate_assets !== true) {
             return
@@ -147,5 +148,5 @@ export default defineHook(({ action }, hookContext) => {
                 }
             })
         }
-    })
+    }))
 })

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/buzzsprout/handlers/buzzsprout.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/buzzsprout/handlers/buzzsprout.ts
@@ -1,4 +1,5 @@
-import { AxiosRequestConfig, default as axios } from 'axios';
+import type { AxiosRequestConfig} from 'axios';
+import { default as axios } from 'axios';
 // @ts-ignore
 import { getFullPodcastTitle, getUrlSlug } from '../../../../../../shared-code/index.ts'
 import { postSlackMessage } from '../../shared/postSlackMessage.ts'

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/buzzsprout/handlers/types.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/buzzsprout/handlers/types.ts
@@ -62,12 +62,6 @@ export interface Env {
     BUZZSPROUT_API_TOKEN: string
 }
 
-// Base Action Data Interface
-export interface ActionData<T = Payload> {
-    payload: T
-    context: Context
-}
-
 export interface Dependencies {
     logger: Logger
     ItemsService: new (collection: string, options: any) => ItemsService

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/buzzsprout/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/buzzsprout/index.ts
@@ -2,6 +2,7 @@ import { defineHook } from '@directus/extensions-sdk'
 import { handlePickOfTheDayAction } from './handlers/handlePickOfTheDayAction.ts'
 import { handlePodcastAction } from './handlers/handlePodcastAction.ts'
 import { handleTagAction } from './handlers/handleTagAction.ts'
+import { safeAction } from '../shared/safeHook.ts'
 
 const HOOK_NAME = 'buzzsprout'
 
@@ -15,9 +16,9 @@ export default defineHook(({ action }, hookContext) => {
         return
     }
 
-    action('podcasts.items.create', function (metadata, eventContext) {
+    const podcastHandler = (metadata: any, eventContext: any) => {
         const { payload } = metadata
-        handlePodcastAction(
+        return handlePodcastAction(
             HOOK_NAME,
             {
                 payload,
@@ -26,23 +27,13 @@ export default defineHook(({ action }, hookContext) => {
             },
             { logger, ItemsService, env }
         )
-    })
-    action('podcasts.items.update', function (metadata, eventContext) {
-        const { payload } = metadata
-        handlePodcastAction(
-            HOOK_NAME,
-            {
-                payload,
-                metadata: { ...metadata, collection: 'podcasts' },
-                context: eventContext,
-            },
-            { logger, ItemsService, env }
-        )
-    })
+    }
+    action('podcasts.items.create', safeAction(HOOK_NAME, logger, podcastHandler))
+    action('podcasts.items.update', safeAction(HOOK_NAME, logger, podcastHandler))
 
-    action('picks_of_the_day.items.create', function (metadata, eventContext) {
+    const pickHandler = (metadata: any, eventContext: any) => {
         const { payload } = metadata
-        handlePickOfTheDayAction(
+        return handlePickOfTheDayAction(
             HOOK_NAME,
             {
                 payload,
@@ -51,23 +42,13 @@ export default defineHook(({ action }, hookContext) => {
             },
             { logger, ItemsService, env }
         )
-    })
-    action('picks_of_the_day.items.update', function (metadata, eventContext) {
-        const { payload } = metadata
-        handlePickOfTheDayAction(
-            HOOK_NAME,
-            {
-                payload,
-                metadata: { ...metadata, collection: 'picks_of_the_day' },
-                context: eventContext,
-            },
-            { logger, ItemsService, env }
-        )
-    })
+    }
+    action('picks_of_the_day.items.create', safeAction(HOOK_NAME, logger, pickHandler))
+    action('picks_of_the_day.items.update', safeAction(HOOK_NAME, logger, pickHandler))
 
-    action('tags.items.create', function (metadata, eventContext) {
+    const tagHandler = (metadata: any, eventContext: any) => {
         const { payload } = metadata
-        handleTagAction(
+        return handleTagAction(
             HOOK_NAME,
             {
                 payload,
@@ -76,18 +57,8 @@ export default defineHook(({ action }, hookContext) => {
             },
             { logger, ItemsService, env }
         )
-    })
-    action('tags.items.update', function (metadata, eventContext) {
-        const { payload } = metadata
-        handleTagAction(
-            HOOK_NAME,
-            {
-                payload,
-                metadata: { ...metadata, collection: 'tags' },
-                context: eventContext,
-            },
-            { logger, ItemsService, env }
-        )
-    })
+    }
+    action('tags.items.create', safeAction(HOOK_NAME, logger, tagHandler))
+    action('tags.items.update', safeAction(HOOK_NAME, logger, tagHandler))
 })
 

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/content-approval/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/content-approval/index.ts
@@ -1,4 +1,5 @@
 import { defineHook } from '@directus/extensions-sdk'
+import { safeAction } from '../shared/safeHook.ts'
 
 const HOOK_NAME = 'content-approval'
 
@@ -8,7 +9,7 @@ export default defineHook(({ action }, hookContext) => {
     const getSchema = hookContext.getSchema
 
     // Listen for updates to podcast_generated_content
-    action('podcast_generated_content.items.update', async function (metadata, eventContext) {
+    action('podcast_generated_content.items.update', safeAction(HOOK_NAME, logger, async function (metadata, eventContext) {
         const { payload, keys } = metadata
 
         if (payload.status === 'approved') {
@@ -16,7 +17,7 @@ export default defineHook(({ action }, hookContext) => {
         } else if (payload.status && payload.status !== 'approved') {
             await handleUnapproval(keys, eventContext)
         }
-    })
+    }))
 
     async function handleApproval(keys: string[], eventContext: any) {
         try {

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/content-generation/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/content-generation/index.ts
@@ -1,6 +1,7 @@
 import { defineHook } from '@directus/extensions-sdk'
 import { generateContent } from './generateContent.js'
 import { postSlackMessage } from '../shared/postSlackMessage.ts'
+import { safeAction } from '../shared/safeHook.ts'
 
 const HOOK_NAME = 'content-generation'
 
@@ -16,7 +17,7 @@ export default defineHook(({ action }, hookContext) => {
     }
 
     // Trigger on podcast update when transcript_text is added
-    action('podcasts.items.update', async function (metadata, eventContext) {
+    action('podcasts.items.update', safeAction(HOOK_NAME, logger, async function (metadata, eventContext) {
         const { payload, keys } = metadata
 
         // Check if transcript_text was updated
@@ -50,5 +51,5 @@ export default defineHook(({ action }, hookContext) => {
                 logger.error(`${HOOK_NAME} hook: Failed to send Slack notification: ${slackErr.message}`)
             }
         })
-    })
+    }))
 })

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/create-profile/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/create-profile/index.ts
@@ -1,6 +1,6 @@
 import { defineHook } from '@directus/extensions-sdk'
 import { createHookErrorConstructor } from '../shared/errors.ts'
-import { FilterHandler} from '@directus/types'
+import type { FilterHandler} from '@directus/types'
 
 const HOOK_NAME = 'create-profile'
 

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/deploy-website/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/deploy-website/index.ts
@@ -2,6 +2,7 @@ import { defineHook } from '@directus/extensions-sdk'
 import axios from 'axios'
 import { createHookErrorConstructor } from '../shared/errors.ts'
 import { postSlackMessage } from './../shared/postSlackMessage.ts'
+import { safeAction } from '../shared/safeHook.ts'
 
 const HOOK_NAME = 'deploy-website'
 
@@ -18,16 +19,16 @@ export default defineHook(({ action }, hookContext) => {
     /**
      * It deploys our website on created items, if necessary.
      */
-    action('items.create', ({ payload, ...metadata }, context) =>
+    action('items.create', safeAction(HOOK_NAME, logger, ({ payload, ...metadata }, context) =>
         handleAction('create', { payload, metadata, context })
-    )
+    ))
 
     /**
      * It deploys our website on updated items, if necessary.
      */
-    action('items.update', ({ payload, ...metadata }, context) =>
+    action('items.update', safeAction(HOOK_NAME, logger, ({ payload, ...metadata }, context) =>
         handleAction('update', { payload, metadata, context })
-    )
+    ))
 
     async function handleAction(
         type: string,

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/member-matching/__tests__/matchMembers.test.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/member-matching/__tests__/matchMembers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from '@jest/globals'
-import { extractSpeakerNames, findMatchingMembers, MemberData } from './../matchMembers.ts'
+import type { MemberData } from './../matchMembers.ts';
+import { extractSpeakerNames, findMatchingMembers } from './../matchMembers.ts'
 
 describe('extractSpeakerNames', () => {
     test('should extract names with timestamp format', () => {

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/member-matching/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/member-matching/index.ts
@@ -1,6 +1,7 @@
 import { defineHook } from '@directus/extensions-sdk'
 import { matchMembersFromTranscript } from './matchMembers.js'
 import { postSlackMessage } from '../shared/postSlackMessage.ts'
+import { safeAction } from '../shared/safeHook.ts'
 
 const HOOK_NAME = 'member-matching'
 
@@ -41,6 +42,6 @@ export default defineHook(({ action }, hookContext) => {
     }
 
     // Trigger on podcast creation or update when transcript_text is present
-    action('podcasts.items.create', handlePodcastAction)
-    action('podcasts.items.update', handlePodcastAction)
+    action('podcasts.items.create', safeAction(HOOK_NAME, logger, handlePodcastAction))
+    action('podcasts.items.update', safeAction(HOOK_NAME, logger, handlePodcastAction))
 })

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/member-matching/matchMembers.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/member-matching/matchMembers.ts
@@ -28,7 +28,7 @@ export function extractSpeakerNames(transcriptText: string): string[] {
     // Pattern 1: Name followed by timestamp in parentheses
     // Examples: "Jan Gregor Emge-Triebel (00:12.534)", "Fabi Fink (00:35.735)"
     // Use [ \t]+ instead of \s+ to avoid matching across newlines
-    const timestampPattern = /^([A-ZÄÖÜa-zäöüß][A-ZÄÖÜa-zäöüß\-]+(?:[ \t]+[A-ZÄÖÜa-zäöüß][A-ZÄÖÜa-zäöüß\-]+)*)[ \t]+\(\d{2}:\d{2}\.\d+\)/gm
+    const timestampPattern = /^([A-ZÄÖÜa-zäöüß][A-ZÄÖÜa-zäöüß-]+(?:[ \t]+[A-ZÄÖÜa-zäöüß][A-ZÄÖÜa-zäöüß-]+)*)[ \t]+\(\d{2}:\d{2}\.\d+\)/gm
 
     let match
     while ((match = timestampPattern.exec(transcriptText)) !== null) {
@@ -40,7 +40,7 @@ export function extractSpeakerNames(transcriptText: string): string[] {
 
     // Pattern 2: Name followed by colon (fallback for other transcript formats)
     // Examples: "Dennis:", "Dennis Becker:", "**Jojo**:"
-    const colonPattern = /^(?:\*\*)?([A-ZÄÖÜa-zäöüß][A-ZÄÖÜa-zäöüß\-]+(?:\s+[A-ZÄÖÜa-zäöüß][A-ZÄÖÜa-zäöüß\-]+)?)(?:\*\*)?:/gm
+    const colonPattern = /^(?:\*\*)?([A-ZÄÖÜa-zäöüß][A-ZÄÖÜa-zäöüß-]+(?:\s+[A-ZÄÖÜa-zäöüß][A-ZÄÖÜa-zäöüß-]+)?)(?:\*\*)?:/gm
 
     while ((match = colonPattern.exec(transcriptText)) !== null) {
         const name = match[1].trim()

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/podcast-transcript/generateTranscriptItem.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/podcast-transcript/generateTranscriptItem.ts
@@ -1,7 +1,7 @@
-import { Dependencies } from '../buzzsprout/handlers/types.js';
+import type { Dependencies } from '../buzzsprout/handlers/types.js';
 import { createHookErrorConstructor } from './../shared/errors.ts';
 import { postSlackMessage } from './../shared/postSlackMessage.ts';
-import { Query } from '@directus/types/dist/query.js'
+import type { Query } from '@directus/types/dist/query.js'
 
 async function generateTranscriptItem(
     HOOK_NAME: string,

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/podcast-transcript/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/podcast-transcript/index.ts
@@ -2,6 +2,7 @@ import { defineHook } from '@directus/extensions-sdk'
 
 import generateTranscriptItem from './generateTranscriptItem.js';
 import processTranscriptItem from './processTranscriptItem.js';
+import { safeAction } from '../shared/safeHook.ts'
 
 const HOOK_NAME = 'podcast-transcript-create'
 
@@ -11,13 +12,13 @@ export default defineHook(({ action, schedule }, hookContext) => {
     const getSchema = hookContext.getSchema
     const env = hookContext.env
 
-    action('podcasts.items.create', ({ payload, ...metadata }, context) =>
+    action('podcasts.items.create', safeAction(HOOK_NAME, logger, ({ payload, ...metadata }, context) =>
         generateTranscriptItem(HOOK_NAME, { payload, metadata, context }, {logger, ItemsService})
-    )
+    ))
 
-    action('podcasts.items.update', ({ payload, ...metadata }, context) =>
+    action('podcasts.items.update', safeAction(HOOK_NAME, logger, ({ payload, ...metadata }, context) =>
         generateTranscriptItem(HOOK_NAME, { payload, metadata, context }, {logger, ItemsService})
-    )
+    ))
 
     schedule('*/5 * * * *',
         processTranscriptItem(HOOK_NAME, {logger, ItemsService, getSchema, env})

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/podcast-transcript/processTranscriptItem.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/podcast-transcript/processTranscriptItem.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 import { postSlackMessage } from './../shared/postSlackMessage.ts'
-import { Dependencies } from './../buzzsprout/handlers/types.js';
+import type { Dependencies } from './../buzzsprout/handlers/types.js';
 
 function processTranscriptItem(
     HOOK_NAME: string,

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/process-guard/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/process-guard/index.ts
@@ -1,0 +1,42 @@
+import { defineHook } from '@directus/extensions-sdk'
+import { postSlackMessage } from '../shared/postSlackMessage.ts'
+
+const HOOK_NAME = 'process-guard'
+
+// Guard against attaching the listeners more than once if the bundle re-initializes.
+let registered = false
+
+/**
+ * A last-resort, process-level safety net. Even if an individual hook misses a
+ * `.catch`, an unhandled promise rejection must never take the whole CMS down.
+ *
+ * - unhandledRejection: swallowed + logged (and reported to Slack). This is the
+ *   crash class that previously rebooted the CMS on hook failures.
+ * - uncaughtException: logged + reported, then the process exits so the host can
+ *   restart it cleanly — after a synchronous crash the in-memory state may be
+ *   corrupt, so running on is riskier than a clean restart.
+ */
+export default defineHook((_, { logger }) => {
+    if (registered) {
+        return
+    }
+    registered = true
+
+    process.on('unhandledRejection', (reason: any) => {
+        logger.error(`${HOOK_NAME}: suppressed unhandledRejection: ${reason?.stack ?? reason}`)
+        postSlackMessage(
+            `:rotating_light: *${HOOK_NAME}*: suppressed unhandledRejection: ${reason?.message ?? reason}`
+        ).catch(() => {})
+    })
+
+    process.on('uncaughtException', (error: any) => {
+        logger.error(`${HOOK_NAME}: uncaughtException: ${error?.stack ?? error}`)
+        postSlackMessage(
+            `:rotating_light: *${HOOK_NAME}*: uncaughtException, restarting: ${error?.message ?? error}`
+        )
+            .catch(() => {})
+            .finally(() => setTimeout(() => process.exit(1), 1000))
+    })
+
+    logger.info(`${HOOK_NAME} hook: Registered global unhandledRejection/uncaughtException handlers.`)
+})

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/screenshot/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/screenshot/index.ts
@@ -8,6 +8,7 @@ import { default as axios } from 'axios'
 import { getUrlSlug } from '../../../../../shared-code/index.ts'
 import { createHookErrorConstructor } from '../shared/errors.ts'
 import { postSlackMessage } from '../shared/postSlackMessage.ts'
+import { safeAction } from '../shared/safeHook.ts'
 
 // Ignoring error here because IDE does not pick up right configuration
 // @ts-ignore
@@ -26,17 +27,17 @@ export default defineHook(({ action }, hookContext) => {
      * It sets the "image" field on newly created
      * pick of the day items, if necessary.
      */
-    action('picks_of_the_day.items.create', ({ payload, ...metadata }, context) =>
+    action('picks_of_the_day.items.create', safeAction(HOOK_NAME, logger, ({ payload, ...metadata }, context) =>
         handleAction({ payload, metadata, context })
-    )
+    ))
 
     /**
      * It sets the "image" field on updated pick
      * of the day items, if necessary.
      */
-    action('picks_of_the_day.items.update', ({ payload, ...metadata }, context) =>
+    action('picks_of_the_day.items.update', safeAction(HOOK_NAME, logger, ({ payload, ...metadata }, context) =>
         handleAction({ payload, metadata, context })
-    )
+    ))
 
     /**
      * It handles the action logic that sets the "image" field on

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/__tests__/isPublishable.test.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/__tests__/isPublishable.test.ts
@@ -103,7 +103,7 @@ describe('isPublishable', () => {
             false,
             'missing audio_file',
         ],
-    ])('Episode %s should be publishable: %s', async (item, expected, reason
+    ])('Episode %s should be publishable: %s', async (item, expected, _reason
     ) => {
         const result = isPublishable(item, PodcastFields);
         expect(result).toBe(expected);
@@ -164,7 +164,7 @@ describe('isPublishable', () => {
             'Other episodes do not require a number',
         ],
 
-    ])('Number is optional for some episodes %s to be publishable: %s', async (item, expected, reason
+    ])('Number is optional for some episodes %s to be publishable: %s', async (item, expected, _reason
     ) => {
         const result = isPublishable(item, PodcastFields);
         expect(result).toBe(expected);

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/__tests__/safeHook.test.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/__tests__/safeHook.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test, jest, beforeEach } from '@jest/globals'
+import { safeAction } from '../safeHook.ts'
+
+function createLogger() {
+    return {
+        error: jest.fn(),
+        warn: jest.fn(),
+        info: jest.fn(),
+    }
+}
+
+// Flush the microtask queue so the wrapper's internal Promise chain settles.
+const flush = () => new Promise((resolve) => setImmediate(resolve))
+
+describe('safeAction', () => {
+    let logger: ReturnType<typeof createLogger>
+
+    beforeEach(() => {
+        logger = createLogger()
+    })
+
+    test('runs the handler with the forwarded arguments', async () => {
+        const handler = jest.fn()
+        const wrapped = safeAction('test-hook', logger, handler)
+
+        wrapped({ key: 1 }, { accountability: 'ctx' })
+        await flush()
+
+        expect(handler).toHaveBeenCalledWith({ key: 1 }, { accountability: 'ctx' })
+    })
+
+    test('returns void synchronously (never a promise that can reject)', () => {
+        const wrapped = safeAction('test-hook', logger, () => {
+            throw new Error('boom')
+        })
+
+        // Calling the wrapped handler must not throw and must not hand back a thenable.
+        const result = wrapped({}, {}) as unknown
+        expect(result).toBeUndefined()
+    })
+
+    test('swallows a synchronous throw and logs it', async () => {
+        const wrapped = safeAction('test-hook', logger, () => {
+            throw new Error('sync boom')
+        })
+
+        wrapped({}, {})
+        await flush()
+
+        expect(logger.error).toHaveBeenCalled()
+        expect(String(logger.error.mock.calls[0]?.[0])).toContain('sync boom')
+    })
+
+    test('swallows a rejected promise returned by the handler and logs it', async () => {
+        const wrapped = safeAction('test-hook', logger, async () => {
+            throw new Error('async boom')
+        })
+
+        wrapped({}, {})
+        await flush()
+
+        expect(logger.error).toHaveBeenCalled()
+        expect(String(logger.error.mock.calls[0]?.[0])).toContain('async boom')
+    })
+
+    test('does not log when the handler resolves successfully', async () => {
+        const wrapped = safeAction('test-hook', logger, async () => 'ok')
+
+        wrapped({}, {})
+        await flush()
+
+        expect(logger.error).not.toHaveBeenCalled()
+    })
+
+    test('survives a non-Error rejection value', async () => {
+        const wrapped = safeAction('test-hook', logger, async () => {
+            return Promise.reject('string failure')
+        })
+
+        wrapped({}, {})
+        await flush()
+
+        expect(logger.error).toHaveBeenCalled()
+        expect(String(logger.error.mock.calls[0]?.[0])).toContain('string failure')
+    })
+})

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/__tests__/test-wallet-passes.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/__tests__/test-wallet-passes.ts
@@ -252,4 +252,7 @@ async function main() {
     }
 }
 
-main()
+main().catch((err) => {
+    console.error(err)
+    process.exitCode = 1
+})

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/email-service.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/email-service.ts
@@ -78,7 +78,7 @@ export async function getSetting(
     key: string,
     context: EmailServiceContext
 ): Promise<string | null> {
-    const { services, getSchema, accountability, logger } = context
+    const { services, getSchema, logger } = context
     const { ItemsService } = services
 
     try {
@@ -112,7 +112,7 @@ export async function getSettings(
     keys: string[],
     context: EmailServiceContext
 ): Promise<Record<string, string>> {
-    const { services, getSchema, accountability, logger } = context
+    const { services, getSchema, logger } = context
     const { ItemsService } = services
 
     const result: Record<string, string> = {}
@@ -146,7 +146,7 @@ export async function getEmailTemplate(
     key: string,
     context: EmailServiceContext
 ): Promise<{ subject: string; body_html: string } | null> {
-    const { services, getSchema, accountability, logger } = context
+    const { services, getSchema, logger } = context
     const { ItemsService } = services
 
     try {
@@ -181,7 +181,7 @@ export async function sendTemplatedEmail(
     options: SendEmailOptions,
     context: EmailServiceContext
 ): Promise<boolean> {
-    const { logger, services, getSchema, accountability } = context
+    const { logger, services, getSchema } = context
     const { MailService } = services
 
     try {
@@ -243,7 +243,7 @@ export async function sendRawEmail(
     },
     context: EmailServiceContext
 ): Promise<boolean> {
-    const { logger, services, getSchema, accountability } = context
+    const { logger, services, getSchema } = context
     const { MailService } = services
 
     try {

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/isPublishable.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/isPublishable.ts
@@ -21,7 +21,6 @@ interface Field {
     }
 }
 
-// eslint-disable-next-line no-unused-vars
 type LoggerFunction = (message: string) => void
 
 const isRuleForPublished = function(rule: any): boolean {

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/safeHook.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/safeHook.ts
@@ -1,0 +1,30 @@
+type ActionHandler = (meta: any, ctx: any) => unknown | Promise<unknown>
+
+/**
+ * Wraps a Directus action handler so that no error it produces — a synchronous
+ * throw or a rejected promise it returns — can ever escape to the Node process
+ * and crash the CMS. Errors are caught and logged instead.
+ *
+ * `Promise.resolve().then(() => handler(...))` captures both synchronous throws
+ * and rejected promises returned by the handler in a single `.catch`. For this
+ * to observe a handler's async work, the handler must RETURN its promise.
+ *
+ * Handlers that intentionally detach their own fire-and-forget promise still
+ * need a local `.catch` on that promise (the wrapper cannot see a detached one).
+ *
+ * @param hookName The hook name, used for log context.
+ * @param logger The hook's logger instance.
+ * @param handler The action handler to protect.
+ */
+export function safeAction(hookName: string, logger: any, handler: ActionHandler) {
+    return (meta: any, ctx: any): void => {
+        Promise.resolve()
+            .then(() => handler(meta, ctx))
+            .catch((error: any) => {
+                logger.error(`${hookName} hook: error in action handler: ${error?.message ?? error}`)
+                if (error?.stack) {
+                    logger.error(error.stack)
+                }
+            })
+    }
+}

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/social-media-publish/bluesky.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/social-media-publish/bluesky.ts
@@ -60,7 +60,7 @@ function detectFacets(text: string): BlueskyFacet[] {
     const encoder = new TextEncoder()
 
     // Detect URLs
-    const urlRegex = /https?:\/\/[^\s<>\"{}|\\^`\[\]]+/g
+    const urlRegex = /https?:\/\/[^\s<>"{}|\\^`[\]]+/g
     let match: RegExpExecArray | null
     while ((match = urlRegex.exec(text)) !== null) {
         const byteStart = encoder.encode(text.slice(0, match.index)).length

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/social-media-publish/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/social-media-publish/index.ts
@@ -1,6 +1,7 @@
 import { defineHook } from '@directus/extensions-sdk'
 import { publishToBluesky } from './bluesky.js'
 import { publishToMastodon } from './mastodon.js'
+import { safeAction } from '../shared/safeHook.ts'
 
 const HOOK_NAME = 'social-media-publish'
 
@@ -23,7 +24,7 @@ export default defineHook(({ action }, hookContext) => {
 
     // Trigger when a social_media_posts item is updated to 'scheduled' and scheduled_for is now or in the past
     // OR when manually triggered by setting status to 'publishing'
-    action('social_media_posts.items.update', async function (metadata, eventContext) {
+    action('social_media_posts.items.update', safeAction(HOOK_NAME, logger, async function (metadata, eventContext) {
         const { payload, keys } = metadata
 
         // Only proceed if status is being set to 'publishing'
@@ -104,7 +105,7 @@ export default defineHook(({ action }, hookContext) => {
                 })
             }
         }
-    })
+    }))
 
     logger.info(`${HOOK_NAME} hook registered`)
 })

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/speaker-portal-notifications/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/speaker-portal-notifications/index.ts
@@ -7,6 +7,7 @@ import {
     type EmailServiceContext,
 } from '../shared/email-service.js'
 import { postSlackMessage } from '../shared/postSlackMessage.js'
+import { safeAction } from '../shared/safeHook.ts'
 
 const HOOK_NAME = 'speaker-portal-notifications'
 
@@ -131,7 +132,7 @@ export default defineHook(({ action, schedule }, hookContext) => {
     /**
      * Send invitation email when a new speaker is created (token is auto-generated).
      */
-    action('speakers.items.create', async function (metadata, eventContext) {
+    action('speakers.items.create', safeAction(HOOK_NAME, logger, async function (metadata, eventContext) {
         const { key } = metadata
 
         try {
@@ -139,12 +140,12 @@ export default defineHook(({ action, schedule }, hookContext) => {
         } catch (err: any) {
             logger.error(`${HOOK_NAME}: Error sending invitation email on create: ${err?.message || err}`)
         }
-    })
+    }))
 
     /**
      * Send invitation email when a speaker's portal token is regenerated.
      */
-    action('speakers.items.update', async function (metadata, eventContext) {
+    action('speakers.items.update', safeAction(HOOK_NAME, logger, async function (metadata, eventContext) {
         const { payload, keys } = metadata
 
         // Only proceed if portal_token was just set
@@ -159,12 +160,12 @@ export default defineHook(({ action, schedule }, hookContext) => {
         } catch (err: any) {
             logger.error(`${HOOK_NAME}: Error sending invitation email on update: ${err?.message || err}`)
         }
-    })
+    }))
 
     /**
      * Send confirmation when a speaker submits their information.
      */
-    action('speakers.items.update', async function (metadata, eventContext) {
+    action('speakers.items.update', safeAction(HOOK_NAME, logger, async function (metadata, eventContext) {
         const { payload, keys } = metadata
 
         // Only proceed if status is being set to 'submitted'
@@ -259,7 +260,7 @@ export default defineHook(({ action, schedule }, hookContext) => {
         } catch (err: any) {
             logger.error(`${HOOK_NAME}: Error sending submission confirmation: ${err?.message || err}`)
         }
-    })
+    }))
 
     /**
      * Scheduled task to send deadline reminders.

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/ticket-order-processing/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/ticket-order-processing/index.ts
@@ -9,6 +9,7 @@ import {
     ticketTypeLabel,
     type InvoiceData,
 } from '../shared/invoice-generator.js'
+import { safeAction } from '../shared/safeHook.ts'
 
 const HOOK_NAME = 'ticket-order-processing'
 
@@ -31,7 +32,7 @@ export default defineHook(({ action }, hookContext) => {
      * Creates tickets with profile tokens, generates invoice, and sends emails
      * (QR codes are generated later when the attendee completes their profile)
      */
-    action('ticket_orders.items.update', async function (metadata, eventContext) {
+    action('ticket_orders.items.update', safeAction(HOOK_NAME, logger, async function (metadata, eventContext) {
         const { payload, keys } = metadata
 
         // Only proceed if status is being set to 'paid'
@@ -333,7 +334,7 @@ export default defineHook(({ action }, hookContext) => {
         } catch (err: any) {
             logger.error(`${HOOK_NAME}: Error processing order: ${err?.message || err}`)
         }
-    })
+    }))
 
     logger.info(`${HOOK_NAME} hook registered`)
 })

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/ticket-profile-completion/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/ticket-profile-completion/index.ts
@@ -6,6 +6,7 @@ import {
     generateGoogleWalletUrl,
     type WalletPassInput,
 } from '../shared/wallet-pass-generator.js'
+import { safeAction } from '../shared/safeHook.ts'
 
 const HOOK_NAME = 'ticket-profile-completion'
 
@@ -24,7 +25,7 @@ export default defineHook(({ action }, hookContext) => {
     /**
      * Send final ticket email with QR code and wallet passes when profile_status changes to 'completed'
      */
-    action('tickets.items.update', async function (metadata, eventContext) {
+    action('tickets.items.update', safeAction(HOOK_NAME, logger, async function (metadata, eventContext) {
         const { payload, keys } = metadata
 
         // Only proceed if profile_status is being set to 'completed'
@@ -173,7 +174,7 @@ export default defineHook(({ action }, hookContext) => {
         } catch (err: any) {
             logger.error(`${HOOK_NAME}: Error processing profile completion: ${err?.message || err}`)
         }
-    })
+    }))
 
     logger.info(`${HOOK_NAME} hook registered`)
 })


### PR DESCRIPTION
## Problem

The CMS crashes while editing/saving items and the whole Directus process goes down (auto-rebooted by DigitalOcean). Root cause: **unhandled promise rejections** from Directus action hooks. Node terminates the process on an unhandled rejection (default since v15).

- **`buzzsprout`** (confirmed trigger): synchronous action callbacks fired the async `handlePodcastAction`/`handlePickOfTheDayAction`/`handleTagAction` with **no `await` and no `.catch()`**. The handlers `throw` on failure → unhandled rejection → CMS down. Hit on every podcast/pick/tag save that errored.
- **`algolia-index`**: same latent pattern — `async function(...) { handleUpdateAction(...) }` never awaited/returned the inner call, so a reindex/Algolia failure rejected unhandled.

## Part 1 — Stop the crashes

- **`src/shared/safeHook.ts`** (new): `safeAction(hookName, logger, handler)` wraps a callback so a sync throw or a rejected promise is caught and logged, never re-thrown.
- **All action hooks routed through `safeAction`** (11 hooks). Callbacks now **return** their handler promise so the wrapper can observe it. Filter hooks keep throwing Directus `createError`s — the controlled way to reject a save, which does not crash the process.
- **`src/process-guard/index.ts`** (new): process-level backstop. `unhandledRejection` is swallowed + logged + Slacked; `uncaughtException` is logged + Slacked then `exit(1)` for a clean restart (in-memory state may be corrupt after a synchronous crash — integrity over uptime).

## Part 2 — Prevent regressions

- Enabled `@typescript-eslint/no-floating-promises` + `no-misused-promises` — the rule that flags the exact buzzsprout bug (verified).
- Made ESLint actually enforceable: the config had 155 latent errors (mostly core `no-undef` false positives on Node globals), so deferred to the TS-aware rules and fixed the genuine pre-existing violations (incl. a duplicate `ActionData` interface and an unused import).
- Added an ESLint step to CI (`.github/workflows/run_tests.yml`) and a `lint` npm script.
- Added `safeHook` unit tests proving the wrapper never rejects.

## Verification

- `npm run lint` — clean
- `npm test` — 46 passed (6 new)
- `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)