### PR TITLE
Add workflow to sync Directus schema snapshot from production

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,5 +1,30 @@
 # GitHub Actions Workflows
 
+## Update Directus schema snapshot
+
+### Overview
+The `directus_schema_snapshot.yml` workflow keeps `directus-cms/schema.json` in sync with the production database. It fetches the live schema from the production `/schema/snapshot` endpoint, normalizes the formatting to match the committed file, and opens a pull request **only if** the schema has drifted from `main`. This replaces the manual WebStorm HTTP request in `directus-cms/_requests/Directus.http`.
+
+### Schedule
+- **Automatic**: Every Monday at 05:00 AM UTC
+- **Manual**: Can be triggered via the GitHub Actions UI (`workflow_dispatch`)
+
+### Required Secrets
+| Secret Name | Description | Example |
+|------------|-------------|---------|
+| `PUBLIC_URL` | Public URL of the production Directus CMS | `https://admin.programmier.bar` |
+| `DIRECTUS_SCHEMA_TOKEN` | Static **admin** token used to read the schema snapshot. Generate it on an admin user in Directus (Settings → the user → Token). The read-only `PROD_API_TOKEN` is **not** sufficient. | `abc123...` |
+
+### Behaviour
+- If production has drifted, the workflow opens (or updates) a PR on the `chore/directus-schema-snapshot` branch labelled `🤖 automated`. Review the diff for unexpected schema changes before merging.
+- If `schema.json` already matches production, the run completes green and creates no PR.
+- Failures surface as a red run in the Actions tab (no auto-issue is created).
+
+### Usage
+1. Go to the `Actions` tab in GitHub.
+2. Select `Update Directus schema snapshot`.
+3. Click `Run workflow`.
+
 ## Algolia Index Maintenance
 
 ### Overview

--- a/.github/workflows/directus_schema_snapshot.yml
+++ b/.github/workflows/directus_schema_snapshot.yml
@@ -1,0 +1,51 @@
+name: Update Directus schema snapshot
+
+on:
+  # Run every Monday at 05:00 UTC (offset from the 06:00 Algolia maintenance job)
+  schedule:
+    - cron: '0 5 * * 1'
+
+  # Allow manual triggering from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: write # peter-evans needs to push the branch
+  pull-requests: write # ...and open the PR
+
+jobs:
+  update-schema:
+    name: Fetch production schema and open PR on drift
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Fetch production schema snapshot
+        env:
+          DIRECTUS_URL: ${{ secrets.PUBLIC_URL }}
+          DIRECTUS_TOKEN: ${{ secrets.DIRECTUS_SCHEMA_TOKEN }}
+        run: |
+          curl --fail --silent --show-error \
+            -H "Authorization: Bearer $DIRECTUS_TOKEN" \
+            -H "Accept: application/json" \
+            "$DIRECTUS_URL/schema/snapshot" -o /tmp/schema-raw.json
+          # Normalize to match the committed format: data wrapper preserved,
+          # 2-space indent, no trailing newline (see directus-cms/schema.json).
+          node -e "const fs=require('fs');const s=JSON.parse(fs.readFileSync('/tmp/schema-raw.json','utf8'));fs.writeFileSync('directus-cms/schema.json', JSON.stringify(s, null, 2))"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          add-paths: directus-cms/schema.json
+          branch: chore/directus-schema-snapshot
+          delete-branch: true
+          commit-message: 'chore(directus): update production schema snapshot'
+          title: 'chore(directus): update production schema snapshot'
+          labels: '🤖 automated'
+          body: |
+            Automated update of `directus-cms/schema.json` from the production
+            `/schema/snapshot` endpoint. Review the diff for unexpected schema drift
+            before merging.
+
+            Triggered by the **Update Directus schema snapshot** workflow.

--- a/.github/workflows/directus_schema_snapshot.yml
+++ b/.github/workflows/directus_schema_snapshot.yml
@@ -26,6 +26,9 @@ jobs:
           DIRECTUS_URL: ${{ secrets.PUBLIC_URL }}
           DIRECTUS_TOKEN: ${{ secrets.DIRECTUS_SCHEMA_TOKEN }}
         run: |
+          # Strip any trailing slashes so PUBLIC_URL values like
+          # "https://admin.programmier.bar/" don't produce a "//schema/snapshot" path.
+          DIRECTUS_URL="$(echo "$DIRECTUS_URL" | sed 's#/*$##')"
           curl --fail --silent --show-error \
             -H "Authorization: Bearer $DIRECTUS_TOKEN" \
             -H "Accept: application/json" \


### PR DESCRIPTION
## Why

`directus-cms/schema.json` drifts out of sync with the production database because it's only refreshed manually. Today the only options are `npm run snapshot-schema` (dumps from the **local** dev instance — useless for tracking production) or a WebStorm-only HTTP request (`directus-cms/_requests/Directus.http`) with a hand-pasted Bearer token.

This adds a GitHub Actions workflow that automates the production fetch and surfaces drift as a reviewable PR.

## What

**`.github/workflows/directus_schema_snapshot.yml`** — runs weekly (Mondays 05:00 UTC, offset from the 06:00 Algolia job) and on manual dispatch. It:

1. Fetches the production schema from `${PUBLIC_URL}/schema/snapshot` with a Bearer token, mirroring the existing `Directus.http` request.
2. Normalizes it via `JSON.stringify(s, null, 2)` — preserving the `{ "data": ... }` wrapper, 2-space indent, and no trailing newline — so the committed file's formatting is reproduced exactly and diffs stay meaningful.
3. Uses `peter-evans/create-pull-request@v7`, which opens/updates a PR on `chore/directus-schema-snapshot` **only when there's a diff** and is a no-op otherwise.

**`.github/workflows/README.md`** — documents the new workflow (schedule, required secrets, behaviour, manual trigger).

## Before it works — manual ops steps

1. In Directus, create a **static admin token** (the read-only `PROD_API_TOKEN` won't have schema access).
2. Add it as the GitHub secret **`DIRECTUS_SCHEMA_TOKEN`** (Settings → Secrets and variables → Actions). `PUBLIC_URL` already exists.

## Note

The **first** automated run will likely produce a large diff — the committed schema reports Directus `11.14.1` while `package.json` pins `^11.17.4`, so production has genuinely drifted. That first PR is the catch-up; subsequent diffs will be small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)