### PR TITLE
Return 404 for unknown conference slugs instead of fatal 500

### DIFF
--- a/nuxt-app/composables/useDirectus.ts
+++ b/nuxt-app/composables/useDirectus.ts
@@ -462,7 +462,9 @@ export function useDirectus() {
       .then((result) => {
         const singleResult = result.pop() as unknown as ConferenceItem | undefined
         if (!singleResult) {
-          throw new Error(`Conference with slug "${slug}" not found in Directus.`)
+          // Unknown slug — return null so the caller can render a 404 instead
+          // of treating a missing conference as a fatal fetch failure.
+          return null
         }
         const speakersPrepared = singleResult.speakers.map((speaker: any) => {
               return {

--- a/nuxt-app/pages/konferenz/[slug]/index.vue
+++ b/nuxt-app/pages/konferenz/[slug]/index.vue
@@ -261,15 +261,14 @@ const { data: pageData, error } = await useAsyncData(route.fullPath, async () =>
             directus.getTestimonials(),
         ])
 
-        if (!conference) {
-            throw new Error(`Conference with slug "${slug}" not found in Directus.`)
-        }
-
         if (!conferencePage) {
           throw new Error('Could not load the conference singleton page from Directus.')
         }
 
-        return { conference, conferencePage, testimonials }
+        // A missing conference is a normal 404 (handled below), not a fetch
+        // failure — so don't throw here. Only genuine transport failures or a
+        // missing singleton page should become a fatal 500.
+        return { conference: conference ?? null, conferencePage, testimonials }
     } catch (err) {
         // Surface the underlying error in prerender/runtime logs so transient
         // Directus failures can be told apart from real data issues. The
@@ -279,7 +278,8 @@ const { data: pageData, error } = await useAsyncData(route.fullPath, async () =>
     }
 })
 
-// Re-throw as a fatal error so prerender (with failOnError) aborts the build
+// Genuine fetch failure (Directus unreachable, missing singleton page):
+// re-throw as a fatal error so prerender (with failOnError) aborts the build
 // instead of baking the failure into a cached blank page via ISR.
 if (error.value) {
     throw createError({
@@ -290,8 +290,17 @@ if (error.value) {
     })
 }
 
+// Unknown slug: the conference simply doesn't exist. Return a normal 404
+// instead of crashing the serverless function with a fatal 500.
+if (!pageData.value?.conference) {
+    throw createError({
+        statusCode: 404,
+        statusMessage: `Konferenz "${route.params.slug}" nicht gefunden.`,
+    })
+}
+
 // Extract conference and page from page data
-const conference: ComputedRef<ConferenceItem | undefined> = computed(() => pageData.value?.conference)
+const conference: ComputedRef<ConferenceItem | undefined> = computed(() => pageData.value?.conference ?? undefined)
 const conferencePage: ComputedRef<DirectusConferencePage | undefined> = computed(() => pageData.value?.conferencePage)
 const testimonials: ComputedRef<DirectusTestimonialItem[]> = computed(() => pageData.value?.testimonials || [])
 


### PR DESCRIPTION
## Problem

`https://www.programmier.bar/konferenz/programmier-con-flutter-edition-2024` (and any unknown conference slug) crashes with a Vercel `FUNCTION_INVOCATION_FAILED` / `500 INTERNAL_SERVER_ERROR`.

That slug never existed — the real 2024 event is `flutter-day-2024`; the `programmier-con-…-edition-<year>` naming was only adopted in 2025.

### Root cause

1. `routeRules: { '/**': { isr: 3600 } }` → an unknown slug (not in the prerendered list) is rendered on-demand by an ISR serverless function.
2. `getConferenceBySlug` throws `"not found"` for the empty result.
3. The conference page catches, re-throws, and converts it into `createError({ statusCode: 500, fatal: true })`.
4. The `fatal: true` throw crashes the on-demand render → `FUNCTION_INVOCATION_FAILED`.

The fatal 500 was only intended to abort the **prerender build** (`prerender.failOnError`) on transient Directus failures — not to handle a genuinely missing slug, which should be a plain 404.

## Fix

- `getConferenceBySlug` returns `null` on an empty result instead of throwing, so callers can distinguish "not found" from a real fetch failure.
- The conference page returns a clean **404** for unknown slugs, keeping the fatal 500 only for genuine transport / missing-singleton failures (so prerender still fails closed).

| Situation | Before | After |
|---|---|---|
| Unknown slug | fatal 500 → `FUNCTION_INVOCATION_FAILED` | clean 404 |
| Directus down / missing singleton page | fatal 500 (aborts prerender) | unchanged |

The tickets pages (`tickets/index.vue`, `tickets/success.vue`) already had `if (!conference) throw 404` guards that never fired because of the throw; they now work as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vyut1G3kfBifTGWzxh2fCG