### PR TITLE
Post published news to Discord via webhook

### DIFF
--- a/directus-cms/.env.example
+++ b/directus-cms/.env.example
@@ -187,6 +187,13 @@ INSTAGRAM_BUSINESS_ACCOUNT_ID=""
 FACEBOOK_ACCESS_TOKEN=""
 
 ####################################################################################################
+## Discord
+## Incoming webhook that published news items are posted to.
+## Create via: Discord channel > Edit Channel > Integrations > Webhooks > New Webhook > Copy URL
+
+DISCORD_WEBHOOK_URL=""
+
+####################################################################################################
 ## Production API Token (for local setup)
 ## Imports admin-only collections: email templates, AI prompts, asset templates, automation settings.
 ## Generate a read-only static token in production Directus: Settings > Access Tokens

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/package.json
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/package.json
@@ -131,6 +131,11 @@
             },
             {
                 "type": "hook",
+                "name": "post-to-discord",
+                "source": "src/post-to-discord/index.ts"
+            },
+            {
+                "type": "hook",
                 "name": "fetch-open-graph",
                 "source": "src/fetch-open-graph/index.ts"
             },

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/post-to-discord/__tests__/discord.test.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/post-to-discord/__tests__/discord.test.ts
@@ -194,6 +194,10 @@ describe('htmlToDiscordText', () => {
         expect(htmlToDiscordText('<p>M&#228;dchen f&#xFC;r</p>')).toBe('Mädchen für')
     })
 
+    test('leaves an out-of-range numeric entity untouched instead of throwing', () => {
+        expect(htmlToDiscordText('<p>&#9999999999;</p>')).toBe('&#9999999999;')
+    })
+
     test('does not double-decode a literal escaped entity', () => {
         expect(htmlToDiscordText('<p>&amp;auml;</p>')).toBe('&auml;')
     })

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/post-to-discord/__tests__/discord.test.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/post-to-discord/__tests__/discord.test.ts
@@ -100,7 +100,7 @@ describe('buildNewsEmbed', () => {
             memberName: 'Jane Doe',
         })
 
-        expect(payload.embeds[0].description).toBe('Great read\n\n*Meinung von Jane Doe*')
+        expect(payload.embeds[0].description).toBe('Great read\n\n_Meinung von Jane Doe_')
     })
 
     test('shows the attribution even when there is no comment', () => {
@@ -111,7 +111,7 @@ describe('buildNewsEmbed', () => {
             memberName: 'Jane Doe',
         })
 
-        expect(payload.embeds[0].description).toBe('*Meinung von Jane Doe*')
+        expect(payload.embeds[0].description).toBe('_Meinung von Jane Doe_')
     })
 
     test('ignores a blank member name', () => {

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/post-to-discord/__tests__/discord.test.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/post-to-discord/__tests__/discord.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, test } from '@jest/globals'
+import { buildNewsEmbed, htmlToDiscordText } from '../discord.ts'
+
+describe('buildNewsEmbed', () => {
+    test('links to the website news page when a slug is present', () => {
+        const payload = buildNewsEmbed({
+            title: 'A great article',
+            comment: '<p>Worth a read</p>',
+            link: 'https://example.com/article',
+            slug: 'a-great-article',
+            websiteUrl: 'https://www.programmier.bar',
+        })
+
+        expect(payload.embeds[0].url).toBe('https://www.programmier.bar/news/a-great-article')
+        expect(payload.embeds[0].title).toBe('A great article')
+        expect(payload.embeds[0].description).toBe('Worth a read')
+    })
+
+    test('uses the brand color for the embed', () => {
+        const payload = buildNewsEmbed({
+            title: 'T',
+            slug: 's',
+            websiteUrl: 'https://www.programmier.bar',
+        })
+
+        expect(payload.embeds[0].color).toBe(0xcfff00)
+    })
+
+    test('strips a trailing slash from the website URL', () => {
+        const payload = buildNewsEmbed({
+            title: 'T',
+            slug: 's',
+            websiteUrl: 'https://www.programmier.bar/',
+        })
+
+        expect(payload.embeds[0].url).toBe('https://www.programmier.bar/news/s')
+    })
+
+    test('falls back to the external link when there is no slug', () => {
+        const payload = buildNewsEmbed({
+            title: 'T',
+            link: 'https://example.com/article',
+            slug: null,
+            websiteUrl: 'https://www.programmier.bar',
+        })
+
+        expect(payload.embeds[0].url).toBe('https://example.com/article')
+    })
+
+    test('throws when neither a slug nor an external link is available', () => {
+        expect(() =>
+            buildNewsEmbed({
+                title: 'T',
+                slug: null,
+                link: null,
+                websiteUrl: 'https://www.programmier.bar',
+            })
+        ).toThrow(/neither a news slug nor an external link/)
+    })
+
+    test('omits the description when there is no comment', () => {
+        const payload = buildNewsEmbed({
+            title: 'T',
+            comment: null,
+            slug: 's',
+            websiteUrl: 'https://www.programmier.bar',
+        })
+
+        expect(payload.embeds[0].description).toBeUndefined()
+    })
+
+    test('omits the description when the comment is only empty HTML', () => {
+        const payload = buildNewsEmbed({
+            title: 'T',
+            comment: '<p></p>',
+            slug: 's',
+            websiteUrl: 'https://www.programmier.bar',
+        })
+
+        expect(payload.embeds[0].description).toBeUndefined()
+    })
+
+    test('converts rich-text HTML in the comment to Discord markdown', () => {
+        const payload = buildNewsEmbed({
+            title: 'T',
+            comment: '<p>Read <a href="https://example.com">this</a> now</p>',
+            slug: 's',
+            websiteUrl: 'https://www.programmier.bar',
+        })
+
+        expect(payload.embeds[0].description).toBe('Read [this](https://example.com) now')
+    })
+
+    test('appends the member attribution after the comment', () => {
+        const payload = buildNewsEmbed({
+            title: 'T',
+            comment: '<p>Great read</p>',
+            slug: 's',
+            websiteUrl: 'https://www.programmier.bar',
+            memberName: 'Jane Doe',
+        })
+
+        expect(payload.embeds[0].description).toBe('Great read\n\n*Meinung von Jane Doe*')
+    })
+
+    test('shows the attribution even when there is no comment', () => {
+        const payload = buildNewsEmbed({
+            title: 'T',
+            slug: 's',
+            websiteUrl: 'https://www.programmier.bar',
+            memberName: 'Jane Doe',
+        })
+
+        expect(payload.embeds[0].description).toBe('*Meinung von Jane Doe*')
+    })
+
+    test('ignores a blank member name', () => {
+        const payload = buildNewsEmbed({
+            title: 'T',
+            comment: '<p>Great read</p>',
+            slug: 's',
+            websiteUrl: 'https://www.programmier.bar',
+            memberName: '   ',
+        })
+
+        expect(payload.embeds[0].description).toBe('Great read')
+    })
+
+    test('adds an image from Open Graph metadata when present', () => {
+        const payload = buildNewsEmbed({
+            title: 'T',
+            slug: 's',
+            websiteUrl: 'https://www.programmier.bar',
+            openGraph: { image: 'https://example.com/og.png' },
+        })
+
+        expect(payload.embeds[0].image).toEqual({ url: 'https://example.com/og.png' })
+    })
+
+    test('truncates an overly long title to the Discord limit', () => {
+        const payload = buildNewsEmbed({
+            title: 'x'.repeat(300),
+            slug: 's',
+            websiteUrl: 'https://www.programmier.bar',
+        })
+
+        expect(payload.embeds[0].title).toHaveLength(256)
+        expect(payload.embeds[0].title.endsWith('…')).toBe(true)
+    })
+})
+
+describe('htmlToDiscordText', () => {
+    test('returns an empty string for empty input', () => {
+        expect(htmlToDiscordText('')).toBe('')
+    })
+
+    test('strips plain formatting tags', () => {
+        expect(htmlToDiscordText('<p>Hello <strong>world</strong></p>')).toBe('Hello world')
+    })
+
+    test('converts anchors to masked markdown links', () => {
+        expect(htmlToDiscordText('See <a href="https://example.com">the docs</a>')).toBe(
+            'See [the docs](https://example.com)'
+        )
+    })
+
+    test('falls back to the bare URL for an empty-text link', () => {
+        expect(htmlToDiscordText('<a href="https://example.com"></a>')).toBe('https://example.com')
+    })
+
+    test('turns list items into bullet lines', () => {
+        expect(htmlToDiscordText('<ul><li>one</li><li>two</li></ul>')).toBe('- one\n- two')
+    })
+
+    test('separates paragraphs with a blank line', () => {
+        expect(htmlToDiscordText('<p>a</p><p>b</p>')).toBe('a\n\nb')
+    })
+
+    test('turns <br> into a single newline', () => {
+        expect(htmlToDiscordText('line<br>break')).toBe('line\nbreak')
+    })
+
+    test('decodes HTML entities', () => {
+        expect(htmlToDiscordText('<p>Tom &amp; Jerry &lt;3 &nbsp;code</p>')).toBe('Tom & Jerry <3 code')
+    })
+
+    test('decodes named German umlaut entities case-sensitively', () => {
+        expect(htmlToDiscordText('<p>&Uuml;ber Stra&szlig;e f&uuml;r M&auml;dchen &Ouml;l</p>')).toBe(
+            'Über Straße für Mädchen Öl'
+        )
+    })
+
+    test('decodes decimal and hex numeric entities', () => {
+        expect(htmlToDiscordText('<p>M&#228;dchen f&#xFC;r</p>')).toBe('Mädchen für')
+    })
+
+    test('does not double-decode a literal escaped entity', () => {
+        expect(htmlToDiscordText('<p>&amp;auml;</p>')).toBe('&auml;')
+    })
+
+    test('leaves unknown named entities untouched', () => {
+        expect(htmlToDiscordText('<p>&unknownentity;</p>')).toBe('&unknownentity;')
+    })
+})

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/post-to-discord/discord.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/post-to-discord/discord.ts
@@ -1,0 +1,222 @@
+import axios from 'axios'
+
+/** programmier.bar brand color (#CFFF00) used as the embed's accent stripe. */
+const EMBED_COLOR = 0xcfff00
+
+// Discord embed limits (https://discord.com/developers/docs/resources/message#embed-object-embed-limits).
+const MAX_TITLE_LENGTH = 256
+const MAX_DESCRIPTION_LENGTH = 4096
+
+type LoggerFunction = (message: string) => void
+
+interface DiscordEmbedImage {
+    url: string
+}
+
+interface DiscordEmbed {
+    title: string
+    url: string
+    description?: string
+    color: number
+    image?: DiscordEmbedImage
+    footer: { text: string }
+}
+
+interface DiscordWebhookPayload {
+    content?: string
+    embeds: DiscordEmbed[]
+}
+
+export interface NewsEmbedInput {
+    /** The source link title — becomes the embed title. */
+    title: string
+    /** The editor's comment on the link — becomes the embed description. */
+    comment?: string | null
+    /** The external URL the news link points at. */
+    link?: string | null
+    /** The `news` slug, used to build the website news page URL. */
+    slug?: string | null
+    /** Base website URL (no trailing slash required). */
+    websiteUrl: string
+    /** Open Graph metadata of the source link, used for the embed image. */
+    openGraph?: { image?: string } | null
+    /** Full name of the member who contributed the link, if any. */
+    memberName?: string | null
+}
+
+/**
+ * Named HTML entities the rich-text editor emits. German umlauts are
+ * case-sensitive (`&auml;` = ä, `&Auml;` = Ä), so both cases are listed
+ * explicitly rather than folded.
+ */
+const NAMED_ENTITIES: Record<string, string> = {
+    amp: '&',
+    lt: '<',
+    gt: '>',
+    quot: '"',
+    apos: "'",
+    nbsp: ' ',
+    auml: 'ä',
+    ouml: 'ö',
+    uuml: 'ü',
+    Auml: 'Ä',
+    Ouml: 'Ö',
+    Uuml: 'Ü',
+    szlig: 'ß',
+    euro: '€',
+    hellip: '…',
+    ndash: '–',
+    mdash: '—',
+    bdquo: '„',
+    ldquo: '“',
+    rdquo: '”',
+    sbquo: '‚',
+    lsquo: '‘',
+    rsquo: '’',
+}
+
+/**
+ * Decode the HTML entities the rich-text editor emits — named (incl. German
+ * umlauts), decimal (`&#228;`) and hex (`&#xE4;`). Runs as a single left-to-right
+ * pass so a literal `&amp;lt;` decodes to the text `&lt;` rather than `<`.
+ */
+function decodeEntities(value: string): string {
+    return value.replace(/&(#x[0-9a-fA-F]+|#\d+|[a-zA-Z][a-zA-Z0-9]*);/g, (match, entity: string) => {
+        if (entity[0] === '#') {
+            const code =
+                entity[1] === 'x' || entity[1] === 'X'
+                    ? Number.parseInt(entity.slice(2), 16)
+                    : Number.parseInt(entity.slice(1), 10)
+            return Number.isFinite(code) ? String.fromCodePoint(code) : match
+        }
+        // Unknown named entities are left untouched rather than dropped.
+        return Object.prototype.hasOwnProperty.call(NAMED_ENTITIES, entity) ? NAMED_ENTITIES[entity] : match
+    })
+}
+
+/** Strip every remaining HTML tag from a string. */
+function stripTags(value: string): string {
+    return value.replace(/<[^>]+>/g, '')
+}
+
+/**
+ * Convert the rich-text HTML from `news_links.comment` into the Markdown that
+ * Discord embed descriptions render. Discord does NOT render HTML, so raw tags
+ * would otherwise show up as literal text.
+ *
+ * Links become masked Markdown links (`[text](url)`), list items become bullet
+ * lines, and block-level tags become newlines; every other tag is dropped.
+ */
+export function htmlToDiscordText(html: string): string {
+    if (!html) {
+        return ''
+    }
+
+    const withMarkdown = html
+        // <a href="url">text</a> → [text](url); fall back to the bare URL when
+        // the link has no visible text.
+        .replace(/<a\b[^>]*\bhref=["']([^"']*)["'][^>]*>([\s\S]*?)<\/a>/gi, (_match, href, label) => {
+            const text = stripTags(label).trim()
+            return text ? `[${text}](${href})` : href
+        })
+        // `<li>` opens its own bullet line; its closing tag is dropped below so
+        // it does not add a second break between items.
+        .replace(/<li\b[^>]*>/gi, '\n- ')
+        .replace(/<br\s*\/?>/gi, '\n')
+        // Block-level closings become a blank line so paragraphs stay separated.
+        .replace(/<\/(p|div|ul|ol|h[1-6]|blockquote)>/gi, '\n\n')
+
+    const text = decodeEntities(stripTags(withMarkdown))
+
+    return text
+        .split('\n')
+        .map((line) => line.replace(/[ \t]+/g, ' ').trim())
+        .join('\n')
+        .replace(/\n{3,}/g, '\n\n')
+        .trim()
+}
+
+/** Trim a string to `max` characters, appending an ellipsis when it overflows. */
+function truncate(value: string, max: number): string {
+    if (value.length <= max) {
+        return value
+    }
+    return `${value.slice(0, max - 1)}…`
+}
+
+/**
+ * Build the Discord webhook payload for a freshly published news item.
+ *
+ * The embed links to the programmier.bar news page (`/news/<slug>`) when a slug
+ * is available; if it is missing (e.g. an item published before the slug was
+ * derived) it falls back to the external source link so the message is never a
+ * dead link.
+ */
+export function buildNewsEmbed({
+    title,
+    comment,
+    link,
+    slug,
+    websiteUrl,
+    openGraph,
+    memberName,
+}: NewsEmbedInput): DiscordWebhookPayload {
+    const base = websiteUrl.replace(/\/+$/, '')
+    const targetUrl = slug ? `${base}/news/${slug}` : link
+
+    if (!targetUrl) {
+        throw new Error('Cannot build Discord embed: neither a news slug nor an external link is available')
+    }
+
+    const embed: DiscordEmbed = {
+        title: truncate(title, MAX_TITLE_LENGTH),
+        url: targetUrl,
+        color: EMBED_COLOR,
+        footer: { text: 'programmier.bar News' },
+    }
+
+    // Attribution line ("Meinung von …") after the comment, separated by a blank
+    // line so it reads as its own note.
+    const attribution = memberName?.trim() ? `_Meinung von ${memberName.trim()}_` : ''
+    const description = [comment ? htmlToDiscordText(comment) : '', attribution].filter(Boolean).join('\n\n')
+    if (description) {
+        embed.description = truncate(description, MAX_DESCRIPTION_LENGTH)
+    }
+
+    if (openGraph?.image) {
+        embed.image = { url: openGraph.image }
+    }
+
+    return {
+        content: '📰 Neuer News-Beitrag',
+        embeds: [embed],
+    }
+}
+
+/**
+ * Post a payload to a Discord channel via an incoming webhook.
+ *
+ * @param webhookUrl The Discord webhook URL.
+ * @param payload The webhook payload (content and/or embeds).
+ * @param options Logger for context.
+ */
+export async function postToDiscord(
+    webhookUrl: string,
+    payload: DiscordWebhookPayload,
+    { logger }: { logger: { info: LoggerFunction; error: LoggerFunction } }
+): Promise<void> {
+    try {
+        await axios({
+            method: 'POST',
+            url: webhookUrl,
+            headers: { 'Content-Type': 'application/json' },
+            data: payload,
+        })
+    } catch (error: any) {
+        // Surface Discord's response body (rate limits, validation errors) so the
+        // failure is actionable rather than a bare "Request failed".
+        const detail = error?.response?.data ? JSON.stringify(error.response.data) : error?.message
+        logger.error(`Discord webhook request failed: ${detail}`)
+        throw new Error(`Discord: ${detail}`)
+    }
+}

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/post-to-discord/discord.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/post-to-discord/discord.ts
@@ -93,6 +93,7 @@ function decodeEntities(value: string): string {
             }
 
             return match
+        }
         // Unknown named entities are left untouched rather than dropped.
         return Object.prototype.hasOwnProperty.call(NAMED_ENTITIES, entity) ? NAMED_ENTITIES[entity] : match
     })

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/post-to-discord/discord.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/post-to-discord/discord.ts
@@ -210,7 +210,7 @@ export async function postToDiscord(
             method: 'POST',
             url: webhookUrl,
             headers: { 'Content-Type': 'application/json' },
-            data: payload,
+            data: { ...payload, allowed_mentions: { parse: [] } },
         })
     } catch (error: any) {
         // Surface Discord's response body (rate limits, validation errors) so the

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/post-to-discord/discord.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/post-to-discord/discord.ts
@@ -87,8 +87,12 @@ function decodeEntities(value: string): string {
                 entity[1] === 'x' || entity[1] === 'X'
                     ? Number.parseInt(entity.slice(2), 16)
                     : Number.parseInt(entity.slice(1), 10)
-            return Number.isFinite(code) ? String.fromCodePoint(code) : match
-        }
+
+            if (Number.isFinite(code) && code >= 0 && code <= 0x10ffff) {
+                return String.fromCodePoint(code)
+            }
+
+            return match
         // Unknown named entities are left untouched rather than dropped.
         return Object.prototype.hasOwnProperty.call(NAMED_ENTITIES, entity) ? NAMED_ENTITIES[entity] : match
     })

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/post-to-discord/discord.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/post-to-discord/discord.ts
@@ -214,6 +214,7 @@ export async function postToDiscord(
         await axios({
             method: 'POST',
             url: webhookUrl,
+            timeout: 10_000,
             headers: { 'Content-Type': 'application/json' },
             data: { ...payload, allowed_mentions: { parse: [] } },
         })

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/post-to-discord/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/post-to-discord/index.ts
@@ -1,0 +1,135 @@
+import { defineHook } from '@directus/extensions-sdk'
+import {
+    extractKeys,
+    JUNCTION_COLLECTION,
+    NEWS_COLLECTION,
+    readJunctionRowsByNewsId,
+    SOURCE_COLLECTION,
+} from '../create-news/util/newsTarget.ts'
+import { getSetting } from '../shared/email-service.js'
+import { postSlackMessage } from '../shared/postSlackMessage.ts'
+import { safeAction } from '../shared/safeHook.ts'
+import { buildNewsEmbed, postToDiscord } from './discord.ts'
+
+const HOOK_NAME = 'post-to-discord'
+
+/** Fallback website URL when the `website_url` setting is not configured. */
+const DEFAULT_WEBSITE_URL = 'https://www.programmier.bar'
+
+/**
+ * Posts a `news` item to Discord (via an incoming webhook) when it is published.
+ *
+ * The `news` collection is the editorial control: an editor publishes by setting
+ * `news.status` to `published` (see the `create-news` hook, which owns the rest
+ * of the news ↔ news_links lifecycle). The actual content — title, external
+ * link, comment, Open Graph image — lives on the source `news_links` item, so we
+ * resolve it through the `news_target` m2a junction before building the message.
+ *
+ * De-duplication: we post only when an update payload explicitly sets `status`
+ * to `published`, i.e. on the publish transition. Directus update payloads carry
+ * only changed fields, so a later re-save of an already-published item omits
+ * `status` and does not re-post. (Unpublishing and re-publishing WILL post again
+ * — an accepted trade-off of the field-less guard.)
+ */
+export default defineHook(({ action }, hookContext) => {
+    const logger = hookContext.logger
+    const env = hookContext.env
+    const ItemsService = hookContext.services.ItemsService
+    const getSchema = hookContext.getSchema
+
+    const webhookUrl = env.DISCORD_WEBHOOK_URL
+
+    if (!webhookUrl) {
+        logger.warn(`${HOOK_NAME} hook: DISCORD_WEBHOOK_URL is not set. Discord posting will not be active.`)
+        return
+    }
+
+    action(
+        `${NEWS_COLLECTION}.items.update`,
+        safeAction(HOOK_NAME, logger, (metadata, eventContext) => handleNewsPublish(metadata, eventContext))
+    )
+
+    async function handleNewsPublish(metadata: Record<string, any>, eventContext: Record<string, any>) {
+        // Only react to the publish transition (see de-duplication note above).
+        if (metadata.payload?.status !== 'published') {
+            return
+        }
+
+        const keys = extractKeys(metadata)
+        if (keys.length === 0) {
+            return
+        }
+
+        const schema = await getSchema()
+        const newsService = new ItemsService(NEWS_COLLECTION, { schema, accountability: eventContext.accountability })
+        const junctionService = new ItemsService(JUNCTION_COLLECTION, {
+            schema,
+            accountability: eventContext.accountability,
+        })
+        const sourceService = new ItemsService(SOURCE_COLLECTION, {
+            schema,
+            accountability: eventContext.accountability,
+        })
+
+        const websiteUrl = (await getSetting('website_url', hookContext)) || DEFAULT_WEBSITE_URL
+
+        // Per-item try/catch so that, in a batch publish, one failure neither
+        // aborts the rest nor blocks the publish itself — the item is already
+        // published; a missed Discord post is recoverable via the Slack alert.
+        for (const newsId of keys) {
+            try {
+                const news = await newsService.readOne(newsId, { fields: ['slug'] })
+
+                const rows = await readJunctionRowsByNewsId(junctionService, newsId, ['target'])
+                const linkIds = rows.map((row: any) => row.target).filter(Boolean)
+                if (linkIds.length === 0) {
+                    logger.warn(`${HOOK_NAME}: News ${newsId} has no source link, skipping Discord post`)
+                    continue
+                }
+
+                const links = await sourceService.readByQuery({
+                    filter: { id: { _in: linkIds } },
+                    fields: ['id', 'title', 'link', 'comment', 'open_graph', 'member.first_name', 'member.last_name'],
+                    limit: 1,
+                })
+                const link = links[0]
+                if (!link) {
+                    logger.warn(`${HOOK_NAME}: Source link for news ${newsId} not found, skipping Discord post`)
+                    continue
+                }
+
+                const memberName = [link.member?.first_name, link.member?.last_name].filter(Boolean).join(' ')
+
+                const payload = buildNewsEmbed({
+                    title: link.title,
+                    comment: link.comment,
+                    link: link.link,
+                    slug: news?.slug,
+                    websiteUrl,
+                    openGraph: link.open_graph,
+                    memberName,
+                })
+
+                await postToDiscord(webhookUrl, payload, { logger })
+                logger.info(`${HOOK_NAME}: Posted news ${newsId} to Discord`)
+            } catch (error: any) {
+                logger.error(`${HOOK_NAME}: Failed to post news ${newsId} to Discord: ${error.message}`)
+                await notifySlack(
+                    `:warning: *${HOOK_NAME}*: Der veröffentlichte News-Eintrag ${newsId} konnte nicht auf Discord gepostet werden. Bitte manuell prüfen.\n` +
+                        `Fehler: ${error.message}\n` +
+                        `${env.PUBLIC_URL}admin/content/${NEWS_COLLECTION}/${newsId}`
+                )
+            }
+        }
+    }
+
+    async function notifySlack(message: string) {
+        try {
+            await postSlackMessage(message)
+        } catch (slackError: any) {
+            logger.error(`${HOOK_NAME}: Failed to send Slack notification: ${slackError.message}`)
+        }
+    }
+
+    logger.info(`${HOOK_NAME} hook registered`)
+})

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/post-to-discord/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/post-to-discord/index.ts
@@ -6,7 +6,7 @@ import {
     readJunctionRowsByNewsId,
     SOURCE_COLLECTION,
 } from '../create-news/util/newsTarget.ts'
-import { getRequiredSetting } from '../shared/email-service.js'
+import { getRequiredSetting } from '../shared/settings.js'
 import { postSlackMessage } from '../shared/postSlackMessage.ts'
 import { safeAction } from '../shared/safeHook.ts'
 import { buildNewsEmbed, postToDiscord } from './discord.ts'

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/post-to-discord/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/post-to-discord/index.ts
@@ -6,15 +6,12 @@ import {
     readJunctionRowsByNewsId,
     SOURCE_COLLECTION,
 } from '../create-news/util/newsTarget.ts'
-import { getSetting } from '../shared/email-service.js'
+import { getRequiredSetting } from '../shared/email-service.js'
 import { postSlackMessage } from '../shared/postSlackMessage.ts'
 import { safeAction } from '../shared/safeHook.ts'
 import { buildNewsEmbed, postToDiscord } from './discord.ts'
 
 const HOOK_NAME = 'post-to-discord'
-
-/** Fallback website URL when the `website_url` setting is not configured. */
-const DEFAULT_WEBSITE_URL = 'https://www.programmier.bar'
 
 /**
  * Posts a `news` item to Discord (via an incoming webhook) when it is published.
@@ -71,13 +68,16 @@ export default defineHook(({ action }, hookContext) => {
             accountability: eventContext.accountability,
         })
 
-        const websiteUrl = (await getSetting('website_url', hookContext)) || DEFAULT_WEBSITE_URL
-
         // Per-item try/catch so that, in a batch publish, one failure neither
         // aborts the rest nor blocks the publish itself — the item is already
         // published; a missed Discord post is recoverable via the Slack alert.
         for (const newsId of keys) {
             try {
+                // Fail closed rather than defaulting to a production URL: a wrong
+                // public Discord link is hard to retract, so if `website_url` is
+                // not configured we skip the post and alert via Slack (below).
+                const websiteUrl = await getRequiredSetting('website_url', hookContext)
+
                 const news = await newsService.readOne(newsId, { fields: ['slug'] })
 
                 const rows = await readJunctionRowsByNewsId(junctionService, newsId, ['target'])

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/__tests__/getRequiredSetting.test.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/__tests__/getRequiredSetting.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, jest, test } from '@jest/globals'
+import { getRequiredSetting } from '../email-service.ts'
+
+/**
+ * Build a minimal EmailServiceContext whose `automation_settings` service
+ * returns the given rows from readByQuery.
+ */
+function buildContext(rows: Array<{ value: any }>) {
+    class ItemsService {
+        async readByQuery() {
+            return rows
+        }
+    }
+
+    return {
+        logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn() },
+        services: { ItemsService, MailService: class {} },
+        getSchema: async () => ({}),
+    } as any
+}
+
+describe('getRequiredSetting', () => {
+    test('returns the value when the setting is present', async () => {
+        await expect(getRequiredSetting('website_url', buildContext([{ value: 'https://staging.example' }]))).resolves.toBe(
+            'https://staging.example'
+        )
+    })
+
+    test('throws when the setting is missing', async () => {
+        await expect(getRequiredSetting('website_url', buildContext([]))).rejects.toThrow(
+            "Required setting 'website_url' is not configured"
+        )
+    })
+
+    test('throws when the setting is blank', async () => {
+        await expect(getRequiredSetting('website_url', buildContext([{ value: '   ' }]))).rejects.toThrow(
+            "Required setting 'website_url' is not configured"
+        )
+    })
+})

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/__tests__/settings.test.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/__tests__/settings.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, jest, test } from '@jest/globals'
-import { getRequiredSetting } from '../email-service.ts'
+import { getRequiredSetting } from '../settings.ts'
 
 /**
- * Build a minimal EmailServiceContext whose `automation_settings` service
+ * Build a minimal SettingsContext whose `automation_settings` service
  * returns the given rows from readByQuery.
  */
 function buildContext(rows: Array<{ value: any }>) {
@@ -13,8 +13,8 @@ function buildContext(rows: Array<{ value: any }>) {
     }
 
     return {
-        logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn() },
-        services: { ItemsService, MailService: class {} },
+        logger: { warn: jest.fn() },
+        services: { ItemsService },
         getSchema: async () => ({}),
     } as any
 }

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/email-service.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/email-service.ts
@@ -106,6 +106,21 @@ export async function getSetting(
 }
 
 /**
+ * Like {@link getSetting}, but throws when the setting is missing or blank.
+ *
+ * Use this for configuration the extension cannot sensibly default (per
+ * AGENTS.md: no fallback values for critical config — fail explicitly rather
+ * than silently substituting a value that may be wrong for the environment).
+ */
+export async function getRequiredSetting(key: string, context: EmailServiceContext): Promise<string> {
+    const value = await getSetting(key, context)
+    if (!value || !value.trim()) {
+        throw new Error(`Required setting '${key}' is not configured`)
+    }
+    return value
+}
+
+/**
  * Get multiple settings as an object.
  */
 export async function getSettings(

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/email-service.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/email-service.ts
@@ -5,7 +5,8 @@
  * - Template rendering using Handlebars syntax
  * - Email sending via Directus MailService
  * - Reading templates from the email_templates collection
- * - Reading settings from the automation_settings collection
+ *
+ * Reading values from the automation_settings collection lives in `settings.ts`.
  */
 
 import type { Logger } from 'pino'
@@ -69,89 +70,6 @@ export interface SendEmailOptions {
     replyTo?: string
     cc?: string
     attachments?: EmailAttachment[]
-}
-
-/**
- * Get a setting value from the automation_settings collection.
- */
-export async function getSetting(
-    key: string,
-    context: EmailServiceContext
-): Promise<string | null> {
-    const { services, getSchema, logger } = context
-    const { ItemsService } = services
-
-    try {
-        const schema = await getSchema()
-        const settingsService = new ItemsService('automation_settings', {
-            schema,
-            accountability: { admin: true },
-        })
-
-        const settings = await settingsService.readByQuery({
-            filter: { key: { _eq: key } },
-            fields: ['value'],
-            limit: 1,
-        })
-
-        if (settings && settings.length > 0) {
-            return settings[0].value
-        }
-
-        return null
-    } catch (err: any) {
-        logger.warn(`Failed to read setting '${key}': ${err?.message || err}`)
-        return null
-    }
-}
-
-/**
- * Like {@link getSetting}, but throws when the setting is missing or blank.
- *
- * Use this for configuration the extension cannot sensibly default (per
- * AGENTS.md: no fallback values for critical config — fail explicitly rather
- * than silently substituting a value that may be wrong for the environment).
- */
-export async function getRequiredSetting(key: string, context: EmailServiceContext): Promise<string> {
-    const value = await getSetting(key, context)
-    if (!value || !value.trim()) {
-        throw new Error(`Required setting '${key}' is not configured`)
-    }
-    return value
-}
-
-/**
- * Get multiple settings as an object.
- */
-export async function getSettings(
-    keys: string[],
-    context: EmailServiceContext
-): Promise<Record<string, string>> {
-    const { services, getSchema, logger } = context
-    const { ItemsService } = services
-
-    const result: Record<string, string> = {}
-
-    try {
-        const schema = await getSchema()
-        const settingsService = new ItemsService('automation_settings', {
-            schema,
-            accountability: { admin: true },
-        })
-
-        const settings = await settingsService.readByQuery({
-            filter: { key: { _in: keys } },
-            fields: ['key', 'value'],
-        })
-
-        for (const setting of settings) {
-            result[setting.key] = setting.value
-        }
-    } catch (err: any) {
-        logger.warn(`Failed to read settings: ${err?.message || err}`)
-    }
-
-    return result
 }
 
 /**

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/settings.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/shared/settings.ts
@@ -1,0 +1,97 @@
+/**
+ * Shared helpers for reading values from the `automation_settings` collection.
+ *
+ * Kept separate from any one feature (email, Discord, wallet passes, …) so every
+ * extension reads runtime configuration through the same, single path.
+ */
+
+/**
+ * The slice of a Directus hook/endpoint context these helpers need. Any full
+ * hook context or `EmailServiceContext` satisfies it structurally.
+ */
+export interface SettingsContext {
+    logger: { warn: (message: string) => void }
+    services: {
+        ItemsService: any
+    }
+    getSchema: () => Promise<any>
+}
+
+/**
+ * Get a setting value from the automation_settings collection. Returns `null`
+ * when the key is absent or the read fails (the failure is logged).
+ */
+export async function getSetting(key: string, context: SettingsContext): Promise<string | null> {
+    const { services, getSchema, logger } = context
+    const { ItemsService } = services
+
+    try {
+        const schema = await getSchema()
+        const settingsService = new ItemsService('automation_settings', {
+            schema,
+            accountability: { admin: true },
+        })
+
+        const settings = await settingsService.readByQuery({
+            filter: { key: { _eq: key } },
+            fields: ['value'],
+            limit: 1,
+        })
+
+        if (settings && settings.length > 0) {
+            return settings[0].value
+        }
+
+        return null
+    } catch (err: any) {
+        logger.warn(`Failed to read setting '${key}': ${err?.message || err}`)
+        return null
+    }
+}
+
+/**
+ * Like {@link getSetting}, but throws when the setting is missing or blank.
+ *
+ * Use this for configuration the extension cannot sensibly default (per
+ * AGENTS.md: no fallback values for critical config — fail explicitly rather
+ * than silently substituting a value that may be wrong for the environment).
+ */
+export async function getRequiredSetting(key: string, context: SettingsContext): Promise<string> {
+    const value = await getSetting(key, context)
+    if (!value || !value.trim()) {
+        throw new Error(`Required setting '${key}' is not configured`)
+    }
+    return value
+}
+
+/**
+ * Get multiple settings as an object. Keys that are absent (or, on a read
+ * failure, all keys) are simply omitted from the result.
+ */
+export async function getSettings(keys: string[], context: SettingsContext): Promise<Record<string, string>> {
+    const { services, getSchema, logger } = context
+    const { ItemsService } = services
+
+    const result: Record<string, string> = {}
+
+    try {
+        const schema = await getSchema()
+        const settingsService = new ItemsService('automation_settings', {
+            schema,
+            accountability: { admin: true },
+        })
+
+        const settings = await settingsService.readByQuery({
+            filter: { key: { _in: keys } },
+            fields: ['key', 'value'],
+        })
+
+        for (const setting of settings) {
+            result[setting.key] = setting.value
+        }
+    } catch (err: any) {
+        logger.warn(`Failed to read settings: ${err?.message || err}`)
+    }
+
+    return result
+}

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/speaker-portal-notifications/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/speaker-portal-notifications/index.ts
@@ -1,11 +1,6 @@
 import { defineHook } from '@directus/extensions-sdk'
-import {
-    sendTemplatedEmail,
-    getSetting,
-    getSettings,
-    formatDateGerman,
-    type EmailServiceContext,
-} from '../shared/email-service.js'
+import { sendTemplatedEmail, formatDateGerman, type EmailServiceContext } from '../shared/email-service.js'
+import { getSetting, getSettings } from '../shared/settings.js'
 import { postSlackMessage } from '../shared/postSlackMessage.js'
 import { safeAction } from '../shared/safeHook.ts'
 

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/ticket-order-processing/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/ticket-order-processing/index.ts
@@ -1,7 +1,8 @@
 import { defineHook } from '@directus/extensions-sdk'
 import { randomUUID } from 'node:crypto'
 import { Readable } from 'node:stream'
-import { sendTemplatedEmail, getSetting, type EmailServiceContext } from '../shared/email-service.js'
+import { sendTemplatedEmail, type EmailServiceContext } from '../shared/email-service.js'
+import { getSetting } from '../shared/settings.js'
 import { generateUniqueTicketCode, formatPrice } from '../shared/ticket-utils.js'
 import {
     generateInvoicePdf,

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/ticket-profile-completion/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/ticket-profile-completion/index.ts
@@ -1,5 +1,6 @@
 import { defineHook } from '@directus/extensions-sdk'
-import { sendTemplatedEmail, getSetting, type EmailServiceContext } from '../shared/email-service.js'
+import { sendTemplatedEmail, type EmailServiceContext } from '../shared/email-service.js'
+import { getSetting } from '../shared/settings.js'
 import { generateQRCodeBuffer } from '../shared/ticket-utils.js'
 import {
     generateAppleWalletPass,

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/ticket-wallet/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/ticket-wallet/index.ts
@@ -1,7 +1,7 @@
 /// <reference types="@directus/extensions/api.d.ts" />
 import { defineEndpoint } from '@directus/extensions-sdk'
 import { generateAppleWalletPass, type WalletPassInput } from '../shared/wallet-pass-generator.js'
-import { getSetting } from '../shared/email-service.js'
+import { getRequiredSetting } from '../shared/email-service.js'
 
 import type { SandboxEndpointRouter } from 'directus:api'
 
@@ -84,10 +84,11 @@ export default defineEndpoint(async (router: SandboxEndpointRouter, context) => 
                 getSchema: context.getSchema,
                 accountability: { admin: true },
             }
-            const websiteUrl = await getSetting('website_url', emailServiceContext)
-
-            if (!websiteUrl) {
-                logger.error('ticket-wallet: website_url setting is not configured')
+            let websiteUrl: string
+            try {
+                websiteUrl = await getRequiredSetting('website_url', emailServiceContext)
+            } catch (settingError: any) {
+                logger.error(`ticket-wallet: ${settingError.message}`)
                 res.status(503).send({ error: 'Website URL not configured' })
                 return
             }

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/ticket-wallet/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/ticket-wallet/index.ts
@@ -1,7 +1,7 @@
 /// <reference types="@directus/extensions/api.d.ts" />
 import { defineEndpoint } from '@directus/extensions-sdk'
 import { generateAppleWalletPass, type WalletPassInput } from '../shared/wallet-pass-generator.js'
-import { getRequiredSetting } from '../shared/email-service.js'
+import { getRequiredSetting } from '../shared/settings.js'
 
 import type { SandboxEndpointRouter } from 'directus:api'
 

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/ticket-wallet/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/ticket-wallet/index.ts
@@ -88,7 +88,7 @@ export default defineEndpoint(async (router: SandboxEndpointRouter, context) => 
             try {
                 websiteUrl = await getRequiredSetting('website_url', emailServiceContext)
             } catch (settingError: any) {
-                logger.error(`ticket-wallet: ${settingError.message}`)
+                logger.error(`ticket-wallet: ${settingError?.message ?? String(settingError)}`)
                 res.status(503).send({ error: 'Website URL not configured' })
                 return
             }


### PR DESCRIPTION
## What

Adds a new `post-to-discord` hook to the Directus extension bundle that posts a `news` item to Discord (via an incoming webhook) when it is published.

## How it works

- **Trigger**: listens on `news.items.update` and fires when an update sets `status` to `published` — the editorial publish signal (the `news` collection is the editorial control; `create-news` owns the rest of the news ↔ `news_links` lifecycle).
- **Content**: the news content lives on the source `news_links` item, resolved through the `news_target` m2a junction (reusing the existing `newsTarget` helpers). The Discord message is a rich embed:
  - **Title** — the link title
  - **Description** — the editor's `comment`, converted from rich-text HTML to Discord Markdown (masked links, bullet lists, paragraph breaks) with full HTML-entity decoding (named incl. German umlauts, decimal, hex)
  - **Attribution** — `_Meinung von <Vorname Nachname>_` when the link has a member
  - **Image** — the link's Open Graph image, when present
  - **Link** — the programmier.bar news page (`/news/<slug>`), falling back to the external source link if no slug exists
  - **Accent color** — brand `#CFFF00`

## Resilience (per `directus-conventions.md`)

- Wrapped in `safeAction` so a failure can never crash the CMS.
- Per-item `try/catch` so one failure in a batch publish neither aborts the rest nor blocks the publish itself.
- Failures send a Slack notification (logs alone aren't visible enough).
- Gated on `DISCORD_WEBHOOK_URL`: if unset, the hook logs a warning and stays inactive (same pattern as `social-media-publish` / `deploy-website`).

## De-duplication

Field-less guard: posts only when an update payload explicitly sets `status` to `published`. Directus update payloads carry only changed fields, so re-saving an already-published item omits `status` and does not re-post. Trade-off: an unpublish → re-publish will post again.

## Config

New env var `DISCORD_WEBHOOK_URL` (added to `.env.example`). Set it in production: Discord channel → Edit Channel → Integrations → Webhooks → New Webhook → Copy URL.

## Tests

25 unit tests for the embed builder and HTML→Markdown converter (`npx jest post-to-discord`). Bundle builds and lints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhYz1Q9326BJRpp1zHitGh