### PR TITLE
Consolidate news publishing & slug on the news collection

### DIFF
--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/cascade-publish/__tests__/cascadePublish.test.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/cascade-publish/__tests__/cascadePublish.test.ts
@@ -13,13 +13,6 @@ const O2M_RELATION: CascadeRelation = {
     targetCollection: 'picks_of_the_day',
 }
 
-const M2A_RELATION: CascadeRelation = {
-    relationField: 'target',
-    childField: 'target',
-    collectionField: 'collection',
-    targetCollection: 'news_links',
-}
-
 describe('isPublishPayload', () => {
     test('should return true when status is published', () => {
         expect(isPublishPayload({ status: 'published' })).toBe(true)
@@ -72,15 +65,6 @@ describe('buildRelationFields', () => {
             'picks_of_the_day.id',
             'picks_of_the_day.status',
         ])
-    })
-
-    test('should build the collection discriminator and a wildcard target for m2a relations', () => {
-        expect(buildRelationFields([M2A_RELATION])).toEqual(['target.collection', 'target.target.*'])
-    })
-
-    test('should throw for an m2a relation missing childField', () => {
-        const invalid: CascadeRelation = { relationField: 'target', collectionField: 'collection', targetCollection: 'news_links' }
-        expect(() => buildRelationFields([invalid])).toThrow(/requires a "childField"/)
     })
 
     test('should return an empty array for no relations', () => {
@@ -158,34 +142,5 @@ describe('extractDraftIds', () => {
 
     test('should not treat a non-array relation value as related items', () => {
         expect(extractDraftIds({ speakers: 'unexpected' }, M2M_RELATION)).toEqual([])
-    })
-
-    test('should unwrap m2a junction records and return only draft target ids', () => {
-        const parentItem = {
-            target: [
-                { collection: 'news_links', target: { id: 'n1', status: 'draft' } },
-                { collection: 'news_links', target: { id: 'n2', status: 'published' } },
-                { collection: 'news_links', target: { id: 'n3', status: 'draft' } },
-            ],
-        }
-
-        expect(extractDraftIds(parentItem, M2A_RELATION)).toEqual(['n1', 'n3'])
-    })
-
-    test('should ignore m2a junction rows pointing at other collections', () => {
-        const parentItem = {
-            target: [
-                { collection: 'news_links', target: { id: 'n1', status: 'draft' } },
-                { collection: 'some_other_source', target: { id: 'x1', status: 'draft' } },
-            ],
-        }
-
-        expect(extractDraftIds(parentItem, M2A_RELATION)).toEqual(['n1'])
-    })
-
-    test('should throw for an m2a relation missing childField', () => {
-        const invalid: CascadeRelation = { relationField: 'target', collectionField: 'collection', targetCollection: 'news_links' }
-        const parentItem = { target: [{ collection: 'news_links', target: { id: 'n1', status: 'draft' } }] }
-        expect(() => extractDraftIds(parentItem, invalid)).toThrow(/requires a "childField"/)
     })
 })

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/cascade-publish/__tests__/index.test.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/cascade-publish/__tests__/index.test.ts
@@ -115,14 +115,12 @@ describe('cascade-publish hook', () => {
         postSlackMessageMock.mockClear()
     })
 
-    test('registers create and update actions for podcasts, meetups and news', () => {
+    test('registers create and update actions for podcasts and meetups', () => {
         const { handlers } = setup()
 
         expect([...handlers.keys()].sort()).toEqual([
             'meetups.items.create',
             'meetups.items.update',
-            'news.items.create',
-            'news.items.update',
             'podcasts.items.create',
             'podcasts.items.update',
         ])
@@ -162,22 +160,6 @@ describe('cascade-publish hook', () => {
             { collection: 'speakers', id: 'sp1', data: { status: 'published' } },
             { collection: 'talks', id: 't1', data: { status: 'published' } },
         ])
-    })
-
-    test('publishes the draft news_links target when a news item is published', async () => {
-        const { handlers, updateOneCalls } = setup({
-            parentItem: {
-                target: [
-                    { collection: 'news_links', target: { id: 'nl1', status: 'draft' } },
-                    { collection: 'news_links', target: { id: 'nl2', status: 'published' } },
-                ],
-            },
-        })
-
-        await invoke(handlers.get('news.items.update')!, { keys: ['news1'], payload: { status: 'published' } })
-
-        expect(updateOneCalls).toEqual([{ collection: 'news_links', id: 'nl1', data: { status: 'published' } }])
-        expect(postSlackMessageMock).not.toHaveBeenCalled()
     })
 
     test('publishes each child individually so downstream hooks see every key', async () => {

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/cascade-publish/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/cascade-publish/index.ts
@@ -32,18 +32,6 @@ const MEETUP_RELATIONS: CascadeRelation[] = [
     },
 ]
 
-// `news` references its source items through the `news_target` many-to-any
-// junction. The o2m alias on `news` is `target`; each junction row carries the
-// related collection in `collection` and the item itself in `target`.
-const NEWS_RELATIONS: CascadeRelation[] = [
-    {
-        relationField: 'target',
-        childField: 'target',
-        collectionField: 'collection',
-        targetCollection: 'news_links',
-    },
-]
-
 interface SkippedItem {
     collection: string
     id: string | number
@@ -85,20 +73,6 @@ export default defineHook(({ action }, hookContext) => {
         'meetups.items.update',
         safeAction(HOOK_NAME, logger, (metadata, eventContext) =>
             handlePublishAction('meetups', metadata, MEETUP_RELATIONS, eventContext)
-        )
-    )
-
-    action(
-        'news.items.create',
-        safeAction(HOOK_NAME, logger, (metadata, eventContext) =>
-            handlePublishAction('news', metadata, NEWS_RELATIONS, eventContext)
-        )
-    )
-
-    action(
-        'news.items.update',
-        safeAction(HOOK_NAME, logger, (metadata, eventContext) =>
-            handlePublishAction('news', metadata, NEWS_RELATIONS, eventContext)
         )
     )
 

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/cascade-publish/util/cascadePublish.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/cascade-publish/util/cascadePublish.ts
@@ -1,35 +1,10 @@
 export interface CascadeRelation {
     /** The relation field name on the parent item (e.g. 'speakers', 'picks_of_the_day') */
     relationField: string
-    /** For m2m/m2a: the field on the junction record that holds the child item (e.g. 'speaker', 'talk', 'target') */
+    /** For m2m: the field on the junction record that holds the child item (e.g. 'speaker', 'talk') */
     childField?: string
-    /**
-     * For many-to-any (m2a): the junction field holding the related collection
-     * name (e.g. 'collection'). Its presence marks the relation as m2a, which is
-     * read and unwrapped differently from a plain m2m — see `buildRelationFields`
-     * and `extractDraftIds`.
-     */
-    collectionField?: string
     /** The Directus collection of the related items */
     targetCollection: string
-}
-
-/**
- * A many-to-any relation needs a `childField` to unwrap the junction record and
- * reach the polymorphic target. `childField` is optional on the type (m2m/o2m
- * don't all use it), so guard here to fail fast on a misconfigured m2a relation
- * rather than silently emitting `<relationField>.undefined.*` or treating the
- * junction rows themselves as items.
- *
- * @param relation The relation to validate.
- */
-function requireM2aChildField(relation: CascadeRelation): string {
-    if (!relation.childField) {
-        throw new Error(
-            `cascade-publish: m2a relation "${relation.relationField}" (collectionField "${relation.collectionField}") requires a "childField" to unwrap the junction record`
-        )
-    }
-    return relation.childField
 }
 
 /**
@@ -62,16 +37,7 @@ export function buildRelationFields(relations: CascadeRelation[]): string[] {
     const fields: string[] = []
 
     for (const relation of relations) {
-        if (relation.collectionField) {
-            // Many-to-any: fetch the collection discriminator so we can filter the
-            // junction rows to `targetCollection`, and pull the polymorphic target
-            // with a wildcard. A wildcard is required because Directus does not
-            // resolve a specific subfield (e.g. `.status`) across an m2a relation
-            // without collection scoping.
-            const childField = requireM2aChildField(relation)
-            fields.push(`${relation.relationField}.${relation.collectionField}`)
-            fields.push(`${relation.relationField}.${childField}.*`)
-        } else if (relation.childField) {
+        if (relation.childField) {
             fields.push(`${relation.relationField}.${relation.childField}.id`)
             fields.push(`${relation.relationField}.${relation.childField}.status`)
         } else {
@@ -98,21 +64,10 @@ export function extractDraftIds(parentItem: Record<string, any>, relation: Casca
         return []
     }
 
-    // For m2a, validate the config (mirrors `buildRelationFields`) and keep only
-    // the junction rows pointing at this relation's target collection before
-    // unwrapping; other allowed collections are irrelevant here.
-    let junctionItems: any[] = relatedItems
-    if (relation.collectionField) {
-        requireM2aChildField(relation)
-        junctionItems = relatedItems.filter(
-            (record: any) => record?.[relation.collectionField!] === relation.targetCollection
-        )
-    }
-
-    // Extract child items: for m2m/m2a, unwrap from junction records; for o2m, use directly
+    // Extract child items: for m2m, unwrap from junction records; for o2m, use directly
     const childItems: any[] = relation.childField
-        ? junctionItems.map((junctionRecord: any) => junctionRecord[relation.childField!]).filter(Boolean)
-        : junctionItems
+        ? relatedItems.map((junctionRecord: any) => junctionRecord[relation.childField!]).filter(Boolean)
+        : relatedItems
 
     // Filter for draft items only and collect their ids
     return childItems

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/create-news/__tests__/index.test.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/create-news/__tests__/index.test.ts
@@ -61,6 +61,8 @@ interface SetupOptions {
     sourceLinks?: Array<Record<string, any>>
     /** Item returned by the `news_links` readOne (title fallback on create). */
     sourceItem?: Record<string, any>
+    /** Current slug returned by the `news` readOne (publish self-heal). */
+    currentNewsSlug?: string | null
     /** Field definitions returned by FieldsService.readAll. */
     fields?: any[]
     newNewsId?: string
@@ -68,8 +70,15 @@ interface SetupOptions {
 }
 
 function setup(options: SetupOptions = {}) {
-    const { junctionRows = [], existingNews = [], sourceLinks = [], sourceItem = {}, fields = [], newNewsId = 'news-new' } =
-        options
+    const {
+        junctionRows = [],
+        existingNews = [],
+        sourceLinks = [],
+        sourceItem = {},
+        currentNewsSlug = null,
+        fields = [],
+        newNewsId = 'news-new',
+    } = options
 
     const recorded: Recorded = { createOne: [], updateOne: [], deleteOne: [] }
     const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
@@ -80,7 +89,7 @@ function setup(options: SetupOptions = {}) {
             if (collection === 'news_links') return sourceLinks
             return junctionRows
         }),
-        readOne: jest.fn(async () => sourceItem),
+        readOne: jest.fn(async () => (collection === 'news' ? { slug: currentNewsSlug } : sourceItem)),
         createOne: jest.fn(async (data: Record<string, any>) => {
             if (options.createOneErrorCollection === collection) {
                 throw new Error(`boom in ${collection}`)
@@ -298,6 +307,41 @@ describe('create-news hook', () => {
             })
             const handler = filters.get('news.items.update')!
             await expect(handler({ status: 'published' }, { keys: ['news1'] }, filterContext)).rejects.toThrow()
+        })
+
+        test('backfills a missing slug from the link title at publish time', async () => {
+            const { filters } = setup({
+                junctionRows: [{ target: 'nl1' }],
+                sourceLinks: [{ id: 'nl1', title: 'React 19 Released' }],
+                currentNewsSlug: null,
+            })
+            const handler = filters.get('news.items.update')!
+            await expect(handler({ status: 'published' }, { keys: ['news1'] }, filterContext)).resolves.toEqual({
+                status: 'published',
+                slug: 'react-19-released',
+            })
+        })
+
+        test('leaves an existing slug untouched at publish time', async () => {
+            const { filters } = setup({
+                junctionRows: [{ target: 'nl1' }],
+                sourceLinks: [{ id: 'nl1', title: 'React 19 Released' }],
+                currentNewsSlug: 'already-set',
+            })
+            const handler = filters.get('news.items.update')!
+            const payload = { status: 'published' }
+            await expect(handler(payload, { keys: ['news1'] }, filterContext)).resolves.toBe(payload)
+        })
+
+        test('does not backfill a slug on a batch publish (shared payload)', async () => {
+            const { filters } = setup({
+                junctionRows: [{ target: 'nl1' }],
+                sourceLinks: [{ id: 'nl1', title: 'React 19 Released' }],
+                currentNewsSlug: null,
+            })
+            const handler = filters.get('news.items.update')!
+            const payload = { status: 'published' }
+            await expect(handler(payload, { keys: ['news1', 'news2'] }, filterContext)).resolves.toBe(payload)
         })
     })
 

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/create-news/__tests__/index.test.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/create-news/__tests__/index.test.ts
@@ -53,8 +53,12 @@ interface Recorded {
 }
 
 interface SetupOptions {
-    /** Rows returned by `news_target` readByQuery. */
+    /** Rows returned by `news_target` readByQuery (when not keyed by news id). */
     junctionRows?: Array<Record<string, any>>
+    /** Junction rows keyed by the `news_id` the query filters on (batch cases). */
+    junctionRowsByNewsId?: Record<string, Array<Record<string, any>>>
+    /** When set, updateOne rejects for this target id (to test batch resilience). */
+    updateOneErrorId?: string
     /** Rows returned by a `news` readByQuery (slug-collision lookup). */
     existingNews?: Array<Record<string, any>>
     /** Rows returned by a `news_links` readByQuery (publish guard). */
@@ -84,9 +88,13 @@ function setup(options: SetupOptions = {}) {
     const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
 
     const ItemsService = jest.fn().mockImplementation((collection: string) => ({
-        readByQuery: jest.fn(async () => {
+        readByQuery: jest.fn(async (query: Record<string, any> = {}) => {
             if (collection === 'news') return existingNews
             if (collection === 'news_links') return sourceLinks
+            const newsIdEq = query.filter?.news_id?._eq
+            if (newsIdEq !== undefined && options.junctionRowsByNewsId) {
+                return options.junctionRowsByNewsId[String(newsIdEq)] ?? []
+            }
             return junctionRows
         }),
         readOne: jest.fn(async () => (collection === 'news' ? { slug: currentNewsSlug } : sourceItem)),
@@ -98,6 +106,9 @@ function setup(options: SetupOptions = {}) {
             return collection === 'news' ? newNewsId : 'junction-new'
         }),
         updateOne: jest.fn(async (id: string | number, data: Record<string, any>) => {
+            if (options.updateOneErrorId !== undefined && String(id) === String(options.updateOneErrorId)) {
+                throw new Error(`update failed for ${id}`)
+            }
             recorded.updateOne.push({ collection, id, data })
             return id
         }),
@@ -354,5 +365,24 @@ describe('create-news hook', () => {
         expect(recorded.updateOne).toEqual([{ collection: 'news_links', id: 'nl1', data: { status: 'archived' } }])
         expect(recorded.deleteOne).toEqual([{ collection: 'news_target', id: 10 }])
         expect(result).toEqual(['news1'])
+    })
+
+    test('news delete: one failing item does not stop the batch from archiving the rest', async () => {
+        const { filters, recorded } = setup({
+            junctionRowsByNewsId: {
+                'news-1': [{ id: 11, target: 'nl1' }],
+                'news-2': [{ id: 12, target: 'nl2' }],
+            },
+            updateOneErrorId: 'nl1', // archiving the first item's link fails
+        })
+        const handler = filters.get('news.items.delete')!
+
+        const result = await handler(['news-1', 'news-2'], {}, filterContext)
+
+        // news-1 failed mid-archive, but news-2 was still archived and its junction dropped.
+        expect(recorded.updateOne).toEqual([{ collection: 'news_links', id: 'nl2', data: { status: 'archived' } }])
+        expect(recorded.deleteOne).toEqual([{ collection: 'news_target', id: 12 }])
+        expect(result).toEqual(['news-1', 'news-2'])
+        expect(postSlackMessageMock).toHaveBeenCalledTimes(1)
     })
 })

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/create-news/__tests__/index.test.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/create-news/__tests__/index.test.ts
@@ -12,55 +12,72 @@ jest.mock('./../../shared/postSlackMessage.ts', () => ({
     postSlackMessage: jest.fn(),
 }))
 
+// `shared/errors.ts` imports `@directus/errors`, which ships as ESM and is not
+// transformed under Jest's CJS mode. Stub it with a plain Error subclass so the
+// publish guard's throw is observable without loading the real dependency.
+jest.mock('./../../shared/errors.ts', () => ({
+    createHookErrorConstructor: (_hook: string, message: string) =>
+        class extends Error {
+            constructor() {
+                super(message)
+            }
+        },
+}))
+
 import { postSlackMessage } from './../../shared/postSlackMessage.ts'
 import registerHook from './../index.ts'
 
 const postSlackMessageMock = jest.mocked(postSlackMessage)
 
-// Handlers are registered through `safeAction`, which detaches the work into its
-// own promise chain and returns void. Flushing the microtask queue lets that
+// Action handlers run through `safeAction`, which detaches the work into its own
+// promise chain and returns void. Flushing the microtask queue lets that
 // detached work (all backed by immediately-resolving mocks) settle before we assert.
 const flush = () => new Promise<void>((resolve) => setImmediate(resolve))
 
-type Handler = (metadata: Record<string, any>, eventContext: Record<string, any>) => void
+type ActionHandler = (metadata: Record<string, any>, eventContext: Record<string, any>) => void
+type FilterHandler = (payload: any, metadata: any, context: any) => any
 
-async function invoke(handler: Handler, metadata: Record<string, any>, eventContext: Record<string, any> = { accountability: {} }) {
+async function invokeAction(
+    handler: ActionHandler,
+    metadata: Record<string, any>,
+    eventContext: Record<string, any> = { accountability: {} }
+) {
     handler(metadata, eventContext)
     await flush()
 }
 
-interface CreateOneCall {
-    collection: string
-    data: Record<string, any>
-}
-interface DeleteOneCall {
-    collection: string
-    id: string | number
+interface Recorded {
+    createOne: Array<{ collection: string; data: Record<string, any> }>
+    updateOne: Array<{ collection: string; id: string | number; data: Record<string, any> }>
+    deleteOne: Array<{ collection: string; id: string | number }>
 }
 
 interface SetupOptions {
-    /** Rows returned by `news_target` readByQuery (idempotency guard / delete lookup). */
+    /** Rows returned by `news_target` readByQuery. */
     junctionRows?: Array<Record<string, any>>
-    /** Item returned by the `news_links` readOne (status fallback). */
+    /** Rows returned by a `news` readByQuery (slug-collision lookup). */
+    existingNews?: Array<Record<string, any>>
+    /** Rows returned by a `news_links` readByQuery (publish guard). */
+    sourceLinks?: Array<Record<string, any>>
+    /** Item returned by the `news_links` readOne (title fallback on create). */
     sourceItem?: Record<string, any>
-    /** Id assigned to a newly created `news` item. */
+    /** Field definitions returned by FieldsService.readAll. */
+    fields?: any[]
     newNewsId?: string
     createOneErrorCollection?: string
-    readByQueryError?: Error
 }
 
 function setup(options: SetupOptions = {}) {
-    const { junctionRows = [], sourceItem = { status: 'draft' }, newNewsId = 'news-new' } = options
+    const { junctionRows = [], existingNews = [], sourceLinks = [], sourceItem = {}, fields = [], newNewsId = 'news-new' } =
+        options
 
-    const createOneCalls: CreateOneCall[] = []
-    const deleteOneCalls: DeleteOneCall[] = []
+    const recorded: Recorded = { createOne: [], updateOne: [], deleteOne: [] }
     const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
 
     const ItemsService = jest.fn().mockImplementation((collection: string) => ({
         readByQuery: jest.fn(async () => {
-            if (options.readByQueryError) {
-                throw options.readByQueryError
-            }
+            if (collection === 'news') return existingNews
+            if (collection === 'news_links') return sourceLinks
             return junctionRows
         }),
         readOne: jest.fn(async () => sourceItem),
@@ -68,113 +85,162 @@ function setup(options: SetupOptions = {}) {
             if (options.createOneErrorCollection === collection) {
                 throw new Error(`boom in ${collection}`)
             }
-            createOneCalls.push({ collection, data })
+            recorded.createOne.push({ collection, data })
             return collection === 'news' ? newNewsId : 'junction-new'
         }),
+        updateOne: jest.fn(async (id: string | number, data: Record<string, any>) => {
+            recorded.updateOne.push({ collection, id, data })
+            return id
+        }),
         deleteOne: jest.fn(async (id: string | number) => {
-            deleteOneCalls.push({ collection, id })
+            recorded.deleteOne.push({ collection, id })
             return id
         }),
     }))
 
-    const handlers = new Map<string, Handler>()
+    const FieldsService = jest.fn().mockImplementation(() => ({
+        readAll: jest.fn(async () => fields),
+    }))
+
+    const actions = new Map<string, ActionHandler>()
+    const filters = new Map<string, FilterHandler>()
     const register = {
-        action: (event: string, handler: Handler) => {
-            handlers.set(event, handler)
+        action: (event: string, handler: ActionHandler) => {
+            actions.set(event, handler)
+        },
+        filter: (event: string, handler: FilterHandler) => {
+            filters.set(event, handler)
         },
     }
 
     const hookContext = {
         logger,
-        services: { ItemsService },
+        services: { ItemsService, FieldsService },
         getSchema: jest.fn(async () => ({})),
         env: { PUBLIC_URL: 'https://cms.example.com/' },
     }
 
     registerHook(register as any, hookContext as any)
 
-    return { handlers, createOneCalls, deleteOneCalls, logger }
+    return { actions, filters, recorded, logger }
 }
+
+const filterContext = { schema: {}, accountability: {} }
 
 describe('create-news hook', () => {
     beforeEach(() => {
         postSlackMessageMock.mockClear()
     })
 
-    test('registers create and delete actions for news_links', () => {
-        const { handlers } = setup()
-        expect(handlers.has('news_links.items.create')).toBe(true)
-        expect(handlers.has('news_links.items.delete')).toBe(true)
+    test('registers the expected filter and action handlers', () => {
+        const { actions, filters } = setup()
+        expect([...actions.keys()].sort()).toEqual([
+            'news.items.update',
+            'news_links.items.create',
+            'news_links.items.delete',
+            'news_links.items.update',
+        ])
+        expect([...filters.keys()].sort()).toEqual([
+            'news.items.delete',
+            'news.items.update',
+            'news_links.items.create',
+        ])
     })
 
-    test('create: mirrors the payload status into a news item and wires up the junction', async () => {
-        const { handlers, createOneCalls } = setup({ newNewsId: 'news-1' })
-        const handler = handlers.get('news_links.items.create')!
+    test('forces new links to draft regardless of the submitted status', () => {
+        const { filters } = setup()
+        const handler = filters.get('news_links.items.create')!
+        expect(handler({ title: 'X', status: 'published' }, {}, filterContext)).toEqual({
+            title: 'X',
+            status: 'draft',
+        })
+    })
 
-        await invoke(handler, { key: 'link-1', payload: { status: 'published' } })
+    test('create: mirrors a link into a draft news item with a slug and wires up the junction', async () => {
+        const { actions, recorded } = setup({ newNewsId: 'news-1' })
+        const handler = actions.get('news_links.items.create')!
 
-        expect(createOneCalls).toEqual([
-            { collection: 'news', data: { status: 'published' } },
+        // The contributor's status is intentionally ignored; the news is draft.
+        await invokeAction(handler, { key: 'link-1', payload: { title: 'React 19 Released', status: 'published' } })
+
+        expect(recorded.createOne).toEqual([
+            { collection: 'news', data: { status: 'draft', slug: 'react-19-released' } },
             { collection: 'news_target', data: { news_id: 'news-1', collection: 'news_links', target: 'link-1' } },
         ])
         expect(postSlackMessageMock).not.toHaveBeenCalled()
     })
 
-    test('create: falls back to the persisted status when the payload omits it', async () => {
-        const { handlers, createOneCalls } = setup({ sourceItem: { status: 'archived' }, newNewsId: 'news-2' })
-        const handler = handlers.get('news_links.items.create')!
+    test('create: appends a numeric suffix when the slug already exists', async () => {
+        const { actions, recorded } = setup({
+            newNewsId: 'news-2',
+            existingNews: [{ id: 'other', slug: 'react-19-released' }],
+        })
+        const handler = actions.get('news_links.items.create')!
 
-        await invoke(handler, { key: 'link-2', payload: {} })
+        await invokeAction(handler, { key: 'link-2', payload: { title: 'React 19 Released' } })
 
-        expect(createOneCalls[0]).toEqual({ collection: 'news', data: { status: 'archived' } })
+        expect(recorded.createOne[0]).toEqual({ collection: 'news', data: { status: 'draft', slug: 'react-19-released-2' } })
+    })
+
+    test('create: creates the news without a slug when the title is empty', async () => {
+        const { actions, recorded } = setup({ newNewsId: 'news-3' })
+        const handler = actions.get('news_links.items.create')!
+
+        await invokeAction(handler, { key: 'link-3', payload: { title: '' } })
+
+        expect(recorded.createOne[0]).toEqual({ collection: 'news', data: { status: 'draft' } })
     })
 
     test('create: is idempotent when a junction row already exists', async () => {
-        const { handlers, createOneCalls, logger } = setup({ junctionRows: [{ id: 7, news_id: 'news-x' }] })
-        const handler = handlers.get('news_links.items.create')!
+        const { actions, recorded, logger } = setup({ junctionRows: [{ id: 7 }] })
+        const handler = actions.get('news_links.items.create')!
 
-        await invoke(handler, { key: 'link-3', payload: { status: 'draft' } })
+        await invokeAction(handler, { key: 'link-4', payload: { title: 'Anything' } })
 
-        expect(createOneCalls).toEqual([])
+        expect(recorded.createOne).toEqual([])
         expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('already linked'))
     })
 
-    test('create: notifies Slack with an admin link when creation fails', async () => {
-        const { handlers, logger } = setup({ createOneErrorCollection: 'news' })
-        const handler = handlers.get('news_links.items.create')!
+    test('create: rolls back the news item when junction creation fails', async () => {
+        const { actions, recorded } = setup({ createOneErrorCollection: 'news_target', newNewsId: 'news-9' })
+        const handler = actions.get('news_links.items.create')!
 
-        await invoke(handler, { key: 'link-4', payload: { status: 'draft' } })
+        await invokeAction(handler, { key: 'link-9', payload: { title: 'Rollback me' } })
 
+        expect(recorded.deleteOne).toEqual([{ collection: 'news', id: 'news-9' }])
         expect(postSlackMessageMock).toHaveBeenCalledTimes(1)
-        expect(postSlackMessageMock).toHaveBeenCalledWith(
-            expect.stringContaining('https://cms.example.com/admin/content/news_links/link-4')
-        )
-        expect(logger.error).toHaveBeenCalled()
     })
 
-    test('create: rolls back the news item when junction creation fails', async () => {
-        const { handlers, deleteOneCalls } = setup({ createOneErrorCollection: 'news_target', newNewsId: 'news-9' })
-        const handler = handlers.get('news_links.items.create')!
+    test('update: re-slugs the parent news when the link title changes', async () => {
+        const { actions, recorded } = setup({ junctionRows: [{ news_id: 'news-a' }] })
+        const handler = actions.get('news_links.items.update')!
 
-        await invoke(handler, { key: 'link-9', payload: { status: 'draft' } })
+        await invokeAction(handler, { keys: ['link-5'], payload: { title: 'A Brand New Title' } })
 
-        // The orphaned news row must be deleted so a retry doesn't accumulate orphans.
-        expect(deleteOneCalls).toEqual([{ collection: 'news', id: 'news-9' }])
-        expect(postSlackMessageMock).toHaveBeenCalledTimes(1)
+        expect(recorded.updateOne).toEqual([{ collection: 'news', id: 'news-a', data: { slug: 'a-brand-new-title' } }])
+    })
+
+    test('update: does nothing when the title is not part of the change', async () => {
+        const { actions, recorded } = setup({ junctionRows: [{ news_id: 'news-a' }] })
+        const handler = actions.get('news_links.items.update')!
+
+        await invokeAction(handler, { keys: ['link-5'], payload: { comment: 'edited' } })
+
+        expect(recorded.updateOne).toEqual([])
     })
 
     test('delete: removes junction rows and their news items, skipping null news_id', async () => {
-        const { handlers, deleteOneCalls } = setup({
+        const { actions, recorded } = setup({
             junctionRows: [
                 { id: 1, news_id: 'news-a' },
                 { id: 2, news_id: null },
             ],
         })
-        const handler = handlers.get('news_links.items.delete')!
+        const handler = actions.get('news_links.items.delete')!
 
-        await invoke(handler, { keys: ['link-5'] })
+        await invokeAction(handler, { keys: ['link-6'] })
 
-        expect(deleteOneCalls).toEqual([
+        expect(recorded.deleteOne).toEqual([
             { collection: 'news_target', id: 1 },
             { collection: 'news_target', id: 2 },
             { collection: 'news', id: 'news-a' },
@@ -182,12 +248,67 @@ describe('create-news hook', () => {
         expect(postSlackMessageMock).not.toHaveBeenCalled()
     })
 
-    test('delete: does nothing when no junction row references the link', async () => {
-        const { handlers, deleteOneCalls } = setup({ junctionRows: [] })
-        const handler = handlers.get('news_links.items.delete')!
+    test('news status change: mirrors the new status onto every source link', async () => {
+        const { actions, recorded } = setup({ junctionRows: [{ target: 'nl1' }, { target: 'nl2' }] })
+        const handler = actions.get('news.items.update')!
 
-        await invoke(handler, { keys: ['link-6'] })
+        await invokeAction(handler, { keys: ['news1'], payload: { status: 'archived' } })
 
-        expect(deleteOneCalls).toEqual([])
+        expect(recorded.updateOne).toEqual([
+            { collection: 'news_links', id: 'nl1', data: { status: 'archived' } },
+            { collection: 'news_links', id: 'nl2', data: { status: 'archived' } },
+        ])
+    })
+
+    test('news status change: does nothing when status is not part of the change', async () => {
+        const { actions, recorded } = setup({ junctionRows: [{ target: 'nl1' }] })
+        const handler = actions.get('news.items.update')!
+
+        await invokeAction(handler, { keys: ['news1'], payload: { slug: 'edited-elsewhere' } })
+
+        expect(recorded.updateOne).toEqual([])
+    })
+
+    describe('publish guard (news.items.update filter)', () => {
+        const REQUIRE_LINK_FIELD = [{ field: 'link', schema: { required: true }, meta: {} }]
+
+        test('passes through when the update is not a publish', async () => {
+            const { filters } = setup()
+            const handler = filters.get('news.items.update')!
+            const payload = { slug: 'x' }
+            await expect(handler(payload, { keys: ['news1'] }, filterContext)).resolves.toBe(payload)
+        })
+
+        test('allows publishing when the source link is complete', async () => {
+            const { filters } = setup({
+                junctionRows: [{ target: 'nl1' }],
+                sourceLinks: [{ id: 'nl1', link: 'https://example.com' }],
+                fields: REQUIRE_LINK_FIELD,
+            })
+            const handler = filters.get('news.items.update')!
+            const payload = { status: 'published' }
+            await expect(handler(payload, { keys: ['news1'] }, filterContext)).resolves.toBe(payload)
+        })
+
+        test('blocks publishing when the source link is missing a required field', async () => {
+            const { filters } = setup({
+                junctionRows: [{ target: 'nl1' }],
+                sourceLinks: [{ id: 'nl1' }],
+                fields: REQUIRE_LINK_FIELD,
+            })
+            const handler = filters.get('news.items.update')!
+            await expect(handler({ status: 'published' }, { keys: ['news1'] }, filterContext)).rejects.toThrow()
+        })
+    })
+
+    test('news delete: archives the source link, drops the junction row, and returns the keys', async () => {
+        const { filters, recorded } = setup({ junctionRows: [{ id: 10, target: 'nl1' }] })
+        const handler = filters.get('news.items.delete')!
+
+        const result = await handler(['news1'], {}, filterContext)
+
+        expect(recorded.updateOne).toEqual([{ collection: 'news_links', id: 'nl1', data: { status: 'archived' } }])
+        expect(recorded.deleteOne).toEqual([{ collection: 'news_target', id: 10 }])
+        expect(result).toEqual(['news1'])
     })
 })

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/create-news/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/create-news/index.ts
@@ -435,17 +435,21 @@ export default defineHook(({ action, filter }, hookContext) => {
             return keys
         }
 
-        try {
-            const junctionService = new ItemsService(JUNCTION_COLLECTION, {
-                schema: context.schema,
-                accountability: context.accountability,
-            })
-            const sourceService = new ItemsService(SOURCE_COLLECTION, {
-                schema: context.schema,
-                accountability: context.accountability,
-            })
+        const junctionService = new ItemsService(JUNCTION_COLLECTION, {
+            schema: context.schema,
+            accountability: context.accountability,
+        })
+        const sourceService = new ItemsService(SOURCE_COLLECTION, {
+            schema: context.schema,
+            accountability: context.accountability,
+        })
 
-            for (const newsId of ids) {
+        // Catch per news id so that, in a batch delete, one failing item does not
+        // abort the rest — otherwise the remaining links would stay published and
+        // publicly readable. Never block the deletion itself; a leftover archived
+        // link / junction row is recoverable, a blocked delete is worse.
+        for (const newsId of ids) {
+            try {
                 const rows = await readJunctionRowsByNewsId(junctionService, newsId, ['id', 'target'])
                 for (const row of rows) {
                     if (row.target) {
@@ -456,15 +460,13 @@ export default defineHook(({ action, filter }, hookContext) => {
                 if (rows.length > 0) {
                     logger.info(`${HOOK_NAME}: Archived ${rows.length} link(s) and dropped junction row(s) for deleted news ${newsId}`)
                 }
+            } catch (error: any) {
+                logger.error(`${HOOK_NAME}: Failed to archive source links for deleted news ${newsId}: ${error.message}`)
+                await notifySlack(
+                    `:warning: *${HOOK_NAME}*: Beim Löschen des News-Eintrags ${newsId} konnte der verknüpfte News-Link nicht archiviert werden. Bitte manuell prüfen.\n` +
+                        `Fehler: ${error.message}`
+                )
             }
-        } catch (error: any) {
-            // Never block the deletion itself; a leftover archived link / junction
-            // row is recoverable, a blocked delete is worse.
-            logger.error(`${HOOK_NAME}: Failed to archive source links for deleted news: ${error.message}`)
-            await notifySlack(
-                `:warning: *${HOOK_NAME}*: Beim Löschen eines News-Eintrags konnte der verknüpfte News-Link nicht archiviert werden. Bitte manuell prüfen.\n` +
-                    `Fehler: ${error.message}`
-            )
         }
 
         return keys

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/create-news/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/create-news/index.ts
@@ -1,43 +1,100 @@
 import { defineHook } from '@directus/extensions-sdk'
+import { createHookErrorConstructor } from '../shared/errors.ts'
+import { isPublishable } from '../shared/isPublishable.ts'
 import { postSlackMessage } from '../shared/postSlackMessage.ts'
 import { safeAction } from '../shared/safeHook.ts'
-import { buildJunctionPayload, extractKeys, resolveStatus, SOURCE_COLLECTION } from './util/newsTarget.ts'
+import {
+    ARCHIVED_STATUS,
+    buildJunctionPayload,
+    buildUniqueNewsSlug,
+    DRAFT_STATUS,
+    extractKeys,
+    JUNCTION_COLLECTION,
+    NEWS_COLLECTION,
+    readJunctionRowsByNewsId,
+    SOURCE_COLLECTION,
+} from './util/newsTarget.ts'
 
 const HOOK_NAME = 'create-news'
-const NEWS_COLLECTION = 'news'
-const JUNCTION_COLLECTION = 'news_target'
 
 /**
- * `news` is a meta collection that references every kind of news source through
+ * `news` is a meta collection that surfaces every kind of news source through
  * the `news_target` many-to-any junction, so links (and future source types)
- * can be queried from a single place. This hook keeps that meta collection in
- * sync for `news_links`:
- *   - on create, it mirrors the link into a new `news` item and wires up the
- *     junction row (status is copied once, at creation time);
- *   - on delete, it removes the linked `news` item and junction row so no
- *     orphans remain.
+ * can be queried from a single place. This hook keeps the two collections in
+ * sync in both directions:
+ *
+ *   Source-driven (hosts/guests author `news_links`):
+ *     - on create, mirror the link into a new `news` item (always `draft`, so
+ *       nothing is public until an editor publishes it) and set `news.slug` from
+ *       the link title;
+ *     - on title update, keep `news.slug` in sync;
+ *     - on delete, remove the `news` item and junction row so no orphans remain.
+ *
+ *   Publication-driven (the editor works only on `news`):
+ *     - `news.status` is the single editorial control; on change we mirror it
+ *       down to `news_links.status`, which is the field the public read
+ *       permission filters on (it is system-managed, never edited by hand);
+ *     - before a `news` is published we validate its source link is complete;
+ *     - on `news` delete we archive the source link (kept for podcast production)
+ *       and drop the dangling junction row.
  *
  * The m2a junction has no foreign key on `news_target.target` and only nullifies
  * `news_id` when a `news` item is deleted, so neither side cascades at the DB
- * level — both paths are handled explicitly here.
+ * level — every path is handled explicitly here.
  */
-export default defineHook(({ action }, hookContext) => {
+export default defineHook(({ action, filter }, hookContext) => {
     const logger = hookContext.logger
     const env = hookContext.env
     const ItemsService = hookContext.services.ItemsService
+    const FieldsService = hookContext.services.FieldsService
     const getSchema = hookContext.getSchema
+
+    // `news_links.status` is system-managed: contributors never publish directly,
+    // so force new links to `draft` regardless of the submitted payload. Only an
+    // editor publishing the wrapping `news` item flips it (mirrored below).
+    filter(`${SOURCE_COLLECTION}.items.create`, (payload: any) => ({
+        ...(payload ?? {}),
+        status: DRAFT_STATUS,
+    }))
 
     action(
         `${SOURCE_COLLECTION}.items.create`,
-        safeAction(HOOK_NAME, logger, (metadata, eventContext) => handleCreate(metadata, eventContext))
+        safeAction(HOOK_NAME, logger, (metadata, eventContext) => handleLinkCreate(metadata, eventContext))
+    )
+
+    action(
+        `${SOURCE_COLLECTION}.items.update`,
+        safeAction(HOOK_NAME, logger, (metadata, eventContext) => handleLinkUpdate(metadata, eventContext))
     )
 
     action(
         `${SOURCE_COLLECTION}.items.delete`,
-        safeAction(HOOK_NAME, logger, (metadata, eventContext) => handleDelete(metadata, eventContext))
+        safeAction(HOOK_NAME, logger, (metadata, eventContext) => handleLinkDelete(metadata, eventContext))
     )
 
-    async function handleCreate(metadata: Record<string, any>, eventContext: Record<string, any>) {
+    // Block publishing a `news` whose source link is missing required fields.
+    // A filter (not an action) so the throw actually prevents the update.
+    filter(`${NEWS_COLLECTION}.items.update`, (payload: any, metadata: any, context: any) =>
+        guardNewsPublish(payload, metadata, context)
+    )
+
+    action(
+        `${NEWS_COLLECTION}.items.update`,
+        safeAction(HOOK_NAME, logger, (metadata, eventContext) => handleNewsStatusChange(metadata, eventContext))
+    )
+
+    // Archive the source link before the `news` row is deleted — a filter,
+    // because after deletion the junction's `news_id` is already nulled and the
+    // link can no longer be reached.
+    filter(`${NEWS_COLLECTION}.items.delete`, (keys: any, metadata: any, context: any) =>
+        handleNewsDelete(keys, context)
+    )
+
+    /**
+     * Mirror a newly created `news_links` item into a `news` meta item and wire
+     * up the junction. The `news` item is always created as `draft`.
+     */
+    async function handleLinkCreate(metadata: Record<string, any>, eventContext: Record<string, any>) {
         const keys = extractKeys(metadata)
         if (keys.length === 0) {
             logger.warn(`${HOOK_NAME}: No key found for ${SOURCE_COLLECTION} create action`)
@@ -71,15 +128,19 @@ export default defineHook(({ action }, hookContext) => {
                     continue
                 }
 
-                // Prefer the payload status; only read the persisted item when the
-                // payload omitted it (e.g. status defaulted on the DB side).
-                let status = resolveStatus(metadata.payload, null)
-                if (metadata.payload?.status === undefined) {
-                    const sourceItem = await sourceService.readOne(newsLinkId, { fields: ['status'] })
-                    status = resolveStatus(metadata.payload, sourceItem)
+                // Derive the slug from the link title. Prefer the payload; only
+                // read the persisted item when the payload omitted it.
+                let title = metadata.payload?.title
+                if (title === undefined) {
+                    const sourceItem = await sourceService.readOne(newsLinkId, { fields: ['title'] })
+                    title = sourceItem?.title
                 }
+                const slug = await buildUniqueNewsSlug(newsService, title)
 
-                const newsId = (await newsService.createOne({ status })) as string
+                const newsId = (await newsService.createOne({
+                    status: DRAFT_STATUS,
+                    ...(slug ? { slug } : {}),
+                })) as string
 
                 // Roll back the just-created news row if wiring up the junction
                 // fails — otherwise it is left orphaned and, since the idempotency
@@ -98,7 +159,7 @@ export default defineHook(({ action }, hookContext) => {
                     throw junctionError
                 }
 
-                logger.info(`${HOOK_NAME}: Created news ${newsId} for ${SOURCE_COLLECTION} ${newsLinkId} (status: ${status})`)
+                logger.info(`${HOOK_NAME}: Created news ${newsId} for ${SOURCE_COLLECTION} ${newsLinkId} (slug: ${slug ?? 'none'})`)
             } catch (error: any) {
                 logger.error(`${HOOK_NAME}: Failed to create news item for ${SOURCE_COLLECTION} ${newsLinkId}: ${error.message}`)
                 await notifySlack(
@@ -110,7 +171,65 @@ export default defineHook(({ action }, hookContext) => {
         }
     }
 
-    async function handleDelete(metadata: Record<string, any>, eventContext: Record<string, any>) {
+    /**
+     * Keep `news.slug` in sync when a link's title changes. The slug lives on
+     * `news` (it is the addressable URL), so it is updated on the parent here.
+     */
+    async function handleLinkUpdate(metadata: Record<string, any>, eventContext: Record<string, any>) {
+        // Only the title feeds the slug; ignore every other link update.
+        if (metadata.payload?.title === undefined) {
+            return
+        }
+
+        const keys = extractKeys(metadata)
+        if (keys.length === 0) {
+            return
+        }
+
+        const schema = await getSchema()
+        const newsService = new ItemsService(NEWS_COLLECTION, { schema, accountability: eventContext.accountability })
+        const junctionService = new ItemsService(JUNCTION_COLLECTION, {
+            schema,
+            accountability: eventContext.accountability,
+        })
+
+        for (const newsLinkId of keys) {
+            try {
+                const rows = await junctionService.readByQuery({
+                    filter: { collection: { _eq: SOURCE_COLLECTION }, target: { _eq: String(newsLinkId) } },
+                    fields: ['news_id'],
+                    limit: 1,
+                })
+                const newsId = rows[0]?.news_id
+                if (!newsId) {
+                    // No wrapper yet (e.g. create is still in flight); the create
+                    // path sets the slug from the same title, so nothing to do.
+                    continue
+                }
+
+                const slug = await buildUniqueNewsSlug(newsService, metadata.payload.title, newsId)
+                if (!slug) {
+                    // Title cleared to empty; keep the existing slug rather than
+                    // nulling a URL that may already be linked to.
+                    continue
+                }
+
+                await newsService.updateOne(newsId, { slug })
+                logger.info(`${HOOK_NAME}: Updated slug of news ${newsId} to "${slug}" from ${SOURCE_COLLECTION} ${newsLinkId}`)
+            } catch (error: any) {
+                logger.error(`${HOOK_NAME}: Failed to sync slug for ${SOURCE_COLLECTION} ${newsLinkId}: ${error.message}`)
+                await notifySlack(
+                    `:warning: *${HOOK_NAME}*: Der Slug des News-Eintrags für den Link ${newsLinkId} konnte nicht aktualisiert werden.\n` +
+                        `Fehler: ${error.message}`
+                )
+            }
+        }
+    }
+
+    /**
+     * Remove the `news` item and junction row when its source link is deleted.
+     */
+    async function handleLinkDelete(metadata: Record<string, any>, eventContext: Record<string, any>) {
         const keys = extractKeys(metadata)
         if (keys.length === 0) {
             logger.warn(`${HOOK_NAME}: No keys found for ${SOURCE_COLLECTION} delete action`)
@@ -158,6 +277,166 @@ export default defineHook(({ action }, hookContext) => {
                 )
             }
         }
+    }
+
+    /**
+     * Prevent publishing a `news` item whose source link is incomplete. Runs the
+     * same `isPublishable` guard the scheduled-publication flow uses. Infra
+     * failures fail open (log + notify) so a transient glitch can't block every
+     * publish; only a genuinely incomplete link throws.
+     */
+    async function guardNewsPublish(payload: any, metadata: any, context: any) {
+        if (payload?.status !== 'published') {
+            return payload
+        }
+
+        const keys = Array.isArray(metadata?.keys) ? metadata.keys : metadata?.key ? [metadata.key] : []
+        if (keys.length === 0) {
+            return payload
+        }
+
+        const pairs: Array<{ newsId: string | number; link: Record<string, any> }> = []
+        let fields: any[]
+        try {
+            const junctionService = new ItemsService(JUNCTION_COLLECTION, {
+                schema: context.schema,
+                accountability: context.accountability,
+            })
+            const sourceService = new ItemsService(SOURCE_COLLECTION, {
+                schema: context.schema,
+                accountability: context.accountability,
+            })
+            const fieldsService = new FieldsService({ schema: context.schema })
+            fields = await fieldsService.readAll(SOURCE_COLLECTION)
+
+            for (const newsId of keys) {
+                const rows = await readJunctionRowsByNewsId(junctionService, newsId, ['target'])
+                const linkIds = rows.map((row: any) => row.target).filter(Boolean)
+                if (linkIds.length === 0) {
+                    continue
+                }
+                const links = await sourceService.readByQuery({ filter: { id: { _in: linkIds } } })
+                for (const link of links) {
+                    pairs.push({ newsId, link })
+                }
+            }
+        } catch (error: any) {
+            logger.error(`${HOOK_NAME}: Publish guard could not verify source links, allowing publish: ${error.message}`)
+            await notifySlack(
+                `:warning: *${HOOK_NAME}*: Die Pflichtfeld-Prüfung vor dem Veröffentlichen von News konnte nicht ausgeführt werden. Die Veröffentlichung wurde trotzdem zugelassen.\n` +
+                    `Fehler: ${error.message}`
+            )
+            return payload
+        }
+
+        for (const { newsId, link } of pairs) {
+            if (!isPublishable(link, fields)) {
+                const hookError = createHookErrorConstructor(
+                    HOOK_NAME,
+                    `News ${newsId} kann nicht veröffentlicht werden: Der verknüpfte News-Link ${link.id} hat nicht alle Pflichtfelder ausgefüllt.`
+                )
+                throw new hookError()
+            }
+        }
+
+        return payload
+    }
+
+    /**
+     * Mirror a `news` status change down to its source link(s). `news.status` is
+     * the editorial source of truth; `news_links.status` is a read gate kept in
+     * lock-step so the public API only exposes published links.
+     */
+    async function handleNewsStatusChange(metadata: Record<string, any>, eventContext: Record<string, any>) {
+        const newStatus = metadata.payload?.status
+        if (newStatus === undefined) {
+            return
+        }
+
+        const keys = extractKeys(metadata)
+        if (keys.length === 0) {
+            return
+        }
+
+        const schema = await getSchema()
+        const junctionService = new ItemsService(JUNCTION_COLLECTION, {
+            schema,
+            accountability: eventContext.accountability,
+        })
+        const sourceService = new ItemsService(SOURCE_COLLECTION, {
+            schema,
+            accountability: eventContext.accountability,
+        })
+
+        for (const newsId of keys) {
+            try {
+                const rows = await readJunctionRowsByNewsId(junctionService, newsId, ['target'])
+                const linkIds = rows.map((row: any) => row.target).filter(Boolean)
+
+                // Update one at a time so each fires its own news_links action for
+                // downstream hooks (Algolia, etc.). See ADR 0002.
+                for (const linkId of linkIds) {
+                    await sourceService.updateOne(linkId, { status: newStatus })
+                }
+
+                if (linkIds.length > 0) {
+                    logger.info(`${HOOK_NAME}: Mirrored status "${newStatus}" from news ${newsId} to ${linkIds.length} link(s)`)
+                }
+            } catch (error: any) {
+                logger.error(`${HOOK_NAME}: Failed to mirror status for news ${newsId}: ${error.message}`)
+                await notifySlack(
+                    `:warning: *${HOOK_NAME}*: Der Status von News ${newsId} konnte nicht auf den verknüpften News-Link übertragen werden. Sichtbarkeit und Status können auseinanderlaufen.\n` +
+                        `Fehler: ${error.message}\n` +
+                        `${env.PUBLIC_URL}admin/content/${NEWS_COLLECTION}/${newsId}`
+                )
+            }
+        }
+    }
+
+    /**
+     * Archive the source link(s) of a `news` item that is being deleted and drop
+     * the junction row. The link is kept (it has editorial value for podcast
+     * production) but hidden from the audience.
+     */
+    async function handleNewsDelete(keys: any, context: any) {
+        const ids = Array.isArray(keys) ? keys : []
+        if (ids.length === 0) {
+            return keys
+        }
+
+        try {
+            const junctionService = new ItemsService(JUNCTION_COLLECTION, {
+                schema: context.schema,
+                accountability: context.accountability,
+            })
+            const sourceService = new ItemsService(SOURCE_COLLECTION, {
+                schema: context.schema,
+                accountability: context.accountability,
+            })
+
+            for (const newsId of ids) {
+                const rows = await readJunctionRowsByNewsId(junctionService, newsId, ['id', 'target'])
+                for (const row of rows) {
+                    if (row.target) {
+                        await sourceService.updateOne(row.target, { status: ARCHIVED_STATUS })
+                    }
+                    await junctionService.deleteOne(row.id)
+                }
+                if (rows.length > 0) {
+                    logger.info(`${HOOK_NAME}: Archived ${rows.length} link(s) and dropped junction row(s) for deleted news ${newsId}`)
+                }
+            }
+        } catch (error: any) {
+            // Never block the deletion itself; a leftover archived link / junction
+            // row is recoverable, a blocked delete is worse.
+            logger.error(`${HOOK_NAME}: Failed to archive source links for deleted news: ${error.message}`)
+            await notifySlack(
+                `:warning: *${HOOK_NAME}*: Beim Löschen eines News-Eintrags konnte der verknüpfte News-Link nicht archiviert werden. Bitte manuell prüfen.\n` +
+                    `Fehler: ${error.message}`
+            )
+        }
+
+        return keys
     }
 
     async function notifySlack(message: string) {

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/create-news/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/create-news/index.ts
@@ -280,10 +280,15 @@ export default defineHook(({ action, filter }, hookContext) => {
     }
 
     /**
-     * Prevent publishing a `news` item whose source link is incomplete. Runs the
-     * same `isPublishable` guard the scheduled-publication flow uses. Infra
-     * failures fail open (log + notify) so a transient glitch can't block every
-     * publish; only a genuinely incomplete link throws.
+     * Runs when a `news` item is published. Two jobs:
+     *   1. Guard — block the publish if the source link is incomplete (same
+     *      `isPublishable` check the scheduled-publication flow uses). Infra
+     *      failures fail open (log + notify) so a transient glitch can't block
+     *      every publish; only a genuinely incomplete link throws.
+     *   2. Self-heal — if the item is being published without a slug (e.g. a
+     *      pre-migration item, or one whose title never produced one), derive it
+     *      from the link title and inject it into the same update, so it is
+     *      reachable at `/news/<slug>` without a manual backfill.
      */
     async function guardNewsPublish(payload: any, metadata: any, context: any) {
         if (payload?.status !== 'published') {
@@ -295,17 +300,22 @@ export default defineHook(({ action, filter }, hookContext) => {
             return payload
         }
 
+        const newsService = new ItemsService(NEWS_COLLECTION, {
+            schema: context.schema,
+            accountability: context.accountability,
+        })
+        const junctionService = new ItemsService(JUNCTION_COLLECTION, {
+            schema: context.schema,
+            accountability: context.accountability,
+        })
+        const sourceService = new ItemsService(SOURCE_COLLECTION, {
+            schema: context.schema,
+            accountability: context.accountability,
+        })
+
         const pairs: Array<{ newsId: string | number; link: Record<string, any> }> = []
         let fields: any[]
         try {
-            const junctionService = new ItemsService(JUNCTION_COLLECTION, {
-                schema: context.schema,
-                accountability: context.accountability,
-            })
-            const sourceService = new ItemsService(SOURCE_COLLECTION, {
-                schema: context.schema,
-                accountability: context.accountability,
-            })
             const fieldsService = new FieldsService({ schema: context.schema })
             fields = await fieldsService.readAll(SOURCE_COLLECTION)
 
@@ -336,6 +346,27 @@ export default defineHook(({ action, filter }, hookContext) => {
                     `News ${newsId} kann nicht veröffentlicht werden: Der verknüpfte News-Link ${link.id} hat nicht alle Pflichtfelder ausgefüllt.`
                 )
                 throw new hookError()
+            }
+        }
+
+        // Self-heal a missing slug. A filter shares one payload across all keys,
+        // so a slug can only be injected for a single-key update; batch publishes
+        // fall back to the create/title-update paths (or a manual backfill).
+        if (keys.length === 1 && !payload.slug) {
+            try {
+                const newsId = keys[0]
+                const current = await newsService.readOne(newsId, { fields: ['slug'] })
+                if (!current?.slug) {
+                    const link = pairs.find((pair) => String(pair.newsId) === String(newsId))?.link
+                    const slug = await buildUniqueNewsSlug(newsService, link?.title, newsId)
+                    if (slug) {
+                        logger.info(`${HOOK_NAME}: Backfilled slug "${slug}" on news ${newsId} at publish time`)
+                        return { ...payload, slug }
+                    }
+                }
+            } catch (error: any) {
+                // A failed backfill must never block the publish itself.
+                logger.warn(`${HOOK_NAME}: Could not backfill slug on publish: ${error.message}`)
             }
         }
 

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/create-news/util/__tests__/newsTarget.test.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/create-news/util/__tests__/newsTarget.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from '@jest/globals'
-import { buildJunctionPayload, DEFAULT_STATUS, extractKeys, resolveStatus, SOURCE_COLLECTION } from './../newsTarget.ts'
+import { describe, expect, jest, test } from '@jest/globals'
+import { buildJunctionPayload, buildUniqueNewsSlug, extractKeys, SOURCE_COLLECTION } from './../newsTarget.ts'
 
 describe('extractKeys', () => {
     test('wraps a single key into an array', () => {
@@ -43,18 +43,26 @@ describe('buildJunctionPayload', () => {
     })
 })
 
-describe('resolveStatus', () => {
-    test('prefers the payload status', () => {
-        expect(resolveStatus({ status: 'published' }, { status: 'draft' })).toBe('published')
+describe('buildUniqueNewsSlug', () => {
+    const service = (rows: Array<Record<string, any>>) => ({ readByQuery: jest.fn(async () => rows) })
+
+    test('returns null when there is no usable title', async () => {
+        await expect(buildUniqueNewsSlug(service([]), '')).resolves.toBeNull()
+        await expect(buildUniqueNewsSlug(service([]), null)).resolves.toBeNull()
+        await expect(buildUniqueNewsSlug(service([]), undefined)).resolves.toBeNull()
     })
 
-    test('falls back to the source item status', () => {
-        expect(resolveStatus({}, { status: 'archived' })).toBe('archived')
-        expect(resolveStatus(undefined, { status: 'archived' })).toBe('archived')
+    test('returns the base slug when it is free', async () => {
+        await expect(buildUniqueNewsSlug(service([]), 'React 19 Released')).resolves.toBe('react-19-released')
     })
 
-    test('defaults to draft when nothing is available', () => {
-        expect(resolveStatus(undefined, null)).toBe(DEFAULT_STATUS)
-        expect(resolveStatus({}, undefined)).toBe('draft')
+    test('appends the next free numeric suffix on collision', async () => {
+        const rows = [{ id: 'a', slug: 'react-19-released' }, { id: 'b', slug: 'react-19-released-2' }]
+        await expect(buildUniqueNewsSlug(service(rows), 'React 19 Released')).resolves.toBe('react-19-released-3')
+    })
+
+    test('ignores the excluded id so an item does not collide with itself', async () => {
+        const rows = [{ id: 'self', slug: 'react-19-released' }]
+        await expect(buildUniqueNewsSlug(service(rows), 'React 19 Released', 'self')).resolves.toBe('react-19-released')
     })
 })

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/create-news/util/newsTarget.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/create-news/util/newsTarget.ts
@@ -1,15 +1,31 @@
+import { getUrlSlug } from './../../../../../../shared-code/index.ts'
+
 /**
  * The Directus collection whose items are mirrored into the `news` meta
  * collection, and the m2a discriminator value stored on the junction.
  */
 export const SOURCE_COLLECTION = 'news_links'
 
-/** Status used when a `news_links` item is created without an explicit status. */
-export const DEFAULT_STATUS = 'draft'
+/** The meta collection every news source is surfaced through. */
+export const NEWS_COLLECTION = 'news'
+
+/** The many-to-any junction linking `news` to its source items. */
+export const JUNCTION_COLLECTION = 'news_target'
+
+/** Status a freshly mirrored / unpublished item carries. */
+export const DRAFT_STATUS = 'draft'
+
+/** Status a source item is set to when its `news` wrapper is deleted. */
+export const ARCHIVED_STATUS = 'archived'
+
+/** Minimal shape of the ItemsService methods used by the helpers below. */
+interface ReadableService {
+    readByQuery: (query: Record<string, any>) => Promise<any[]>
+}
 
 /**
  * Extract the affected keys from a Directus action metadata object. Single
- * creates expose `key` while (batch) creates/deletes expose `keys` (an array).
+ * creates expose `key` while (batch) creates/deletes/updates expose `keys`.
  *
  * @param metadata The action metadata.
  */
@@ -42,15 +58,71 @@ export function buildJunctionPayload(newsId: string, newsLinkId: string | number
 }
 
 /**
- * Resolve the status to mirror onto the `news` item. Prefer the status from the
- * create payload, fall back to the persisted source item, then to a draft.
+ * Read the junction rows that link a given `news` item to its `news_links`
+ * sources. Used to find the source item(s) to mirror status onto (or archive).
  *
- * @param payload The create action payload (may omit status).
- * @param sourceItem The persisted `news_links` item, if it had to be read.
+ * @param junctionService An ItemsService for `news_target`.
+ * @param newsId The id of the `news` item.
+ * @param fields The junction fields to read.
  */
-export function resolveStatus(
-    payload: Record<string, any> | undefined,
-    sourceItem?: Record<string, any> | null
-): string {
-    return payload?.status ?? sourceItem?.status ?? DEFAULT_STATUS
+export async function readJunctionRowsByNewsId(
+    junctionService: ReadableService,
+    newsId: string | number,
+    fields: string[] = ['id', 'target']
+): Promise<any[]> {
+    return junctionService.readByQuery({
+        filter: { news_id: { _eq: newsId }, collection: { _eq: SOURCE_COLLECTION } },
+        fields,
+        limit: -1,
+    })
+}
+
+/**
+ * Build a unique slug for a `news` item from its source link title. The `news`
+ * collection has a unique constraint on `slug`, so a plain `getUrlSlug(title)`
+ * would throw on a duplicate title; append `-2`, `-3`, … until free.
+ *
+ * Returns `null` when there is no usable title, leaving the slug unset (the
+ * column is nullable, and Postgres allows multiple NULLs under a unique index).
+ *
+ * @param newsService An ItemsService for `news`.
+ * @param title The source link title to derive the slug from.
+ * @param excludeNewsId A `news` id to ignore when checking for collisions (used
+ *   when re-slugging an existing item so it doesn't collide with itself).
+ */
+export async function buildUniqueNewsSlug(
+    newsService: ReadableService,
+    title: string | null | undefined,
+    excludeNewsId?: string | number
+): Promise<string | null> {
+    if (!title) {
+        return null
+    }
+
+    const base = getUrlSlug(title)
+    if (!base) {
+        return null
+    }
+
+    const existing = await newsService.readByQuery({
+        filter: { slug: { _starts_with: base } },
+        fields: ['id', 'slug'],
+        limit: -1,
+    })
+
+    const taken = new Set(
+        (existing ?? [])
+            .filter((row: any) => excludeNewsId === undefined || String(row.id) !== String(excludeNewsId))
+            .map((row: any) => row.slug)
+    )
+
+    if (!taken.has(base)) {
+        return base
+    }
+
+    let suffix = 2
+    while (taken.has(`${base}-${suffix}`)) {
+        suffix++
+    }
+    return `${base}-${suffix}`
 }

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/schedule-publication/__tests__/index.test.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/schedule-publication/__tests__/index.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals'
+
+// The extensions SDK ships as ESM and is not transformed under Jest's CJS mode,
+// so stub it. The real `defineHook` simply returns its callback.
+jest.mock('@directus/extensions-sdk', () => ({
+    defineHook: (callback: unknown) => callback,
+}))
+
+// Slack helper mocked so the hook never hits the network and we can assert on it.
+jest.mock('./../../shared/postSlackMessage.ts', () => ({
+    postSlackMessage: jest.fn(),
+}))
+
+// `shared/errors.ts` imports `@directus/errors` (ESM), which Jest can't parse.
+jest.mock('./../../shared/errors.ts', () => ({
+    createHookErrorConstructor: (_hook: string, message: string) =>
+        class extends Error {
+            constructor() {
+                super(message)
+            }
+        },
+}))
+
+import { postSlackMessage } from './../../shared/postSlackMessage.ts'
+import registerHook from './../index.ts'
+
+const postSlackMessageMock = jest.mocked(postSlackMessage)
+
+interface UpdateCall {
+    id: string | number
+    data: Record<string, any>
+}
+
+interface SetupOptions {
+    /** Draft, due items returned by readByQuery for the `news` collection. */
+    dueItems?: Array<Record<string, any>>
+    /** Field definitions returned by FieldsService.readAll. */
+    fields?: any[]
+    /** When set, updateOne rejects for a `{ status: 'published' }` payload. */
+    rejectPublish?: boolean
+}
+
+function setup(options: SetupOptions = {}) {
+    const { dueItems = [], fields = [], rejectPublish = false } = options
+
+    const updateCalls: UpdateCall[] = []
+    const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+
+    const ItemsService = jest.fn().mockImplementation(() => ({
+        readByQuery: jest.fn(async () => dueItems),
+        updateOne: jest.fn(async (id: string | number, data: Record<string, any>) => {
+            if (rejectPublish && data.status === 'published') {
+                throw new Error('downstream hook rejected the publish')
+            }
+            updateCalls.push({ id, data })
+            return id
+        }),
+    }))
+
+    const FieldsService = jest.fn().mockImplementation(() => ({
+        readAll: jest.fn(async () => fields),
+    }))
+
+    const globalSchema = {
+        collections: {
+            news: {
+                singleton: false,
+                primary: 'id',
+                fields: { status: {}, published_on: {} },
+            },
+        },
+    }
+
+    let scheduled: (() => Promise<void>) | undefined
+    const register = {
+        schedule: (_cron: string, callback: () => Promise<void>) => {
+            scheduled = callback
+        },
+    }
+
+    const hookContext = {
+        logger,
+        services: { ItemsService, FieldsService },
+        getSchema: jest.fn(async () => globalSchema),
+        env: { PUBLIC_URL: 'https://cms.example.com/' },
+    }
+
+    registerHook(register as any, hookContext as any)
+
+    return { runSchedule: () => scheduled!(), updateCalls, logger }
+}
+
+// A field that is required on the schema, so an item lacking it is not publishable.
+const REQUIRE_LINK_FIELD = [{ field: 'link', schema: { required: true }, meta: {} }]
+
+describe('schedule-publication hook', () => {
+    beforeEach(() => {
+        postSlackMessageMock.mockClear()
+    })
+
+    test('publishes a due item whose required fields are set', async () => {
+        const { runSchedule, updateCalls } = setup({
+            dueItems: [{ id: 'news-1', link: 'https://example.com' }],
+            fields: REQUIRE_LINK_FIELD,
+        })
+
+        await runSchedule()
+
+        expect(updateCalls).toEqual([{ id: 'news-1', data: { status: 'published' } }])
+        expect(postSlackMessageMock).not.toHaveBeenCalled()
+    })
+
+    test('de-schedules and notifies when a due item is missing a required field', async () => {
+        const { runSchedule, updateCalls } = setup({
+            dueItems: [{ id: 'news-2' }],
+            fields: REQUIRE_LINK_FIELD,
+        })
+
+        await runSchedule()
+
+        // Not published; published_on nulled so it drops out of the next run.
+        expect(updateCalls).toEqual([{ id: 'news-2', data: { published_on: null } }])
+        expect(postSlackMessageMock).toHaveBeenCalledTimes(1)
+        expect(postSlackMessageMock).toHaveBeenCalledWith(expect.stringContaining('news-2'))
+    })
+
+    test('de-schedules and notifies when a downstream hook rejects the publish', async () => {
+        const { runSchedule, updateCalls, logger } = setup({
+            dueItems: [{ id: 'news-3', link: 'https://example.com' }],
+            fields: REQUIRE_LINK_FIELD,
+            rejectPublish: true,
+        })
+
+        await runSchedule()
+
+        // The publish threw; it must not fail the run — instead the item is
+        // de-scheduled (published_on nulled) and the team is notified once.
+        expect(updateCalls).toEqual([{ id: 'news-3', data: { published_on: null } }])
+        expect(postSlackMessageMock).toHaveBeenCalledTimes(1)
+        expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('downstream hook rejected the publish'))
+    })
+
+    test('does nothing when no items are due', async () => {
+        const { runSchedule, updateCalls } = setup({ dueItems: [] })
+
+        await runSchedule()
+
+        expect(updateCalls).toEqual([])
+        expect(postSlackMessageMock).not.toHaveBeenCalled()
+    })
+})

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/schedule-publication/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/schedule-publication/index.ts
@@ -13,6 +13,42 @@ export default defineHook(({ schedule }, hookContext) => {
     const getSchema = hookContext.getSchema
 
     /**
+     * Unset "published_on" so a failed item is excluded from the next run (the
+     * schedule query only matches items whose "published_on" is set and due), and
+     * notify the team so the publication can be completed manually. Without the
+     * unset, the item would keep matching and fail on every run.
+     *
+     * The unset is a `{ published_on: null }` update with no status change, so it
+     * does not re-trigger any publish-related hook.
+     *
+     * @param itemsService The ItemsService for the item's collection.
+     * @param collectionName The collection name (for the message + admin link).
+     * @param primaryKey The primary key of the item to de-schedule.
+     * @param reasonClause A German clause explaining why publication failed.
+     */
+    async function descheduleItem(
+        itemsService: any,
+        collectionName: string,
+        primaryKey: string | number,
+        reasonClause: string
+    ) {
+        await itemsService.updateOne(primaryKey, { published_on: null })
+
+        try {
+            // Inform team via Slack about the problem with the information to fix it
+            await postSlackMessage(
+                [
+                    `Achtung: Ein Eintrag in der "${collectionName}" Collection konnte nicht automatisch veröffentlicht werden, ${reasonClause}.`,
+                    `Die Veröffentlichung muss nun manuell über den folgenden Link vorgenommen werden:`,
+                    `${env.PUBLIC_URL}admin/content/${collectionName}/${primaryKey}`,
+                ].join(' ')
+            )
+        } catch (slackError: any) {
+            logger.error(`${HOOK_NAME} hook: Error: Could not post message to Slack: ${slackError.message}`)
+        }
+    }
+
+    /**
      * It runs a cron job every minute that publishes items automatically.
      */
     schedule('*/1 * * * *', async () => {
@@ -74,16 +110,34 @@ export default defineHook(({ schedule }, hookContext) => {
                             // Run code for each item async
                             await Promise.all(
                                 items.map(async (item: any) => {
+                                    // Get primary key
+                                    const primaryKey = item[collectionSchema.primary]
+
                                     // Check if all required fields are set
                                     // We also need to bind the logger/pino instance properly for this forwarded function to work
                                     // Refer to: https://github.com/pinojs/pino/issues/1687
                                     const requiredFieldsAreSet = isPublishable(item, fields, logger.info.bind(logger))
 
-                                    // Get primary key
-                                    const primaryKey = item[collectionSchema.primary]
+                                    // De-schedule items that are missing mandatory fields
+                                    if (!requiredFieldsAreSet) {
+                                        logger.warn(
+                                            `${HOOK_NAME} hook: Could not publish "${collectionName}" item with ID "${primaryKey}" due to missing mandatory fields`
+                                        )
+                                        await descheduleItem(
+                                            itemsService,
+                                            collectionName,
+                                            primaryKey,
+                                            'da ein Pflichtfeld nicht ausgefüllt wurde'
+                                        )
+                                        return
+                                    }
 
-                                    // Publish item if all required fields are set
-                                    if (requiredFieldsAreSet) {
+                                    // Publish the item. A downstream hook can still reject the
+                                    // publish (e.g. the news publish guard when a linked source item
+                                    // is incomplete); catch that so a single item cannot fail the
+                                    // whole run, and de-schedule it so it does not retry every minute
+                                    // until fixed.
+                                    try {
                                         await itemsService.updateOne(primaryKey, {
                                             status: 'published',
                                         })
@@ -92,33 +146,16 @@ export default defineHook(({ schedule }, hookContext) => {
                                         logger.info(
                                             `${HOOK_NAME} hook: Published "${collectionName}" item with ID "${primaryKey}"`
                                         )
-
-                                        // Otherwise unset "published_on" and send error message
-                                    } else {
-                                        // Log publication warning
+                                    } catch (publishError: any) {
                                         logger.warn(
-                                            `${HOOK_NAME} hook: Could not publish "${collectionName}" item with ID "${primaryKey}" due to missing mandatory fields`
+                                            `${HOOK_NAME} hook: Could not publish "${collectionName}" item with ID "${primaryKey}": ${publishError.message}`
                                         )
-                                        // Set "published_on" to "null" to exclude
-                                        // item from next run of schedule function
-                                        await itemsService.updateOne(item[collectionSchema.primary], {
-                                            published_on: null,
-                                        })
-                                        try {
-                                            // Inform team via Slack about problem with
-                                            // necessary information to fix it
-                                            await postSlackMessage(
-                                                [
-                                                    `Achtung: Ein Eintrag in der "${collectionName}" Collection konnte nicht automatisch veröffentlicht werden, da ein Pflichtfeld nicht ausgefüllt wurde.`,
-                                                    `Die Veröffentlichung muss nun manuell über den folgenden Link vorgenommen werden:`,
-                                                    `${env.PUBLIC_URL}admin/content/${collectionName}/${item[collectionSchema.primary]}`,
-                                                ].join(' ')
-                                            )
-                                        } catch (slackError: any) {
-                                            logger.error(
-                                                `${HOOK_NAME} hook: Error: Could not post message to Slack: ${slackError.message}`
-                                            )
-                                        }
+                                        await descheduleItem(
+                                            itemsService,
+                                            collectionName,
+                                            primaryKey,
+                                            `da die Veröffentlichung abgelehnt wurde (${publishError.message})`
+                                        )
                                     }
                                 })
                             )

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/set-slug/__tests__/getPayloadWithSlug.test.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/set-slug/__tests__/getPayloadWithSlug.test.ts
@@ -180,39 +180,6 @@ describe('getPayloadWithSlug', () => {
         });
     });
 
-    test('should generate slug for news_links', async () => {
-        // Arrange
-        const futureItem = {
-            title: 'React 19 Released',
-        };
-        const payload = { title: 'React 19 Released' };
-        const metadata = { collection: 'news_links', keys: ['505'] };
-
-        // Act
-        const result = await getPayloadWithSlug(futureItem, { payload, metadata });
-
-        // Assert
-        expect(result).toEqual({
-            ...payload,
-            slug: 'react-19-released',
-        });
-    });
-
-    test('should not generate slug for news_links without a title', async () => {
-        // Arrange
-        const futureItem = {
-            link: 'https://example.com/article',
-        };
-        const payload = { link: 'https://example.com/article' };
-        const metadata = { collection: 'news_links', keys: ['506'] };
-
-        // Act
-        const result = await getPayloadWithSlug(futureItem, { payload, metadata });
-
-        // Assert
-        expect(result).toEqual(payload);
-    });
-
     test('should generate slug for profiles with first_name and last_name', async () => {
         // Arrange
         const futureItem = {

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/set-slug/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/set-slug/index.ts
@@ -54,7 +54,6 @@ export default defineHook(({ filter }, hookContext) => {
                         (metadata.collection === 'podcasts' && (payload.type || payload.number || payload.title)) ||
                         (metadata.collection === 'meetups' && payload.title) ||
                         (metadata.collection === 'conferences' && payload.title) ||
-                        (metadata.collection === 'news_links' && payload.title) ||
                         (metadata.collection === 'profiles' && (payload.first_name || payload.last_name))
                     )
                 ) {

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/set-slug/util/getPayloadWithSlug.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/set-slug/util/getPayloadWithSlug.ts
@@ -55,15 +55,6 @@ export async function getPayloadWithSlug(
         }
     }
 
-    // If collection name is "news_links" and "title" is set,
-    // return payload with news link slug
-    if (metadata.collection === 'news_links' && futureItem.title) {
-        return {
-            ...payload,
-            slug: getUrlSlug(futureItem.title),
-        }
-    }
-
     // If collection name is "profiles" and "first_name" and "last_name" are set,
     //  return payload with profile slug
     if (metadata.collection === 'profiles' && futureItem.first_name && futureItem.last_name) {

--- a/directus-cms/schema.json
+++ b/directus-cms/schema.json
@@ -18328,7 +18328,7 @@
         "translations": null,
         "validation": null,
         "validation_message": null,
-        "width": "full"
+        "width": "half"
       },
       "schema": {
         "name": "status",
@@ -18367,7 +18367,7 @@
         "readonly": false,
         "required": false,
         "searchable": true,
-        "sort": 3,
+        "sort": 4,
         "special": null,
         "translations": null,
         "validation": null,
@@ -18413,7 +18413,7 @@
         "readonly": true,
         "required": false,
         "searchable": true,
-        "sort": 4,
+        "sort": 5,
         "special": [
           "user-created"
         ],
@@ -18461,7 +18461,7 @@
         "readonly": true,
         "required": false,
         "searchable": true,
-        "sort": 5,
+        "sort": 6,
         "special": [
           "date-created"
         ],
@@ -18509,7 +18509,7 @@
         "readonly": true,
         "required": false,
         "searchable": true,
-        "sort": 6,
+        "sort": 7,
         "special": [
           "user-updated"
         ],
@@ -18557,7 +18557,7 @@
         "readonly": true,
         "required": false,
         "searchable": true,
-        "sort": 7,
+        "sort": 8,
         "special": [
           "date-updated"
         ],
@@ -18592,8 +18592,10 @@
       "meta": {
         "collection": "news",
         "conditions": null,
-        "display": null,
-        "display_options": null,
+        "display": "related-values",
+        "display_options": {
+          "template": "{{target:news_links.title}} - {{target:news_links.link}}"
+        },
         "field": "target",
         "group": null,
         "hidden": false,
@@ -18605,7 +18607,7 @@
         "readonly": false,
         "required": true,
         "searchable": true,
-        "sort": 8,
+        "sort": 10,
         "special": [
           "m2a"
         ],
@@ -18613,6 +18615,94 @@
         "validation": null,
         "validation_message": null,
         "width": "full"
+      }
+    },
+    {
+      "collection": "news",
+      "field": "published_on",
+      "type": "dateTime",
+      "meta": {
+        "collection": "news",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "published_on",
+        "group": null,
+        "hidden": false,
+        "interface": "datetime",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": false,
+        "searchable": true,
+        "sort": 3,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "half"
+      },
+      "schema": {
+        "name": "published_on",
+        "table": "news",
+        "data_type": "timestamp without time zone",
+        "default_value": null,
+        "max_length": null,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_indexed": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
+      }
+    },
+    {
+      "collection": "news",
+      "field": "slug",
+      "type": "string",
+      "meta": {
+        "collection": "news",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "slug",
+        "group": null,
+        "hidden": false,
+        "interface": "input",
+        "note": null,
+        "options": null,
+        "readonly": false,
+        "required": true,
+        "searchable": true,
+        "sort": 9,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "slug",
+        "table": "news",
+        "data_type": "character varying",
+        "default_value": null,
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": true,
+        "is_unique": true,
+        "is_indexed": true,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
       }
     },
     {
@@ -18663,93 +18753,6 @@
     },
     {
       "collection": "news_links",
-      "field": "status",
-      "type": "string",
-      "meta": {
-        "collection": "news_links",
-        "conditions": null,
-        "display": "labels",
-        "display_options": {
-          "choices": [
-            {
-              "background": "var(--theme--primary-background)",
-              "color": "var(--theme--primary)",
-              "foreground": "var(--theme--primary)",
-              "text": "$t:published",
-              "value": "published"
-            },
-            {
-              "background": "var(--theme--background-normal)",
-              "color": "var(--theme--foreground)",
-              "foreground": "var(--theme--foreground)",
-              "text": "$t:draft",
-              "value": "draft"
-            },
-            {
-              "background": "var(--theme--warning-background)",
-              "color": "var(--theme--warning)",
-              "foreground": "var(--theme--warning)",
-              "text": "$t:archived",
-              "value": "archived"
-            }
-          ],
-          "showAsDot": true
-        },
-        "field": "status",
-        "group": null,
-        "hidden": false,
-        "interface": "select-dropdown",
-        "note": null,
-        "options": {
-          "choices": [
-            {
-              "color": "var(--theme--primary)",
-              "text": "$t:published",
-              "value": "published"
-            },
-            {
-              "color": "var(--theme--foreground)",
-              "text": "$t:draft",
-              "value": "draft"
-            },
-            {
-              "color": "var(--theme--warning)",
-              "text": "$t:archived",
-              "value": "archived"
-            }
-          ]
-        },
-        "readonly": false,
-        "required": false,
-        "searchable": true,
-        "sort": 2,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "status",
-        "table": "news_links",
-        "data_type": "character varying",
-        "default_value": "draft",
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": false,
-        "is_unique": false,
-        "is_indexed": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
-      }
-    },
-    {
-      "collection": "news_links",
       "field": "sort",
       "type": "integer",
       "meta": {
@@ -18766,7 +18769,7 @@
         "readonly": false,
         "required": false,
         "searchable": true,
-        "sort": 3,
+        "sort": 2,
         "special": null,
         "translations": null,
         "validation": null,
@@ -19046,7 +19049,7 @@
         "readonly": false,
         "required": true,
         "searchable": true,
-        "sort": 10,
+        "sort": 9,
         "special": null,
         "translations": null,
         "validation": null,
@@ -19090,7 +19093,7 @@
         "readonly": false,
         "required": false,
         "searchable": true,
-        "sort": 18,
+        "sort": 17,
         "special": [
           "cast-json"
         ],
@@ -19149,7 +19152,7 @@
         "readonly": false,
         "required": true,
         "searchable": true,
-        "sort": 11,
+        "sort": 10,
         "special": null,
         "translations": null,
         "validation": null,
@@ -19196,7 +19199,7 @@
         "readonly": false,
         "required": true,
         "searchable": true,
-        "sort": 12,
+        "sort": 11,
         "special": [
           "m2o"
         ],
@@ -19245,7 +19248,7 @@
         "readonly": false,
         "required": false,
         "searchable": true,
-        "sort": 14,
+        "sort": 13,
         "special": [
           "m2o"
         ],
@@ -19295,7 +19298,7 @@
         "readonly": false,
         "required": false,
         "searchable": true,
-        "sort": 15,
+        "sort": 14,
         "special": null,
         "translations": null,
         "validation": null,
@@ -19343,7 +19346,7 @@
         "readonly": false,
         "required": false,
         "searchable": true,
-        "sort": 16,
+        "sort": 15,
         "special": null,
         "translations": null,
         "validation": null,
@@ -19390,7 +19393,7 @@
         "readonly": false,
         "required": false,
         "searchable": true,
-        "sort": 13,
+        "sort": 12,
         "special": [
           "alias",
           "no-data"
@@ -19399,50 +19402,6 @@
         "validation": null,
         "validation_message": null,
         "width": "full"
-      }
-    },
-    {
-      "collection": "news_links",
-      "field": "slug",
-      "type": "string",
-      "meta": {
-        "collection": "news_links",
-        "conditions": null,
-        "display": null,
-        "display_options": null,
-        "field": "slug",
-        "group": null,
-        "hidden": false,
-        "interface": "input",
-        "note": null,
-        "options": null,
-        "readonly": false,
-        "required": false,
-        "searchable": true,
-        "sort": 9,
-        "special": null,
-        "translations": null,
-        "validation": null,
-        "validation_message": null,
-        "width": "full"
-      },
-      "schema": {
-        "name": "slug",
-        "table": "news_links",
-        "data_type": "character varying",
-        "default_value": null,
-        "max_length": 255,
-        "numeric_precision": null,
-        "numeric_scale": null,
-        "is_nullable": true,
-        "is_unique": false,
-        "is_indexed": false,
-        "is_primary_key": false,
-        "is_generated": false,
-        "generation_expression": null,
-        "has_auto_increment": false,
-        "foreign_key_table": null,
-        "foreign_key_column": null
       }
     },
     {
@@ -19465,7 +19424,7 @@
         "readonly": false,
         "required": false,
         "searchable": true,
-        "sort": 17,
+        "sort": 16,
         "special": [
           "alias",
           "no-data"
@@ -19474,6 +19433,65 @@
         "validation": null,
         "validation_message": null,
         "width": "full"
+      }
+    },
+    {
+      "collection": "news_links",
+      "field": "status",
+      "type": "string",
+      "meta": {
+        "collection": "news_links",
+        "conditions": null,
+        "display": null,
+        "display_options": null,
+        "field": "status",
+        "group": null,
+        "hidden": false,
+        "interface": "select-dropdown",
+        "note": null,
+        "options": {
+          "choices": [
+            {
+              "text": "Draft",
+              "value": "draft"
+            },
+            {
+              "text": "Published",
+              "value": "published"
+            },
+            {
+              "text": "Archived",
+              "value": "archived"
+            }
+          ]
+        },
+        "readonly": false,
+        "required": false,
+        "searchable": true,
+        "sort": 3,
+        "special": null,
+        "translations": null,
+        "validation": null,
+        "validation_message": null,
+        "width": "full"
+      },
+      "schema": {
+        "name": "status",
+        "table": "news_links",
+        "data_type": "character varying",
+        "default_value": "draft",
+        "max_length": 255,
+        "numeric_precision": null,
+        "numeric_scale": null,
+        "is_nullable": false,
+        "is_unique": false,
+        "is_indexed": false,
+        "is_primary_key": false,
+        "is_generated": false,
+        "generation_expression": null,
+        "has_auto_increment": false,
+        "foreign_key_table": null,
+        "foreign_key_column": null
       }
     },
     {

--- a/directus-cms/schema.json
+++ b/directus-cms/schema.json
@@ -18677,7 +18677,7 @@
         "note": null,
         "options": null,
         "readonly": false,
-        "required": true,
+        "required": false,
         "searchable": true,
         "sort": 9,
         "special": null,

--- a/nuxt-app/composables/useDirectus.ts
+++ b/nuxt-app/composables/useDirectus.ts
@@ -959,7 +959,7 @@ export function useDirectus() {
         page: number = 1,
         { withAuthor = false }: { withAuthor?: boolean } = {}
     ) {
-        const fields = ['id', 'date_created', 'target.id', 'target.collection', 'target.target.*']
+        const fields = ['id', 'slug', 'date_created', 'target.id', 'target.collection', 'target.target.*']
         if (withAuthor) {
             fields.push('target.target.member.*', 'target.target.member.normal_image.*')
         }
@@ -975,22 +975,20 @@ export function useDirectus() {
         )) as DirectusNewsItem[]
     }
 
-    // A single published news entry for the `/news/[slug]` detail page, resolved
-    // by the slug of its source item. We always query the `news` meta collection
-    // — never a source collection like `news_links` directly — because `news` is
-    // the join point for every source type (today only `news_links`, in future
-    // e.g. `news_event`), which keeps routing forward-compatible. Note the m2a
-    // asymmetry: *filtering* the nested target needs the collection-scoped
-    // `target:news_links` key, while *reading* it uses plain `target.target.*`.
+    // A single published news entry for the `/news/[slug]` detail page. The slug
+    // lives on the `news` meta collection itself (it is the addressable URL, kept
+    // in sync from the source title by the CMS `create-news` hook), so this is a
+    // plain top-level filter — no m2a nested filter needed. We always query
+    // `news` — never a source collection like `news_links` directly — because
+    // `news` is the join point for every source type (today only `news_links`, in
+    // future e.g. `news_event`), which keeps routing forward-compatible.
     async function getPublishedNewsBySlug(slug: string) {
         const news = (await directus.request(
             readItems('news', {
                 filter: {
                     status: { _eq: 'published' },
-                    target: {
-                        ['target:news_links']: { slug: { _eq: slug } },
-                    },
-                } as any,
+                    slug: { _eq: slug },
+                },
                 fields: [
                     'id',
                     'date_created',

--- a/nuxt-app/pages/news/index.vue
+++ b/nuxt-app/pages/news/index.vue
@@ -25,7 +25,7 @@
                 <NewsItem
                     class="h-full"
                     :news-link="card.link"
-                    :to="card.link.slug ? `/news/${card.link.slug}` : undefined"
+                    :to="card.news.slug ? `/news/${card.news.slug}` : undefined"
                     heading-level="h2"
                 />
             </li>

--- a/nuxt-app/types/directus.ts
+++ b/nuxt-app/types/directus.ts
@@ -344,7 +344,6 @@ export interface DirectusNewsLinkItem {
     link: string
     comment: string | null
     open_graph: OpenGraphMetadata | null
-    slug: string
     member: string | DirectusMemberItem | null
     podcast: string | DirectusPodcastItem | null
     podcast_seconds_from: number | null
@@ -360,6 +359,7 @@ export interface DirectusNewsLinkItem {
 export interface DirectusNewsItem {
     id: string
     status: string
+    slug: string | null
     sort: number | null
     date_created: string
     date_updated: string | null


### PR DESCRIPTION
## Why

`news` is a meta collection that surfaces every kind of news source (today `news_links`, later e.g. `news_event`) through an m2a junction. Publication state and the URL slug were living on `news_links`, duplicated with `news`, and the status sync only ran in the publish direction — so un-publishing a news left the source link publicly readable.

This makes **`news` the single owner** of a news item's lifecycle:

- **`news.status`** — the editorial control (the editor works only on `news`).
- **`news.slug`** (unique) — the addressable `/news/<slug>` URL.
- **`news_links.status`** — kept, but demoted to a **system-managed read gate** (the public role filters on it) that's mirrored from `news.status`, never edited by hand. Contributors (podcast hosts/guests) author link content only.

Why keep `status` on `news_links` at all? The site reads as the anonymous Directus role, so the public read-permission filter (`status = published`) is load-bearing, and an m2a target can't be gated by the parent's status through the polymorphic junction. So the flag stays — as denormalized visibility metadata a hook maintains.

## Data model (already applied in Directus; reflected in `schema.json`)

- `news.slug` added (unique) · `news_links.slug` removed
- `news.published_on` added → `news` is now picked up by the generic `schedule-publication` / `set-published-on` hooks automatically
- `news_links.status` retained (system-managed)

## Changes

**`create-news` → full `news`↔`news_links` sync hub**
- `news_links` create → `news` mirror always `draft` (no contributor self-publish) + a filter forcing `status: draft`
- `news.slug` derived from the link title, deduped against the unique constraint, and re-synced when the **title changes**
- `news.status` change → mirrored to `news_links.status` on **every** transition (publish *and* un-publish/archive) — closes the visibility leak
- filter blocks publishing a `news` whose source link is incomplete (`isPublishable`, fails open on infra errors)
- `news` delete → **archive** the link (kept for podcast production) + drop the dangling junction row, via a pre-delete filter (runs while `news_id` is still intact)

**`cascade-publish`** — news relations removed (superseded by the mirror, which also handles un-publish). The now-unused m2a support + tests stripped; back to podcasts/meetups → speakers/talks/picks.

**`set-slug`** — `news_links` branch removed (slug no longer lives there).

**`schedule-publication`** — a per-item publish that a downstream hook rejects now **de-schedules** (nulls `published_on`) + Slacks instead of failing the whole cron run; without the null-out it would retry every minute. New test coverage added.

**Nuxt** — `getPublishedNewsBySlug` simplified to a top-level `{ status, slug }` filter on `news` (drops the m2a nested filter and the `target:news_links` hack); `slug` moved from `DirectusNewsLinkItem` → `DirectusNewsItem`.

## Verification

- CMS: `directus-extension build` ✔, **155 tests pass** (12 suites), eslint clean
- Nuxt: eslint clean; typecheck shows only pre-existing errors (confirmed against baseline — no regressions)
- Validated against production Directus that the public role can filter `news` by the new top-level `slug`

## Deploy notes

1. This bundle must be deployed and a news item (re-)published so the mirror backfills `news.slug` and flips `news_links.status`. Until then, published `news` return empty `target` to the public role (their links are still `draft`).
2. Confirm the public role has read on **`news_target`** and **`news_links`** (the latter filtered to `status = published`) — the m2a expansion depends on it.
3. The publish-completeness guard surfaces incomplete links only via **Slack** (the item de-schedules to `published_on: null`), so that channel needs watching.

## Out of scope

Slug redirect history (keep superseded slugs and 301 old `/news/<slug>` URLs) — natural future extension of `handleLinkUpdate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhYz1Q9326BJRpp1zHitGh