### PR TITLE
Newsletter opt-out: unsubscribe flow + shared token-page components

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,11 @@
 
 This file provides context for AI assistants working with the programmier.bar website codebase.
 
+## Behaviour
+
+Do not automatically commit code changes, unless you were tasked with doing so.
+Do not automatically push code changes, unless you were tasked with doing so.
+
 ## Project Overview
 
 A podcast/conference/meetup platform for the German developer community. Built with Nuxt 3 (Vue 3) frontend and Directus 11 headless CMS.

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/newsletter-double-opt-in/__tests__/index.test.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/newsletter-double-opt-in/__tests__/index.test.ts
@@ -157,6 +157,7 @@ describe('newsletter-double-opt-in hook', () => {
                 email: 'me@example.de',
                 status: 'pending',
                 confirm_token: 'tok-123',
+                unsubscribe_token: 'unsub-456',
             })
 
             await invokeAction(actions.get(CREATE)!, { key: 'sub_1' })
@@ -166,6 +167,10 @@ describe('newsletter-double-opt-in hook', () => {
             expect(options.templateKey).toBe('newsletter_double_opt_in')
             expect(options.to).toBe('me@example.de')
             expect(options.data.confirm_url).toBe('https://www.programmier.bar/newsletter/confirm?token=tok-123')
+            // Permanent token, so the same link stays valid in later issues.
+            expect(options.data.unsubscribe_url).toBe(
+                'https://www.programmier.bar/newsletter/unsubscribe?token=unsub-456'
+            )
             expect(postSlackMessageMock).not.toHaveBeenCalled()
         })
 

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/newsletter-double-opt-in/__tests__/index.test.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/newsletter-double-opt-in/__tests__/index.test.ts
@@ -70,6 +70,12 @@ function setup(subscriber: Record<string, any> | null) {
 const CREATE = 'newsletter_subscribers.items.create'
 const UPDATE = 'newsletter_subscribers.items.update'
 
+// The resend guard compares the window against "now", so these are relative
+// rather than fixed dates — a literal would flip meaning once it passes.
+const HOUR_MS = 60 * 60 * 1000
+const inOneHour = new Date(Date.now() + HOUR_MS).toISOString()
+const anHourAgo = new Date(Date.now() - HOUR_MS).toISOString()
+
 const invokeAction = async (handler: ActionHandler, meta: any) => {
     handler(meta, { accountability: {} })
     await flush()
@@ -265,10 +271,65 @@ describe('newsletter-double-opt-in hook', () => {
 
             await invokeAction(actions.get(UPDATE)!, {
                 keys: ['sub_1'],
-                payload: { confirm_token_expires_at: '2030-01-01T00:00:00.000Z' },
+                payload: { confirm_token_expires_at: inOneHour },
             })
 
             expect(sendTemplatedEmailMock).toHaveBeenCalledTimes(1)
+        })
+
+        // Backdating the window by hand is how a link gets invalidated, not
+        // reissued — a mail sent here would carry an already-expired link.
+        test('does not resend when the window is moved into the past', async () => {
+            const { actions, readOne } = setup({
+                id: 'sub_1',
+                email: 'me@example.de',
+                status: 'pending',
+                confirm_token: 'tok-123',
+            })
+
+            await invokeAction(actions.get(UPDATE)!, {
+                keys: ['sub_1'],
+                payload: { confirm_token_expires_at: anHourAgo },
+            })
+
+            expect(readOne).not.toHaveBeenCalled()
+            expect(sendTemplatedEmailMock).not.toHaveBeenCalled()
+        })
+
+        test('does not resend when a rotation carries an explicitly backdated window', async () => {
+            const { actions, readOne } = setup({
+                id: 'sub_1',
+                email: 'me@example.de',
+                status: 'pending',
+                confirm_token: 'tok-new',
+            })
+
+            // The create/update filters let an explicit expiry win, so a token
+            // rotation can arrive with a dead window attached.
+            await invokeAction(actions.get(UPDATE)!, {
+                keys: ['sub_1'],
+                payload: { confirm_token: 'tok-new', confirm_token_expires_at: anHourAgo },
+            })
+
+            expect(readOne).not.toHaveBeenCalled()
+            expect(sendTemplatedEmailMock).not.toHaveBeenCalled()
+        })
+
+        test('does not resend for an unparseable window', async () => {
+            const { actions, readOne } = setup({
+                id: 'sub_1',
+                email: 'me@example.de',
+                status: 'pending',
+                confirm_token: 'tok-123',
+            })
+
+            await invokeAction(actions.get(UPDATE)!, {
+                keys: ['sub_1'],
+                payload: { confirm_token_expires_at: 'not-a-date' },
+            })
+
+            expect(readOne).not.toHaveBeenCalled()
+            expect(sendTemplatedEmailMock).not.toHaveBeenCalled()
         })
 
         test('does not resend when the update touches neither token nor window', async () => {

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/newsletter-double-opt-in/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/newsletter-double-opt-in/index.ts
@@ -209,8 +209,25 @@ export default defineHook(({ filter, action }, hookContext) => {
         `${COLLECTION}.items.update`,
         safeAction(HOOK_NAME, logger, async (metadata: any, eventContext: any) => {
             const payload = metadata?.payload ?? {}
-            if (payload.confirm_token === undefined && payload.confirm_token_expires_at === undefined) {
+            const changedWindow = payload.confirm_token_expires_at !== undefined
+            if (payload.confirm_token === undefined && !changedWindow) {
                 return
+            }
+
+            // A window supplied by the caller can point into the past:
+            // backdating it is how a link gets *invalidated* by hand, not how
+            // one is reissued, so mailing here would deliver an already-dead
+            // link. A rotation that leaves the expiry to us needs no check —
+            // the update filter above stamps a fresh window.
+            if (changedWindow) {
+                const expiresAt = new Date(payload.confirm_token_expires_at).getTime()
+                if (!Number.isFinite(expiresAt) || expiresAt <= Date.now()) {
+                    logger.info(
+                        `${HOOK_NAME}: confirmation window is not in the future ` +
+                            `(${payload.confirm_token_expires_at}); no mail sent`
+                    )
+                    return
+                }
             }
 
             const keys: Array<string | number> = Array.isArray(metadata?.keys)

--- a/directus-cms/extensions/directus-extension-programmierbar-bundle/src/newsletter-double-opt-in/index.ts
+++ b/directus-cms/extensions/directus-extension-programmierbar-bundle/src/newsletter-double-opt-in/index.ts
@@ -59,7 +59,7 @@ export default defineHook(({ filter, action }, hookContext) => {
         })
 
         const subscriber = await subscribersService.readOne(key, {
-            fields: ['id', 'email', 'status', 'confirm_token'],
+            fields: ['id', 'email', 'status', 'confirm_token', 'unsubscribe_token'],
         })
 
         if (!subscriber) {
@@ -97,11 +97,17 @@ export default defineHook(({ filter, action }, hookContext) => {
 
         const confirmUrl = `${websiteUrl}/newsletter/confirm?token=${encodeURIComponent(subscriber.confirm_token)}`
 
+        // The unsubscribe token is permanent and works from any state, so the
+        // same link is valid in this mail and in every later newsletter issue.
+        const unsubscribeUrl = `${websiteUrl}/newsletter/unsubscribe?token=${encodeURIComponent(
+            subscriber.unsubscribe_token
+        )}`
+
         const sent = await sendTemplatedEmail(
             {
                 templateKey: TEMPLATE_KEY,
                 to: subscriber.email,
-                data: { confirm_url: confirmUrl },
+                data: { confirm_url: confirmUrl, unsubscribe_url: unsubscribeUrl },
             },
             context
         )

--- a/docs/newsletter.md
+++ b/docs/newsletter.md
@@ -10,6 +10,17 @@ Sign-up with a confirmed (double opt-in) subscription flow.
    Duplicate emails return the same success response as new ones (no
    enumeration). The admin token never reaches the browser.
 
+   A repeat signup for an address that previously **unsubscribed** reactivates it
+   (`resubscribeNewsletterSubscriber`): back to `pending` with a fresh
+   `confirm_token`, which makes the CMS send a new confirmation mail — consent is
+   re-obtained, never inherited from the old signup. Without this, opting out
+   would be a one-way door, because the row still exists and every later signup
+   lands in the duplicate branch. The reactivation is guarded on
+   `status = unsubscribed`, so a pending or confirmed address stays a no-op and
+   the response is identical either way; a failure there is logged and swallowed,
+   since a 500 that only fires for existing addresses would be an enumeration
+   oracle.
+
 2. **Directus fills the technical fields** — on insert Directus generates
    `confirm_token` / `unsubscribe_token` (uuid special flags), `signed_up_at`
    (date-created) and defaults `status` to `pending`. The
@@ -42,13 +53,13 @@ Sign-up with a confirmed (double opt-in) subscription flow.
    GET — consistent with the ticket/speaker submit routes), which looks the
    subscriber up by `confirm_token` and:
 
-   | Situation                                     | Result                                                        | Page state          |
-   | --------------------------------------------- | ------------------------------------------------------------- | ------------------- |
-   | `pending` and not expired                     | flips to `confirmed`, sets `confirmed_at`                     | `confirmed`         |
-   | already `confirmed`                           | no-op (idempotent)                                            | `already_confirmed` |
-   | `pending` but past `confirm_token_expires_at` | new `confirm_token` → CMS stamps a fresh window and resends   | `resent`            |
-   | unknown token / other status                  | no-op                                                         | `invalid`           |
-   | Directus down / token misconfigured (500)     | no-op                                                         | `error` (retry)     |
+   | Situation                                     | Result                                                      | Page state          |
+   | --------------------------------------------- | ----------------------------------------------------------- | ------------------- |
+   | `pending` and not expired                     | flips to `confirmed`, sets `confirmed_at`                   | `confirmed`         |
+   | already `confirmed`                           | no-op (idempotent)                                          | `already_confirmed` |
+   | `pending` but past `confirm_token_expires_at` | new `confirm_token` → CMS stamps a fresh window and resends | `resent`            |
+   | unknown token / other status                  | no-op                                                       | `invalid`           |
+   | Directus down / token misconfigured (500)     | no-op                                                       | `error` (retry)     |
 
    **Expired links are recoverable.** An expired token can't be re-sent via
    re-signup (that hits the duplicate branch, which is a no-op for privacy), so
@@ -75,23 +86,65 @@ Sign-up with a confirmed (double opt-in) subscription flow.
    access — i.e. it would have to live in the CMS (see
    [#215](https://github.com/programmierbar/website/issues/215)).
 
-   **Previewing the states without the flow:** when `FLAG_ENABLE_UI_PREVIEWS` is
-   set (non-prod only — off in production), the confirm page accepts
-   `?preview=<confirmed|already_confirmed|resent|invalid|error>` to render any
-   state directly (no API call), and shows a small state-switcher toolbar. This
-   previews the real page, so there's no separate mock to drift from.
-
    `confirm_token` is **not** nulled on confirmation (it is NOT NULL). A used
    link is neutralised by the `status` + expiry checks instead.
+
+4. **Unsubscribe** — the mail links to
+   `{website_url}/newsletter/unsubscribe?token={unsubscribe_token}` (page
+   `pages/newsletter/unsubscribe.vue`, route `POST /api/newsletter/unsubscribe`).
+
+   The token here is the **`unsubscribe_token`, not the confirm token**: it never
+   expires and stays valid after confirmation, because an unsubscribe link has to
+   keep working for the life of the subscription. Like confirmation, the call runs
+   client-side only, so a mail scanner can't opt someone out on their behalf.
+
+   | Situation                                 | Result                                     | Page state             |
+   | ----------------------------------------- | ------------------------------------------ | ---------------------- |
+   | any status except `unsubscribed`          | `status = unsubscribed`, `unsubscribed_at` | `unsubscribed`         |
+   | already `unsubscribed`                    | no-op (idempotent)                         | `already_unsubscribed` |
+   | unknown token                             | no-op                                      | `invalid`              |
+   | Directus down / token misconfigured (500) | no-op                                      | `error` (retry)        |
+
+   Opting out works from `pending` too — someone who never confirmed can still
+   say no, and it stops the confirmation resends. The write is guarded on
+   not-already-unsubscribed, so `unsubscribed_at` keeps the timestamp of the first
+   opt-out rather than being pushed forward by every re-click. Coming back is
+   possible via a normal signup, see step 1.
+
+## Shared page pieces
+
+Both token pages are thin: they supply their own copy map and nothing else.
+
+- `composables/useNewsletterTokenAction.ts` — the flow: reads `?token=`, posts it
+  to the given route on the **client only** (`onMounted`, never during SSR — that
+  is what keeps scanners and prefetchers from confirming or unsubscribing), maps
+  the result onto a status, and handles the `?preview=` override.
+- `components/NewsletterStatusPanel.vue` — the result page: spotlights, status
+  icon, eyebrow, headline, copy, CTA (a retry button when the view sets `retry`)
+  and the non-prod state switcher.
+
+**Previewing the states without the flow:** when `FLAG_ENABLE_UI_PREVIEWS` is set
+(non-prod only — off in production), both pages accept `?preview=<state>` to
+render any state directly (no API call) and show a small state-switcher toolbar.
+This previews the real page, so there's no separate mock to drift from.
+
+Both routes are excluded from ISR in `nuxt.config.ts` — they render per request
+from the query, and a cached query-less render would otherwise be served for
+every token.
 
 ## `email_templates`
 
 Create one row in the `email_templates` collection. Handlebars syntax
 (`{{variable}}`, `{{{raw_html}}}`).
 
-| Template Key               | Trigger                                                | Available Variables |
-| -------------------------- | ------------------------------------------------------ | ------------------- |
-| `newsletter_double_opt_in` | New `pending` subscriber, or an expired link refreshed | `confirm_url`       |
+| Template Key               | Trigger                                                | Available Variables              |
+| -------------------------- | ------------------------------------------------------ | -------------------------------- |
+| `newsletter_double_opt_in` | New `pending` subscriber, or an expired link refreshed | `confirm_url`, `unsubscribe_url` |
+
+`unsubscribe_url` is optional in this template — nothing is subscribed yet until
+the address confirms. It is available because the token is permanent, so the same
+link can be reused verbatim in later newsletter issues, where an unsubscribe link
+is mandatory.
 
 **Legal note:** this confirmation email must be **advertising-free** — greeting,
 confirmation link and sender/imprint only. No offers, no CTAs beyond confirming.

--- a/docs/newsletter.md
+++ b/docs/newsletter.md
@@ -94,6 +94,14 @@ Sign-up with a confirmed (double opt-in) subscription flow.
    `confirm_token` is **not** nulled on confirmation (it is NOT NULL). A used
    link is neutralised by the `status` + expiry checks instead.
 
+   **Confirming works without JavaScript**, via the same form-POST fallback as the
+   opt-out (see step 4 for how it works and why a POST keeps scanners out).
+   Strictly speaking this one fails safe — no confirmation just means no
+   subscription — but a visitor whose client can't run the call would otherwise be
+   stuck on the spinner and could never subscribe at all. The 303 matters here in
+   particular: a reload that repeated the POST on an expired link would rotate the
+   token again and send a second mail.
+
 4. **Unsubscribe** — the mail links to
    `{website_url}/newsletter/unsubscribe?token={unsubscribe_token}` (page
    `pages/newsletter/unsubscribe.vue`, route `POST /api/newsletter/unsubscribe`).
@@ -116,6 +124,27 @@ Sign-up with a confirmed (double opt-in) subscription flow.
    opt-out rather than being pushed forward by every re-click. Coming back is
    possible via a normal signup, see step 1.
 
+   **Opting out never depends on JavaScript.** The page also renders a plain form
+   that POSTs to `server/routes/newsletter/unsubscribe.post.ts` (a Nitro route
+   sharing the page's URL, POST only, so the page's GET is untouched). It covers
+   JavaScript disabled or blocked by CSP, a hydration that failed, and a
+   client-side call that hangs. Being a form POST, it keeps the protection the
+   client-side call existed for: scanners and link-expanders follow links, they
+   don't submit forms. Confirmation has the same fallback (step 3).
+
+   The form route answers **POST → 303 → GET** on `?status=<result>`, which the
+   page renders server-side, so a reload can't repeat the submission. A crafted
+   `?status=` therefore changes only what is displayed — nothing is written on that
+   path — and unknown values fall back to the loading state. In the `error` state
+   the retry CTA becomes a second form submit, so recovering doesn't need a client
+   either. Both routes share `server/utils/newsletterUnsubscribe.ts`, so "what
+   counts as an unusable link" is defined once.
+
+   The form is rendered inside the loading state, which means visitors with working
+   JavaScript may see it for the moment before the call resolves. That's deliberate:
+   hiding it until a timeout would make the guarantee depend on the very client
+   that might be broken.
+
 ## Shared page pieces
 
 Both token pages are thin: they supply their own copy map and nothing else.
@@ -123,10 +152,17 @@ Both token pages are thin: they supply their own copy map and nothing else.
 - `composables/useNewsletterTokenAction.ts` — the flow: reads `?token=`, posts it
   to the given route on the **client only** (`onMounted`, never during SSR — that
   is what keeps scanners and prefetchers from confirming or unsubscribing), maps
-  the result onto a status, and handles the `?preview=` override.
+  the result onto a status, and handles the `?preview=` and `?status=` overrides
+  (the latter is how the no-JS form redirect hands its outcome back).
 - `components/NewsletterStatusPanel.vue` — the result page: spotlights, status
   icon, eyebrow, headline, copy, CTA (a retry button when the view sets `retry`)
-  and the non-prod state switcher.
+  and the non-prod state switcher. An optional `fallback` prop adds the no-JS form
+  described in step 4; both pages set it. When a view asks for a `retry` CTA and a
+  fallback exists, the retry is rendered as a form submit rather than a JS button,
+  so recovering from the `error` state doesn't need a client either.
+- `server/utils/newsletterConfirm.ts` / `newsletterUnsubscribe.ts` — the actual
+  decisions (what is an unusable link, how a lost race is answered), shared by each
+  flow's JSON route and its form route so the two cannot diverge.
 
 **Previewing the states without the flow:** when `FLAG_ENABLE_UI_PREVIEWS` is set
 (non-prod only — off in production), both pages accept `?preview=<state>` to

--- a/docs/newsletter.md
+++ b/docs/newsletter.md
@@ -75,8 +75,9 @@ Sign-up with a confirmed (double opt-in) subscription flow.
 
    **Concurrent clicks.** The route reads by token and then writes, so both
    mutations are **conditional on the state that was read** — the update filters
-   on `status = pending` and the token from the link (the refresh additionally on
-   an already-expired window). If a concurrent request (a double-clicked link, a
+   on `status = pending` and the token from the link. The token is what makes this
+   work: a competing refresh rotates it, so the loser's filter stops matching. If
+   a concurrent request (a double-clicked link, a
    retry, two tabs) got there first, the write reports no change and the handler
    answers from the row's current state instead of its own stale read. That
    matters most for the refresh path: every rotation triggers a mail and only the
@@ -135,6 +136,39 @@ This previews the real page, so there's no separate mock to drift from.
 Both routes are excluded from ISR in `nuxt.config.ts` — they render per request
 from the query, and a cached query-less render would otherwise be served for
 every token.
+
+## Permissions for the API token
+
+The website talks to Directus with `NUXT_DIRECTUS_API_TOKEN`; its policy needs
+these fields on `newsletter_subscribers`. Field lists matter here — a missing
+field is a **403**, which the routes surface as a technical error (500), not as
+an invalid link.
+
+| Action | Fields                                                                                                              | Why                                                    |
+| ------ | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| Create | `email`, `confirm_token_expires_at`                                                                                 | signup writes the email; the hook adds the window      |
+| Read   | `id`, `status`, `confirm_token`, `confirm_token_expires_at`, `confirmed_at`, `unsubscribe_token`, `unsubscribed_at` | token lookups filter on the tokens and evaluate expiry |
+| Update | `status`, `confirmed_at`, `confirm_token`, `confirm_token_expires_at`, `unsubscribed_at`                            | confirm, refresh, unsubscribe, reactivate              |
+
+**`confirm_token_expires_at` needs create _and_ update permission even though
+the website never sets it.** Filter hooks mutate the payload inside the caller's
+request, and Directus validates the payload _after_ hooks against the caller's
+policy (`ItemsService.updateMany` → `emitFilter` → `validateItemAccess({ action:
+'update', fields: Object.keys(payloadAfterHooks) })`). So the field the CMS adds
+is checked against the website's permissions. Moving the TTL into the CMS moved
+the _value_, not the permission requirement.
+
+Filters in a query-based update (`refreshNewsletterConfirmation` and friends) are
+**not** permission-checked — `getKeysByQuery` resolves them through an
+`ItemsService` constructed without accountability. Only payload fields are.
+
+**Read permission is also what makes the guarded writes work.** They infer "did I
+win the race?" from the number of rows the PATCH returns, and Directus produces
+those by reading the updated rows back — a read whose `Forbidden` the controller
+**swallows** (`controllers/items.js`: `catch → if Forbidden return next()`). Without
+read permission the response carries no `data`, so a _successful_ write looks like
+a lost race and confirm answers `already_confirmed` / `invalid` with nothing in the
+logs. Update permission alone is not enough.
 
 ## `email_templates`
 

--- a/docs/newsletter.md
+++ b/docs/newsletter.md
@@ -37,7 +37,11 @@ Sign-up with a confirmed (double opt-in) subscription flow.
      It fires on create and again on any update that brings a new link into
      existence — a rotated `confirm_token` or an explicitly extended window (see
      step 3). Updates that touch neither (the confirm flip, unsubscribe) don't
-     resend.
+     resend. An explicitly supplied window must lie in the **future**: moving it
+     into the past by hand is how a link gets invalidated, not reissued, so that
+     sends nothing (it would deliver an already-dead link). A rotation that
+     leaves the expiry to the hook is always fine — the filter stamps a fresh
+     window.
      If the link cannot be built or sent — `website_url` unset (required, no
      fallback), template missing, or transport error — it sends **no** mail and
      posts a Slack warning, because the subscriber is otherwise stuck in

--- a/nuxt-app/components/NewsletterStatusPanel.vue
+++ b/nuxt-app/components/NewsletterStatusPanel.vue
@@ -1,0 +1,116 @@
+<template>
+    <section class="relative overflow-hidden">
+        <!-- Ambient brand spotlights behind the content (see index.vue) -->
+        <BackgroundSpotlights position="-top-40 fixed right-[-34vw] -translate-x-1/2 transform" index="-10" />
+        <BackgroundSpotlights position="-top-40 fixed left-[-6vw] -translate-x-1/2 transform" index="-10" />
+
+        <div class="relative z-10 flex min-h-[80vh] items-center justify-center px-6 py-24 md:py-32">
+            <!-- Loading: the SSR/initial render. The state-changing call runs
+                 client-side (see useNewsletterTokenAction) so crawlers, scanners
+                 and prefetchers — which don't run JS — never trigger it. -->
+            <div v-if="status === 'loading'" key="loading" class="text-center">
+                <p class="text-xl font-light text-shade-200">{{ loadingText }}</p>
+            </div>
+
+            <div v-else key="result" class="flex max-w-[600px] flex-col items-center text-center" role="status">
+                <!-- Status icon -->
+                <div
+                    class="flex h-[88px] w-[88px] shrink-0 items-center justify-center rounded-full"
+                    :class="view.circleClass"
+                >
+                    <component :is="view.icon" class="h-[46px] w-[46px] text-black" aria-hidden="true" />
+                </div>
+
+                <!-- Eyebrow -->
+                <div class="mt-9 font-azeret text-sm uppercase tracking-[0.15em] text-blue">
+                    {{ view.eyebrow }}
+                </div>
+
+                <!-- Headline with signature lime/pink underline -->
+                <h1
+                    class="mt-4 inline-block border-b-[6px] pb-3 text-4xl font-black leading-[1.05] tracking-[-0.01em] text-white md:text-[44px]"
+                    :class="view.underlineClass"
+                >
+                    {{ view.headline }}
+                </h1>
+
+                <!-- Body copy -->
+                <p class="mt-7 text-xl font-light leading-normal text-shade-200">
+                    {{ view.text }}
+                </p>
+
+                <!-- CTA -->
+                <div class="mt-10">
+                    <button
+                        v-if="view.retry"
+                        type="button"
+                        class="inline-flex h-[58px] items-center rounded-full bg-lime px-8 text-sm font-black uppercase tracking-widest text-black transition-colors hover:bg-blue hover:text-white"
+                        data-cursor-hover
+                        @click="emit('retry')"
+                    >
+                        {{ view.cta.label }}
+                    </button>
+                    <NuxtLink
+                        v-else
+                        :to="view.cta.to"
+                        class="inline-flex h-[58px] items-center rounded-full bg-lime px-8 text-sm font-black uppercase tracking-widest text-black transition-colors hover:bg-blue hover:text-white"
+                        data-cursor-hover
+                    >
+                        {{ view.cta.label }}
+                    </NuxtLink>
+                </div>
+            </div>
+        </div>
+
+        <!-- Non-prod state switcher (env-gated); lets us review every state without the flow. -->
+        <div
+            v-if="previewEnabled"
+            class="fixed bottom-4 left-1/2 z-50 flex -translate-x-1/2 items-center gap-1 rounded-full border border-shade-800 bg-gray-900/95 px-2 py-1.5"
+        >
+            <span class="px-2 font-azeret text-[10px] uppercase tracking-widest text-shade-400">Preview</span>
+            <NuxtLink
+                v-for="state in previewStates"
+                :key="state"
+                :to="{ query: { preview: state } }"
+                class="rounded-full px-3 py-1 text-xs font-bold transition-colors"
+                :class="status === state ? 'bg-lime text-black' : 'text-shade-200 hover:text-blue'"
+                data-cursor-hover
+            >
+                {{ state }}
+            </NuxtLink>
+        </div>
+    </section>
+</template>
+
+<script setup lang="ts">
+import type { NewsletterStatusView } from '~/composables/useNewsletterTokenAction'
+import { computed } from 'vue'
+
+/**
+ * Shared result page for the token-driven newsletter flows (confirm,
+ * unsubscribe): status icon, headline, copy and CTA, plus the non-prod state
+ * switcher. Each page supplies its own `views` map and keeps the flow logic in
+ * `useNewsletterTokenAction`.
+ */
+const props = withDefaults(
+    defineProps<{
+        /** Current state; 'loading' renders the neutral placeholder. */
+        status: string
+        /** Copy and styling per state, keyed by status. */
+        views: Record<string, NewsletterStatusView>
+        /** States offered by the preview switcher (non-prod only). */
+        previewStates?: readonly string[]
+        previewEnabled?: boolean
+        loadingText?: string
+    }>(),
+    {
+        previewStates: () => [],
+        previewEnabled: false,
+        loadingText: 'Einen Moment…',
+    }
+)
+
+const emit = defineEmits<{ retry: [] }>()
+
+const view = computed<NewsletterStatusView>(() => props.views[props.status] as NewsletterStatusView)
+</script>

--- a/nuxt-app/components/NewsletterStatusPanel.vue
+++ b/nuxt-app/components/NewsletterStatusPanel.vue
@@ -8,8 +8,22 @@
             <!-- Loading: the SSR/initial render. The state-changing call runs
                  client-side (see useNewsletterTokenAction) so crawlers, scanners
                  and prefetchers — which don't run JS — never trigger it. -->
-            <div v-if="status === 'loading'" key="loading" class="text-center">
+            <div v-if="status === 'loading'" key="loading" class="max-w-[600px] text-center">
                 <p class="text-xl font-light text-shade-200">{{ loadingText }}</p>
+
+                <!-- Works entirely without JavaScript: when it is disabled,
+                     blocked, or hydration failed, the client-side call never
+                     runs and this is the only way to act. Rendered as part of
+                     the loading state on purpose — it is also the escape hatch
+                     if that call hangs. A POST (never a GET) keeps the scanner
+                     protection intact. -->
+                <form v-if="fallback" :action="fallback.action" method="post" class="mt-10">
+                    <input type="hidden" name="token" :value="fallback.token" />
+                    <p class="text-base font-light leading-normal text-shade-400">{{ fallback.hint }}</p>
+                    <button type="submit" :class="CTA_CLASS" class="mt-6" data-cursor-hover>
+                        {{ fallback.label }}
+                    </button>
+                </form>
             </div>
 
             <div v-else key="result" class="flex max-w-[600px] flex-col items-center text-center" role="status">
@@ -41,21 +55,26 @@
 
                 <!-- CTA -->
                 <div class="mt-10">
+                    <!-- Retrying must survive a missing client too: with a
+                         fallback the retry is a real form submit, so it works
+                         with and without JavaScript (this is the state a no-JS
+                         visitor lands on when the form POST hit a failure). -->
+                    <form v-if="view.retry && fallback" :action="fallback.action" method="post">
+                        <input type="hidden" name="token" :value="fallback.token" />
+                        <button type="submit" :class="CTA_CLASS" data-cursor-hover>
+                            {{ view.cta.label }}
+                        </button>
+                    </form>
                     <button
-                        v-if="view.retry"
+                        v-else-if="view.retry"
                         type="button"
-                        class="inline-flex h-[58px] items-center rounded-full bg-lime px-8 text-sm font-black uppercase tracking-widest text-black transition-colors hover:bg-blue hover:text-white"
+                        :class="CTA_CLASS"
                         data-cursor-hover
                         @click="emit('retry')"
                     >
                         {{ view.cta.label }}
                     </button>
-                    <NuxtLink
-                        v-else
-                        :to="view.cta.to"
-                        class="inline-flex h-[58px] items-center rounded-full bg-lime px-8 text-sm font-black uppercase tracking-widest text-black transition-colors hover:bg-blue hover:text-white"
-                        data-cursor-hover
-                    >
+                    <NuxtLink v-else :to="view.cta.to" :class="CTA_CLASS" data-cursor-hover>
                         {{ view.cta.label }}
                     </NuxtLink>
                 </div>
@@ -102,13 +121,26 @@ const props = withDefaults(
         previewStates?: readonly string[]
         previewEnabled?: boolean
         loadingText?: string
+        /**
+         * Makes the action available without JavaScript, as a form POST to
+         * `action` carrying `token`. Set it for flows that must never depend on
+         * a working client (unsubscribe); omit it and the panel behaves as
+         * before.
+         */
+        fallback?: { action: string; token: string; label: string; hint: string }
     }>(),
     {
         previewStates: () => [],
         previewEnabled: false,
         loadingText: 'Einen Moment…',
+        fallback: undefined,
     }
 )
+
+// One pill for every CTA shape the panel renders (link, retry button, form
+// submit), so they cannot drift apart visually.
+const CTA_CLASS =
+    'inline-flex h-[58px] items-center rounded-full bg-lime px-8 text-sm font-black uppercase tracking-widest text-black transition-colors hover:bg-blue hover:text-white'
 
 const emit = defineEmits<{ retry: [] }>()
 

--- a/nuxt-app/composables/useNewsletterTokenAction.ts
+++ b/nuxt-app/composables/useNewsletterTokenAction.ts
@@ -1,0 +1,95 @@
+import type { FunctionalComponent, SVGAttributes } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
+
+// `*.svg` imports are components at runtime but typed as their module default,
+// so accept either shape here.
+export type NewsletterStatusIcon = FunctionalComponent<SVGAttributes> | string
+
+/** One rendered outcome of a token action — see `NewsletterStatusPanel`. */
+export type NewsletterStatusView = {
+    circleClass: string
+    underlineClass: string
+    icon: NewsletterStatusIcon
+    eyebrow: string
+    headline: string
+    text: string
+    /** Renders the CTA as a retry button instead of a link. */
+    retry?: boolean
+    cta: { label: string; to: string }
+}
+
+export type NewsletterTokenActionStatus<TResult extends string> = TResult | 'loading' | 'error'
+
+/**
+ * Composable behind the token-driven newsletter pages (confirm, unsubscribe).
+ *
+ * Both flows are the same shape: an emailed link carries a `?token=`, the page
+ * hands it to a POST route and renders the returned status. The shared piece
+ * that matters is *when* the call happens: it runs on the client only, in
+ * `onMounted`, and never during SSR. These endpoints change state, and email
+ * scanners, link-expanders and prefetchers request URLs without running JS —
+ * so keeping the call client-side is what stops them from confirming or
+ * unsubscribing on the recipient's behalf.
+ *
+ * @param endpoint Server route to post the token to.
+ * @param previewStates States selectable via `?preview=` (non-prod only).
+ */
+export function useNewsletterTokenAction<TResult extends string>(
+    endpoint: string,
+    previewStates: readonly NewsletterTokenActionStatus<TResult>[]
+) {
+    const route = useRoute()
+
+    // Non-prod only (env-gated, off in production): jump straight to any view
+    // state via `?preview=<state>` so the design can be reviewed without walking
+    // the whole flow. In production the flag is false, so this is inert.
+    const previewEnabled = Boolean(useRuntimeConfig().public.FLAG_ENABLE_UI_PREVIEWS)
+    const previewState = computed<NewsletterTokenActionStatus<TResult> | null>(() => {
+        if (!previewEnabled) return null
+        const preview = route.query.preview
+        if (typeof preview !== 'string') return null
+        return (previewStates as readonly string[]).includes(preview)
+            ? (preview as NewsletterTokenActionStatus<TResult>)
+            : null
+    })
+
+    // Start on the preview state when previewing (so SSR and client agree),
+    // otherwise 'loading' until the client-side call resolves.
+    const status = ref<NewsletterTokenActionStatus<TResult>>(previewState.value ?? 'loading')
+
+    // The page stays mounted when the preview switcher changes `?preview=`, so
+    // re-derive the view on query changes (preview-only; in production
+    // previewState is always null and this never fires).
+    watch(previewState, (state) => {
+        if (state) status.value = state
+    })
+
+    /** It posts the token from the URL and maps the result onto `status`. */
+    async function run() {
+        status.value = 'loading'
+
+        try {
+            // A missing or malformed token is not checked here on purpose: the
+            // route answers 'invalid' for it without touching Directus, so what
+            // counts as an unusable link is defined in exactly one place.
+            const token = typeof route.query.token === 'string' ? route.query.token : ''
+            const result = await $fetch<{ status: TResult }>(endpoint, {
+                method: 'POST',
+                body: { token },
+            })
+            status.value = result.status
+        } catch {
+            // A technical failure (Directus down, misconfiguration) is distinct
+            // from a dead link — the view offers a retry instead of blaming the
+            // link.
+            status.value = 'error'
+        }
+    }
+
+    onMounted(() => {
+        if (previewState.value) return
+        run()
+    })
+
+    return { status, previewEnabled, previewStates, run }
+}

--- a/nuxt-app/composables/useNewsletterTokenAction.ts
+++ b/nuxt-app/composables/useNewsletterTokenAction.ts
@@ -53,9 +53,23 @@ export function useNewsletterTokenAction<TResult extends string>(
             : null
     })
 
-    // Start on the preview state when previewing (so SSR and client agree),
-    // otherwise 'loading' until the client-side call resolves.
-    const status = ref<NewsletterTokenActionStatus<TResult>>(previewState.value ?? 'loading')
+    // A no-JS form submission is answered with a redirect that carries the
+    // outcome (POST → 303 → GET), so the result has to be renderable from the
+    // query alone, during SSR, without any client-side call. Only states this
+    // page actually knows are accepted; a hand-crafted value changes what is
+    // displayed and nothing else, since no state is written on this path.
+    const queryStatus = computed<NewsletterTokenActionStatus<TResult> | null>(() => {
+        const status = route.query.status
+        if (typeof status !== 'string') return null
+        return (previewStates as readonly string[]).includes(status)
+            ? (status as NewsletterTokenActionStatus<TResult>)
+            : null
+    })
+
+    // Start on the preview state when previewing, or on a state handed back by
+    // the form redirect (so SSR and client agree either way), otherwise
+    // 'loading' until the client-side call resolves.
+    const status = ref<NewsletterTokenActionStatus<TResult>>(previewState.value ?? queryStatus.value ?? 'loading')
 
     // The page stays mounted when the preview switcher changes `?preview=`, so
     // re-derive the view on query changes (preview-only; in production
@@ -88,6 +102,10 @@ export function useNewsletterTokenAction<TResult extends string>(
 
     onMounted(() => {
         if (previewState.value) return
+        // The form route already performed the action and told us the outcome;
+        // re-posting on mount would repeat it (and overwrite an 'error' the user
+        // is looking at with a second failure).
+        if (queryStatus.value) return
         run()
     })
 

--- a/nuxt-app/nuxt.config.ts
+++ b/nuxt-app/nuxt.config.ts
@@ -196,10 +196,11 @@ export default defineNuxtConfig({
         '/suche': { isr: false },
         '/api/**': { isr: false },
 
-        // Renders per-request from the `?token=` (and `?preview=`) query. Under
+        // Render per-request from the `?token=` (and `?preview=`) query. Under
         // ISR the first query-less render (invalid) would be cached and served
         // for every token, breaking confirmation — same reason as the portals.
         '/newsletter/confirm': { isr: false },
+        '/newsletter/unsubscribe': { isr: false },
 
         // /app UA-branches between iOS/Android store URLs on conference hosts;
         // a cached response would pin the first-seen platform for everyone.

--- a/nuxt-app/pages/newsletter/confirm.vue
+++ b/nuxt-app/pages/newsletter/confirm.vue
@@ -4,6 +4,7 @@
         :views="VIEWS"
         :preview-states="previewStates"
         :preview-enabled="previewEnabled"
+        :fallback="FALLBACK"
         loading-text="Anmeldung wird bestätigt…"
         @retry="run"
     />
@@ -15,7 +16,7 @@ import CheckIcon from '~/assets/icons/check.svg'
 import InfoCircleIcon from '~/assets/icons/info-circle.svg'
 import type { NewsletterStatusView } from '~/composables/useNewsletterTokenAction'
 import { getMetaInfo } from '~/helpers'
-import type { NewsletterConfirmResult } from '~/server/api/newsletter/confirm.post'
+import type { NewsletterConfirmResult } from '~/server/utils/newsletterConfirm'
 
 // The API results plus the view-only technical-failure state.
 type ViewStatus = NewsletterConfirmResult | 'error'
@@ -77,6 +78,17 @@ const VIEWS: Record<ViewStatus, NewsletterStatusView> = {
 }
 
 const route = useRoute()
+
+// Confirming must not depend on JavaScript either: without this, a visitor whose
+// client can't run the call is stuck on the spinner and can never subscribe. The
+// panel renders it as a plain form POST to the Nitro route that shares this URL;
+// it is a POST, so link scanners still cannot trigger it.
+const FALLBACK = computed(() => ({
+    action: '/newsletter/confirm',
+    token: typeof route.query.token === 'string' ? route.query.token : '',
+    label: 'Anmeldung bestätigen',
+    hint: 'Passiert nichts? Dann bestätige deine Anmeldung hier:',
+}))
 
 useHead(
     getMetaInfo({

--- a/nuxt-app/pages/newsletter/unsubscribe.vue
+++ b/nuxt-app/pages/newsletter/unsubscribe.vue
@@ -4,7 +4,7 @@
         :views="VIEWS"
         :preview-states="previewStates"
         :preview-enabled="previewEnabled"
-        loading-text="Anmeldung wird bestätigt…"
+        loading-text="Abmeldung wird verarbeitet…"
         @retry="run"
     />
 </template>
@@ -12,48 +12,38 @@
 <script setup lang="ts">
 import AlertIcon from '~/assets/icons/alert.svg'
 import CheckIcon from '~/assets/icons/check.svg'
-import InfoCircleIcon from '~/assets/icons/info-circle.svg'
 import type { NewsletterStatusView } from '~/composables/useNewsletterTokenAction'
 import { getMetaInfo } from '~/helpers'
-import type { NewsletterConfirmResult } from '~/server/api/newsletter/confirm.post'
+import type { NewsletterUnsubscribeResult } from '~/server/api/newsletter/unsubscribe.post'
 
 // The API results plus the view-only technical-failure state.
-type ViewStatus = NewsletterConfirmResult | 'error'
+type ViewStatus = NewsletterUnsubscribeResult | 'error'
 
-const PREVIEW_STATES: ViewStatus[] = ['confirmed', 'already_confirmed', 'resent', 'invalid', 'error']
+const PREVIEW_STATES: ViewStatus[] = ['unsubscribed', 'already_unsubscribed', 'invalid', 'error']
 
 const { status, previewEnabled, previewStates, run } = useNewsletterTokenAction<ViewStatus>(
-    '/api/newsletter/confirm',
+    '/api/newsletter/unsubscribe',
     PREVIEW_STATES
 )
 
 const VIEWS: Record<ViewStatus, NewsletterStatusView> = {
-    confirmed: {
+    unsubscribed: {
         circleClass: 'bg-lime',
         underlineClass: 'border-lime',
         icon: CheckIcon,
-        eyebrow: '// Newsletter bestätigt',
-        headline: 'Du bist dabei!',
-        text: 'Deine Anmeldung ist bestätigt. Ab jetzt bekommst du jeden Freitag die wichtigsten Dev-News, neue Folgen sowie Meetup- und Konferenz-Termine direkt in dein Postfach.',
+        eyebrow: '// Newsletter abgemeldet',
+        headline: 'Du bist abgemeldet',
+        text: 'Deine E-Mail-Adresse wurde aus dem Newsletter-Verteiler entfernt. Du bekommst ab jetzt keine weiteren Newsletter von uns. Schade, dass du gehst!',
         cta: { label: 'Zur programmier.bar', to: '/' },
     },
-    already_confirmed: {
+    already_unsubscribed: {
         circleClass: 'bg-lime',
         underlineClass: 'border-lime',
         icon: CheckIcon,
         eyebrow: '// Newsletter',
-        headline: 'Schon bestätigt',
-        text: 'Diese E-Mail-Adresse ist bereits für den Newsletter bestätigt. Du musst nichts weiter tun.',
+        headline: 'Schon abgemeldet',
+        text: 'Diese E-Mail-Adresse ist bereits abgemeldet. Du musst nichts weiter tun — von uns kommt kein Newsletter mehr.',
         cta: { label: 'Zur programmier.bar', to: '/' },
-    },
-    resent: {
-        circleClass: 'bg-lime',
-        underlineClass: 'border-lime',
-        icon: InfoCircleIcon,
-        eyebrow: '// Neuer Link unterwegs',
-        headline: 'Link war abgelaufen',
-        text: 'Dein Bestätigungslink war nicht mehr gültig — wir haben dir gerade einen frischen Link geschickt. Bitte prüfe dein Postfach.',
-        cta: { label: 'Zur Startseite', to: '/' },
     },
     invalid: {
         circleClass: 'bg-pink',
@@ -61,8 +51,8 @@ const VIEWS: Record<ViewStatus, NewsletterStatusView> = {
         icon: AlertIcon,
         eyebrow: '// Link ungültig',
         headline: 'Link ungültig',
-        text: 'Dieser Bestätigungslink konnte nicht verarbeitet werden. Bitte nutze den aktuellsten Link aus deiner E-Mail oder melde dich erneut an.',
-        cta: { label: 'Zur Startseite', to: '/' },
+        text: 'Dieser Abmeldelink konnte nicht verarbeitet werden. Bitte nutze den Link aus einer aktuellen Newsletter-Mail oder schreib uns kurz — wir melden dich dann von Hand ab.',
+        cta: { label: 'Kontakt aufnehmen', to: '/kontakt' },
     },
     error: {
         circleClass: 'bg-pink',
@@ -70,7 +60,7 @@ const VIEWS: Record<ViewStatus, NewsletterStatusView> = {
         icon: AlertIcon,
         eyebrow: '// Technischer Fehler',
         headline: 'Etwas ist schiefgelaufen',
-        text: 'Deine Anmeldung konnte gerade nicht bestätigt werden. Das liegt an einem vorübergehenden technischen Problem — bitte versuche es in ein paar Minuten erneut.',
+        text: 'Deine Abmeldung konnte gerade nicht verarbeitet werden. Das liegt an einem vorübergehenden technischen Problem — bitte versuche es in ein paar Minuten erneut.',
         retry: true,
         cta: { label: 'Erneut versuchen', to: '/' },
     },
@@ -82,7 +72,7 @@ useHead(
     getMetaInfo({
         type: 'website',
         path: route.path,
-        title: 'Newsletter bestätigen',
+        title: 'Newsletter abmelden',
         noIndex: true,
     })
 )

--- a/nuxt-app/pages/newsletter/unsubscribe.vue
+++ b/nuxt-app/pages/newsletter/unsubscribe.vue
@@ -4,6 +4,7 @@
         :views="VIEWS"
         :preview-states="previewStates"
         :preview-enabled="previewEnabled"
+        :fallback="FALLBACK"
         loading-text="Abmeldung wird verarbeitet…"
         @retry="run"
     />
@@ -14,7 +15,7 @@ import AlertIcon from '~/assets/icons/alert.svg'
 import CheckIcon from '~/assets/icons/check.svg'
 import type { NewsletterStatusView } from '~/composables/useNewsletterTokenAction'
 import { getMetaInfo } from '~/helpers'
-import type { NewsletterUnsubscribeResult } from '~/server/api/newsletter/unsubscribe.post'
+import type { NewsletterUnsubscribeResult } from '~/server/utils/newsletterUnsubscribe'
 
 // The API results plus the view-only technical-failure state.
 type ViewStatus = NewsletterUnsubscribeResult | 'error'
@@ -67,6 +68,17 @@ const VIEWS: Record<ViewStatus, NewsletterStatusView> = {
 }
 
 const route = useRoute()
+
+// Opting out is the one action a recipient is always entitled to, so it must not
+// depend on JavaScript being available. The panel renders this as a plain form
+// POST to the Nitro route that shares this URL; it is a POST, so link scanners
+// still cannot trigger it.
+const FALLBACK = computed(() => ({
+    action: '/newsletter/unsubscribe',
+    token: typeof route.query.token === 'string' ? route.query.token : '',
+    label: 'Jetzt abmelden',
+    hint: 'Passiert nichts? Dann schließe die Abmeldung hier ab:',
+}))
 
 useHead(
     getMetaInfo({

--- a/nuxt-app/server/api/newsletter/confirm.post.ts
+++ b/nuxt-app/server/api/newsletter/confirm.post.ts
@@ -1,74 +1,17 @@
-// Confirms a double-opt-in newsletter subscription. POST (not GET) because it
-// changes state — the confirm page reads the token from the email link and
-// calls this client-side. Idempotent: re-confirming is a no-op, and
-// unknown / expired / non-pending tokens get neutral results (no enumeration).
-export type NewsletterConfirmResult = 'confirmed' | 'already_confirmed' | 'resent' | 'invalid'
+import { performNewsletterConfirm, type NewsletterConfirmResult } from '../../utils/newsletterConfirm'
 
+// JSON confirmation, called client-side by `pages/newsletter/confirm.vue`. POST
+// (not GET) because it changes state, which is also what keeps email scanners
+// and link-expanders from confirming a subscription on the recipient's behalf.
+//
+// The visitors this route cannot serve — JavaScript disabled or blocked, or a
+// failed hydration — go through the form POST in `server/routes/newsletter/
+// confirm.post.ts` instead. Both share the logic below.
 export default defineEventHandler(async (event): Promise<{ status: NewsletterConfirmResult }> => {
     const body = await readBody(event)
-    const token = body?.token
-
-    if (typeof token !== 'string' || token.length === 0) {
-        return { status: 'invalid' }
-    }
 
     try {
-        const directus = useAuthenticatedDirectus()
-        const subscriber = await directus.readNewsletterSubscriberByToken(token)
-
-        // Unknown token → neutral, no detail.
-        if (!subscriber) {
-            return { status: 'invalid' }
-        }
-
-        // Already confirmed → idempotent success (handles link re-clicks).
-        if (subscriber.status === 'confirmed') {
-            return { status: 'already_confirmed' }
-        }
-
-        // Any other non-pending status (unsubscribed / bounced / complained) is
-        // treated as an invalid link rather than confirmed.
-        if (subscriber.status !== 'pending') {
-            return { status: 'invalid' }
-        }
-
-        // Pending but past the confirmation window → don't leave the address
-        // stuck. Rotate the token; the CMS stamps a fresh window and resends the
-        // confirmation mail. (Re-signup hits the duplicate branch and can't
-        // resend, so recovery has to happen here.)
-        //
-        // Both writes below are conditional on the state read above, so a
-        // concurrent request (a double-clicked link, a retry) that got there
-        // first cannot be overwritten. When that happens the write reports no
-        // change and we answer from the row's current state rather than from our
-        // own read — see the note on the guards in authenticatedDirectus.ts.
-        const expiresAt = new Date(subscriber.confirm_token_expires_at).getTime()
-        if (!Number.isFinite(expiresAt) || expiresAt <= Date.now()) {
-            const refreshed = await directus.refreshNewsletterConfirmation(subscriber.id, token)
-            if (refreshed) {
-                return { status: 'resent' }
-            }
-
-            // Someone else rotated the token first: our token no longer resolves,
-            // and their mail is already on its way — 'resent' stays honest, and
-            // no second mail is sent.
-            const current = await directus.readNewsletterSubscriberByToken(token)
-            if (!current) {
-                return { status: 'resent' }
-            }
-
-            return { status: current.status === 'confirmed' ? 'already_confirmed' : 'invalid' }
-        }
-
-        const confirmed = await directus.confirmNewsletterSubscriber(subscriber.id, token)
-        if (confirmed) {
-            return { status: 'confirmed' }
-        }
-
-        // Lost the race: a concurrent confirm, or a status change (unsubscribe)
-        // that we must not overwrite.
-        const current = await directus.readNewsletterSubscriberByToken(token)
-        return { status: current?.status === 'confirmed' ? 'already_confirmed' : 'invalid' }
+        return { status: await performNewsletterConfirm(body?.token) }
     } catch (err: any) {
         console.error('Newsletter confirm error:', err)
         throw createError({

--- a/nuxt-app/server/api/newsletter/subscribe.post.ts
+++ b/nuxt-app/server/api/newsletter/subscribe.post.ts
@@ -51,6 +51,21 @@ export default defineEventHandler(async (event) => {
         // subscribed (email enumeration). No duplicate row is created, so no
         // second confirmation mail goes out.
         if (isDuplicateError(err)) {
+            // One exception: a previously unsubscribed address must be able to
+            // come back. Without this, opting out is a one-way door — the row
+            // exists, so every later signup lands here and silently does
+            // nothing. The reactivation is guarded on `status = unsubscribed`,
+            // so a pending or confirmed address stays a no-op and the response
+            // is identical either way.
+            try {
+                await directus.resubscribeNewsletterSubscriber(email)
+            } catch (reactivateError: any) {
+                // Swallowed on purpose: a 500 here would only ever fire for
+                // addresses that already exist, which would turn this branch
+                // into the enumeration oracle the shared response avoids.
+                console.error('Newsletter reactivation error:', reactivateError)
+            }
+
             return { status: 'success' as const }
         }
         if (err.statusCode) {

--- a/nuxt-app/server/api/newsletter/unsubscribe.post.ts
+++ b/nuxt-app/server/api/newsletter/unsubscribe.post.ts
@@ -1,0 +1,51 @@
+// Opts an address out of the newsletter. POST (not GET) because it changes
+// state — the unsubscribe page reads the token from the email link and calls
+// this client-side. Idempotent: re-clicking an unsubscribe link is a no-op, and
+// unknown tokens get a neutral result (no enumeration).
+//
+// The token is the long-lived `unsubscribe_token`, not the confirm token: it
+// never expires and stays valid after confirmation, because an unsubscribe link
+// has to keep working for the life of the subscription.
+export type NewsletterUnsubscribeResult = 'unsubscribed' | 'already_unsubscribed' | 'invalid'
+
+export default defineEventHandler(async (event): Promise<{ status: NewsletterUnsubscribeResult }> => {
+    const body = await readBody(event)
+    const token = body?.token
+
+    if (typeof token !== 'string' || token.length === 0) {
+        return { status: 'invalid' }
+    }
+
+    try {
+        const directus = useAuthenticatedDirectus()
+        const subscriber = await directus.readNewsletterSubscriberByUnsubscribeToken(token)
+
+        // Unknown token → neutral, no detail.
+        if (!subscriber) {
+            return { status: 'invalid' }
+        }
+
+        // Already opted out → idempotent success (handles link re-clicks and
+        // mail clients that follow links more than once).
+        if (subscriber.status === 'unsubscribed') {
+            return { status: 'already_unsubscribed' }
+        }
+
+        // Conditional on the state read above, so a concurrent request can't
+        // overwrite it; when it reports no change we answer from the row's
+        // current state — see the note on the guards in authenticatedDirectus.ts.
+        const unsubscribed = await directus.unsubscribeNewsletterSubscriber(subscriber.id, token)
+        if (unsubscribed) {
+            return { status: 'unsubscribed' }
+        }
+
+        const current = await directus.readNewsletterSubscriberByUnsubscribeToken(token)
+        return { status: current?.status === 'unsubscribed' ? 'already_unsubscribed' : 'invalid' }
+    } catch (err: any) {
+        console.error('Newsletter unsubscribe error:', err)
+        throw createError({
+            statusCode: 500,
+            message: 'Bei der Abmeldung ist ein Fehler aufgetreten.',
+        })
+    }
+})

--- a/nuxt-app/server/api/newsletter/unsubscribe.post.ts
+++ b/nuxt-app/server/api/newsletter/unsubscribe.post.ts
@@ -1,46 +1,17 @@
-// Opts an address out of the newsletter. POST (not GET) because it changes
-// state — the unsubscribe page reads the token from the email link and calls
-// this client-side. Idempotent: re-clicking an unsubscribe link is a no-op, and
-// unknown tokens get a neutral result (no enumeration).
-//
-// The token is the long-lived `unsubscribe_token`, not the confirm token: it
-// never expires and stays valid after confirmation, because an unsubscribe link
-// has to keep working for the life of the subscription.
-export type NewsletterUnsubscribeResult = 'unsubscribed' | 'already_unsubscribed' | 'invalid'
+import { performNewsletterUnsubscribe, type NewsletterUnsubscribeResult } from '../../utils/newsletterUnsubscribe'
 
+// JSON opt-out, called client-side by `pages/newsletter/unsubscribe.vue`. POST
+// (not GET) because it changes state, which is also what keeps email scanners
+// and link-expanders from opting someone out on their behalf.
+//
+// The visitors this route cannot serve — JavaScript disabled or blocked, or a
+// failed hydration — go through the form POST in `server/routes/newsletter/
+// unsubscribe.post.ts` instead. Both share the logic below.
 export default defineEventHandler(async (event): Promise<{ status: NewsletterUnsubscribeResult }> => {
     const body = await readBody(event)
-    const token = body?.token
-
-    if (typeof token !== 'string' || token.length === 0) {
-        return { status: 'invalid' }
-    }
 
     try {
-        const directus = useAuthenticatedDirectus()
-        const subscriber = await directus.readNewsletterSubscriberByUnsubscribeToken(token)
-
-        // Unknown token → neutral, no detail.
-        if (!subscriber) {
-            return { status: 'invalid' }
-        }
-
-        // Already opted out → idempotent success (handles link re-clicks and
-        // mail clients that follow links more than once).
-        if (subscriber.status === 'unsubscribed') {
-            return { status: 'already_unsubscribed' }
-        }
-
-        // Conditional on the state read above, so a concurrent request can't
-        // overwrite it; when it reports no change we answer from the row's
-        // current state — see the note on the guards in authenticatedDirectus.ts.
-        const unsubscribed = await directus.unsubscribeNewsletterSubscriber(subscriber.id, token)
-        if (unsubscribed) {
-            return { status: 'unsubscribed' }
-        }
-
-        const current = await directus.readNewsletterSubscriberByUnsubscribeToken(token)
-        return { status: current?.status === 'unsubscribed' ? 'already_unsubscribed' : 'invalid' }
+        return { status: await performNewsletterUnsubscribe(body?.token) }
     } catch (err: any) {
         console.error('Newsletter unsubscribe error:', err)
         throw createError({

--- a/nuxt-app/server/routes/newsletter/confirm.post.ts
+++ b/nuxt-app/server/routes/newsletter/confirm.post.ts
@@ -1,0 +1,34 @@
+import { performNewsletterConfirm } from '../../utils/newsletterConfirm'
+
+// No-JavaScript confirmation. Shares the URL of the confirm page but only handles
+// POST, so the page itself (GET) is unaffected: the form on that page submits
+// here without any client-side code.
+//
+// Unlike the unsubscribe fallback this one is not strictly required — a
+// confirmation that never happens fails safe, since no subscription is created —
+// but leaving these visitors stuck on a spinner means they can never subscribe at
+// all, and the double opt-in is exactly the point where a real human action is
+// being recorded. A form POST keeps the protection the client-side call was there
+// for: scanners and link-expanders follow links, they do not submit forms.
+//
+// Answers with a redirect (POST → 303 → GET) so the outcome is rendered from the
+// query server-side and a reload cannot repeat the submission — which matters
+// here, because a repeat on an expired link would rotate the token again and send
+// a second mail.
+export default defineEventHandler(async (event) => {
+    // Form submissions arrive as `application/x-www-form-urlencoded`; readBody
+    // parses that into an object just like it does JSON.
+    const body = await readBody(event)
+
+    let status: string
+    try {
+        status = await performNewsletterConfirm(body?.token)
+    } catch (err: any) {
+        // The page has an 'error' view for exactly this — a technical failure is
+        // not the same as a dead link, and it offers another attempt.
+        console.error('Newsletter confirm (form) error:', err)
+        status = 'error'
+    }
+
+    return await sendRedirect(event, `/newsletter/confirm?status=${status}`, 303)
+})

--- a/nuxt-app/server/routes/newsletter/unsubscribe.post.ts
+++ b/nuxt-app/server/routes/newsletter/unsubscribe.post.ts
@@ -1,0 +1,31 @@
+import { performNewsletterUnsubscribe } from '../../utils/newsletterUnsubscribe'
+
+// No-JavaScript opt-out. Shares the URL of the unsubscribe page but only handles
+// POST, so the page itself (GET) is unaffected: the form on that page submits
+// here without any client-side code.
+//
+// Opting out must work for everyone — it is the one action a recipient is always
+// entitled to — and the page's client-side call cannot serve visitors with
+// JavaScript disabled or blocked, or a hydration that failed. A form POST keeps
+// the protection the client-side call was there for: scanners and link-expanders
+// follow links, they do not submit forms.
+//
+// Answers with a redirect (POST → 303 → GET) so the outcome is rendered from the
+// query server-side and a reload cannot repeat the submission.
+export default defineEventHandler(async (event) => {
+    // Form submissions arrive as `application/x-www-form-urlencoded`; readBody
+    // parses that into an object just like it does JSON.
+    const body = await readBody(event)
+
+    let status: string
+    try {
+        status = await performNewsletterUnsubscribe(body?.token)
+    } catch (err: any) {
+        // The page has an 'error' view for exactly this — a technical failure is
+        // not the same as a dead link, and it offers another attempt.
+        console.error('Newsletter unsubscribe (form) error:', err)
+        status = 'error'
+    }
+
+    return await sendRedirect(event, `/newsletter/unsubscribe?status=${status}`, 303)
+})

--- a/nuxt-app/server/utils/authenticatedDirectus.ts
+++ b/nuxt-app/server/utils/authenticatedDirectus.ts
@@ -355,6 +355,80 @@ export function useAuthenticatedDirectus() {
         return (updated?.length ?? 0) > 0
     }
 
+    // Looks a subscriber up by its (permanent) unsubscribe token. As with the
+    // confirm token, the status is evaluated by the caller so it can tell an
+    // already-unsubscribed address from an unusable link.
+    async function readNewsletterSubscriberByUnsubscribeToken(token: string) {
+        const subscribers = await client.request(
+            readItems('newsletter_subscribers', {
+                filter: { unsubscribe_token: { _eq: token } },
+                fields: ['id', 'status', 'unsubscribed_at'],
+                limit: 1,
+            })
+        )
+
+        return subscribers?.[0] ?? null
+    }
+
+    // Opts a subscriber out, from any state that isn't already 'unsubscribed' —
+    // a `pending` address that never confirmed can opt out too, which also stops
+    // the confirmation resends.
+    //
+    // Guarded on the token and on not-already-unsubscribed like the confirm
+    // writes above, so `unsubscribed_at` keeps the timestamp of the first opt-out
+    // instead of being pushed forward by every re-click. Same caveat about the
+    // residual read-to-write window applies.
+    async function unsubscribeNewsletterSubscriber(id: string, expectedToken: string) {
+        const updated = await client.request(
+            updateItems(
+                'newsletter_subscribers',
+                {
+                    filter: {
+                        id: { _eq: id },
+                        unsubscribe_token: { _eq: expectedToken },
+                        status: { _neq: 'unsubscribed' },
+                    },
+                },
+                {
+                    status: 'unsubscribed',
+                    unsubscribed_at: new Date().toISOString(),
+                }
+            )
+        )
+
+        return (updated?.length ?? 0) > 0
+    }
+
+    // Puts a previously unsubscribed address back into the double-opt-in flow:
+    // status back to 'pending' and a fresh `confirm_token`, which makes the CMS
+    // hook stamp a new window and send a confirmation mail. Consent is therefore
+    // re-obtained rather than assumed from the earlier signup.
+    //
+    // Guarded on `status = unsubscribed` so this can never reset a live
+    // subscription (and so a repeat signup for a pending/confirmed address stays
+    // the no-op that keeps the endpoint free of email enumeration).
+    async function resubscribeNewsletterSubscriber(email: string) {
+        const updated = await client.request(
+            updateItems(
+                'newsletter_subscribers',
+                {
+                    filter: {
+                        email: { _eq: email },
+                        status: { _eq: 'unsubscribed' },
+                    },
+                },
+                {
+                    status: 'pending',
+                    confirm_token: randomUUID(),
+                    confirmed_at: null,
+                    unsubscribed_at: null,
+                }
+            )
+        )
+
+        return (updated?.length ?? 0) > 0
+    }
+
     return {
         getSpeakerByPortalToken,
         updateSpeaker,
@@ -378,5 +452,8 @@ export function useAuthenticatedDirectus() {
         readNewsletterSubscriberByToken,
         confirmNewsletterSubscriber,
         refreshNewsletterConfirmation,
+        readNewsletterSubscriberByUnsubscribeToken,
+        unsubscribeNewsletterSubscriber,
+        resubscribeNewsletterSubscriber,
     }
 }

--- a/nuxt-app/server/utils/authenticatedDirectus.ts
+++ b/nuxt-app/server/utils/authenticatedDirectus.ts
@@ -329,6 +329,10 @@ export function useAuthenticatedDirectus() {
     //
     // The expiry is deliberately NOT set here — the confirmation TTL is defined
     // once, in the CMS hook, so the create and refresh paths can't drift apart.
+    // That does NOT remove the permission requirement: the hook's filter adds
+    // `confirm_token_expires_at` to this very payload, and Directus validates the
+    // post-hook payload against the *caller's* policy. The API token therefore
+    // needs update permission on that field too (see docs/newsletter.md).
     //
     // Guarded like `confirmNewsletterSubscriber` above, and for a sharper reason:
     // every rotation triggers a mail, and only the newest token still works. Two
@@ -343,9 +347,13 @@ export function useAuthenticatedDirectus() {
                     filter: {
                         id: { _eq: id },
                         status: { _eq: 'pending' },
+                        // The token IS the compare-and-swap witness here: a
+                        // competing refresh rotates it, so this filter stops
+                        // matching. An extra `confirm_token_expires_at` clause
+                        // would add nothing — the only way the window moves
+                        // without the token changing is a manual CMS edit — and
+                        // the caller already decided the window was over.
                         confirm_token: { _eq: expectedToken },
-                        // Don't shorten a window someone else just refreshed.
-                        confirm_token_expires_at: { _lte: new Date().toISOString() },
                     },
                 },
                 { confirm_token: randomUUID() }

--- a/nuxt-app/server/utils/newsletterConfirm.ts
+++ b/nuxt-app/server/utils/newsletterConfirm.ts
@@ -1,0 +1,79 @@
+// Confirming a double-opt-in subscription is reachable two ways: the JSON route
+// the page calls client-side, and the plain form POST the page renders for
+// visitors without working JavaScript. Both must agree on what counts as an
+// unusable link and on how a lost race is answered, so the decision lives here
+// once instead of in each handler.
+export type NewsletterConfirmResult = 'confirmed' | 'already_confirmed' | 'resent' | 'invalid'
+
+/**
+ * Confirm one subscriber by its confirm token. Idempotent: re-confirming is a
+ * no-op, and unknown / expired / non-pending tokens get neutral results (no
+ * enumeration).
+ *
+ * Technical failures are thrown, not mapped — the callers differ in how they
+ * report them (a 500 for the JSON route, a redirect for the form route).
+ */
+export async function performNewsletterConfirm(token: unknown): Promise<NewsletterConfirmResult> {
+    // Checked here rather than in the handlers so an empty or malformed token
+    // never reaches Directus, and 'invalid' means the same thing on both routes.
+    if (typeof token !== 'string' || token.length === 0) {
+        return 'invalid'
+    }
+
+    const directus = useAuthenticatedDirectus()
+    const subscriber = await directus.readNewsletterSubscriberByToken(token)
+
+    // Unknown token → neutral, no detail.
+    if (!subscriber) {
+        return 'invalid'
+    }
+
+    // Already confirmed → idempotent success (handles link re-clicks).
+    if (subscriber.status === 'confirmed') {
+        return 'already_confirmed'
+    }
+
+    // Any other non-pending status (unsubscribed / bounced / complained) is
+    // treated as an invalid link rather than confirmed.
+    if (subscriber.status !== 'pending') {
+        return 'invalid'
+    }
+
+    // Pending but past the confirmation window → don't leave the address stuck.
+    // Rotate the token; the CMS stamps a fresh window and resends the
+    // confirmation mail. (Re-signup hits the duplicate branch and can't resend,
+    // so recovery has to happen here.)
+    //
+    // Both writes below are conditional on the state read above, so a concurrent
+    // request (a double-clicked link, a retry, two tabs) that got there first
+    // cannot be overwritten. When that happens the write reports no change and we
+    // answer from the row's current state rather than from our own read — see the
+    // note on the guards in authenticatedDirectus.ts.
+    const expiresAt = new Date(subscriber.confirm_token_expires_at).getTime()
+    if (!Number.isFinite(expiresAt) || expiresAt <= Date.now()) {
+        const refreshed = await directus.refreshNewsletterConfirmation(subscriber.id, token)
+        if (refreshed) {
+            return 'resent'
+        }
+
+        // Someone else rotated the token first: our token no longer resolves, and
+        // their mail is already on its way — 'resent' stays honest, and no second
+        // mail is sent.
+        const current = await directus.readNewsletterSubscriberByToken(token)
+        if (!current) {
+            return 'resent'
+        }
+
+        return current.status === 'confirmed' ? 'already_confirmed' : 'invalid'
+    }
+
+    const confirmed = await directus.confirmNewsletterSubscriber(subscriber.id, token)
+    if (confirmed) {
+        return 'confirmed'
+    }
+
+    // Lost the race: a concurrent confirm, or a status change (unsubscribe) that
+    // we must not overwrite.
+    const current = await directus.readNewsletterSubscriberByToken(token)
+    return current?.status === 'confirmed' ? 'already_confirmed' : 'invalid'
+}

--- a/nuxt-app/server/utils/newsletterUnsubscribe.ts
+++ b/nuxt-app/server/utils/newsletterUnsubscribe.ts
@@ -1,0 +1,50 @@
+// Opting out has to work for everyone, so it is reachable two ways: the JSON
+// route the page calls client-side, and the plain form POST the page renders for
+// visitors without working JavaScript. Both must agree on what counts as an
+// unusable link and on when a row is actually written, so the decision lives
+// here once instead of in each handler.
+//
+// The token is the long-lived `unsubscribe_token`, not the confirm token: it
+// never expires and stays valid after confirmation, because an unsubscribe link
+// has to keep working for the life of the subscription.
+export type NewsletterUnsubscribeResult = 'unsubscribed' | 'already_unsubscribed' | 'invalid'
+
+/**
+ * Opt one subscriber out by its unsubscribe token. Idempotent: re-clicking a
+ * link is a no-op, and unknown tokens get a neutral result (no enumeration).
+ *
+ * Technical failures are thrown, not mapped — the callers differ in how they
+ * report them (a 500 for the JSON route, a redirect for the form route).
+ */
+export async function performNewsletterUnsubscribe(token: unknown): Promise<NewsletterUnsubscribeResult> {
+    // Checked here rather than in the handlers so an empty or malformed token
+    // never reaches Directus, and 'invalid' means the same thing on both routes.
+    if (typeof token !== 'string' || token.length === 0) {
+        return 'invalid'
+    }
+
+    const directus = useAuthenticatedDirectus()
+    const subscriber = await directus.readNewsletterSubscriberByUnsubscribeToken(token)
+
+    // Unknown token → neutral, no detail.
+    if (!subscriber) {
+        return 'invalid'
+    }
+
+    // Already opted out → idempotent success (handles link re-clicks and mail
+    // clients that follow links more than once).
+    if (subscriber.status === 'unsubscribed') {
+        return 'already_unsubscribed'
+    }
+
+    // Conditional on the state read above, so a concurrent request can't be
+    // overwritten; when it reports no change we answer from the row's current
+    // state — see the note on the guards in authenticatedDirectus.ts.
+    const unsubscribed = await directus.unsubscribeNewsletterSubscriber(subscriber.id, token)
+    if (unsubscribed) {
+        return 'unsubscribed'
+    }
+
+    const current = await directus.readNewsletterSubscriberByUnsubscribeToken(token)
+    return current?.status === 'unsubscribed' ? 'already_unsubscribed' : 'invalid'
+}

--- a/nuxt-app/test/newsletter-confirm.form.test.ts
+++ b/nuxt-app/test/newsletter-confirm.form.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import handler from '../server/routes/newsletter/confirm.post'
+
+// The no-JS confirmation path: a plain form POST, answered with a redirect that
+// carries the outcome so the page can render it server-side.
+//
+// The handler's Nuxt/Nitro auto-imports must exist BEFORE the module is imported
+// (the `export default defineEventHandler(...)` runs at load time). vitest hoists
+// this vi.hoisted() block above all imports, so these globals are set when that
+// module evaluates.
+const { readNewsletterSubscriberByToken, confirmNewsletterSubscriber, refreshNewsletterConfirmation, sendRedirect } =
+    vi.hoisted(() => {
+        const readNewsletterSubscriberByToken = vi.fn()
+        const confirmNewsletterSubscriber = vi.fn()
+        const refreshNewsletterConfirmation = vi.fn()
+        // Record what the handler redirects to instead of touching a response.
+        const sendRedirect = vi.fn(async (_event: any, location: string, status?: number) => ({ location, status }))
+        const g = globalThis as any
+        g.defineEventHandler = (fn: any) => fn
+        g.readBody = async (event: any) => event.body ?? {}
+        g.sendRedirect = sendRedirect
+        g.useAuthenticatedDirectus = () => ({
+            readNewsletterSubscriberByToken,
+            confirmNewsletterSubscriber,
+            refreshNewsletterConfirmation,
+        })
+        return {
+            readNewsletterSubscriberByToken,
+            confirmNewsletterSubscriber,
+            refreshNewsletterConfirmation,
+            sendRedirect,
+        }
+    })
+
+const invoke = (body: Record<string, unknown>) => (handler as any)({ body })
+
+const inOneHour = new Date(Date.now() + 60 * 60 * 1000).toISOString()
+const anHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString()
+
+beforeEach(() => {
+    readNewsletterSubscriberByToken.mockReset()
+    // The guarded writes report whether a row actually changed; default to "won
+    // the race" so only the concurrency cases opt into `false`.
+    confirmNewsletterSubscriber.mockReset().mockResolvedValue(true)
+    refreshNewsletterConfirmation.mockReset().mockResolvedValue(true)
+    sendRedirect.mockClear()
+})
+
+afterEach(() => {
+    vi.restoreAllMocks()
+})
+
+const expectRedirect = (status: string) =>
+    expect(sendRedirect).toHaveBeenCalledWith(expect.anything(), `/newsletter/confirm?status=${status}`, 303)
+
+describe('POST /newsletter/confirm (no-JS form)', () => {
+    // 303 specifically: the browser must follow up with a GET, so a reload cannot
+    // repeat the submission — which on an expired link would rotate the token a
+    // second time and send another mail.
+    it('confirms a pending subscriber and redirects with the outcome', async () => {
+        readNewsletterSubscriberByToken.mockResolvedValue({
+            id: 'sub_1',
+            status: 'pending',
+            confirm_token_expires_at: inOneHour,
+        })
+
+        await invoke({ token: 'good' })
+
+        expect(confirmNewsletterSubscriber).toHaveBeenCalledWith('sub_1', 'good')
+        expectRedirect('confirmed')
+    })
+
+    it('reports an already-confirmed address without re-writing it', async () => {
+        readNewsletterSubscriberByToken.mockResolvedValue({ id: 'sub_1', status: 'confirmed' })
+
+        await invoke({ token: 'good' })
+
+        expect(confirmNewsletterSubscriber).not.toHaveBeenCalled()
+        expectRedirect('already_confirmed')
+    })
+
+    it('refreshes an expired link and reports the resend', async () => {
+        readNewsletterSubscriberByToken.mockResolvedValue({
+            id: 'sub_1',
+            status: 'pending',
+            confirm_token_expires_at: anHourAgo,
+        })
+
+        await invoke({ token: 'stale' })
+
+        expect(refreshNewsletterConfirmation).toHaveBeenCalledWith('sub_1', 'stale')
+        expect(confirmNewsletterSubscriber).not.toHaveBeenCalled()
+        expectRedirect('resent')
+    })
+
+    it('reports an unknown token as invalid', async () => {
+        readNewsletterSubscriberByToken.mockResolvedValue(null)
+
+        await invoke({ token: 'nope' })
+
+        expectRedirect('invalid')
+    })
+
+    it('reports a missing token as invalid, without touching Directus', async () => {
+        await invoke({})
+
+        expect(readNewsletterSubscriberByToken).not.toHaveBeenCalled()
+        expectRedirect('invalid')
+    })
+
+    // A technical failure must not leave the visitor on a dead page: the 'error'
+    // view renders another submit button, which works without JS too.
+    it('redirects to the error state when Directus fails, rather than throwing', async () => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        readNewsletterSubscriberByToken.mockRejectedValue(new Error('directus down'))
+
+        await invoke({ token: 'boom' })
+
+        expectRedirect('error')
+    })
+})

--- a/nuxt-app/test/newsletter-subscribe.route.test.ts
+++ b/nuxt-app/test/newsletter-subscribe.route.test.ts
@@ -5,14 +5,15 @@ import handler, { isDuplicateError } from '../server/api/newsletter/subscribe.po
 // imported, because `export default defineEventHandler(...)` runs at load time.
 // vitest hoists this vi.hoisted() block above all imports (including the
 // handler import above), so these globals are set when that module evaluates.
-const { createNewsletterSubscriber } = vi.hoisted(() => {
+const { createNewsletterSubscriber, resubscribeNewsletterSubscriber } = vi.hoisted(() => {
     const createNewsletterSubscriber = vi.fn()
+    const resubscribeNewsletterSubscriber = vi.fn()
     const g = globalThis as any
     g.defineEventHandler = (fn: any) => fn
     g.readBody = async (event: any) => event.body
     g.createError = (input: any) => Object.assign(new Error(input.message), input)
-    g.useAuthenticatedDirectus = () => ({ createNewsletterSubscriber })
-    return { createNewsletterSubscriber }
+    g.useAuthenticatedDirectus = () => ({ createNewsletterSubscriber, resubscribeNewsletterSubscriber })
+    return { createNewsletterSubscriber, resubscribeNewsletterSubscriber }
 })
 
 // Invoke the real handler with a mock H3 event (readBody reads event.body).
@@ -22,6 +23,7 @@ const recordNotUnique = { errors: [{ extensions: { code: 'RECORD_NOT_UNIQUE' } }
 
 beforeEach(() => {
     createNewsletterSubscriber.mockReset()
+    resubscribeNewsletterSubscriber.mockReset().mockResolvedValue(false)
 })
 
 // Restore any spies (e.g. the console.error stub below) so they don't leak
@@ -60,6 +62,31 @@ describe('POST /api/newsletter/subscribe', () => {
     // endpoint can't be used for email enumeration.
     it('returns success (not "exists", not an error) for a duplicate address', async () => {
         createNewsletterSubscriber.mockRejectedValue(recordNotUnique)
+        const result = await invoke({ email: 'duplicate@example.com' })
+        expect(result).toEqual({ status: 'success' })
+    })
+
+    // Opting out must not be a one-way door: the row already exists, so a later
+    // signup lands in the duplicate branch and would otherwise do nothing.
+    it('reactivates a previously unsubscribed address on a repeat signup', async () => {
+        createNewsletterSubscriber.mockRejectedValue(recordNotUnique)
+        resubscribeNewsletterSubscriber.mockResolvedValue(true)
+
+        const result = await invoke({ email: '  Comeback@Example.DE ' })
+
+        expect(result).toEqual({ status: 'success' })
+        // Normalised, and guarded CMS-side on status = unsubscribed, so a live
+        // subscription can't be reset by someone entering a known address.
+        expect(resubscribeNewsletterSubscriber).toHaveBeenCalledWith('comeback@example.de')
+    })
+
+    it('still returns success when the reactivation itself fails', async () => {
+        // A 500 here would fire only for addresses that already exist, which
+        // would turn the duplicate branch into an enumeration oracle.
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        createNewsletterSubscriber.mockRejectedValue(recordNotUnique)
+        resubscribeNewsletterSubscriber.mockRejectedValue(new Error('directus down'))
+
         const result = await invoke({ email: 'duplicate@example.com' })
         expect(result).toEqual({ status: 'success' })
     })

--- a/nuxt-app/test/newsletter-unsubscribe.form.test.ts
+++ b/nuxt-app/test/newsletter-unsubscribe.form.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import handler from '../server/routes/newsletter/unsubscribe.post'
+
+// The no-JS opt-out path: a plain form POST, answered with a redirect that
+// carries the outcome so the page can render it server-side.
+//
+// The handler's Nuxt/Nitro auto-imports must exist BEFORE the module is imported
+// (the `export default defineEventHandler(...)` runs at load time). vitest hoists
+// this vi.hoisted() block above all imports, so these globals are set when that
+// module evaluates.
+const { readNewsletterSubscriberByUnsubscribeToken, unsubscribeNewsletterSubscriber, sendRedirect } = vi.hoisted(() => {
+    const readNewsletterSubscriberByUnsubscribeToken = vi.fn()
+    const unsubscribeNewsletterSubscriber = vi.fn()
+    // Record what the handler redirects to instead of touching a response.
+    const sendRedirect = vi.fn(async (_event: any, location: string, status?: number) => ({ location, status }))
+    const g = globalThis as any
+    g.defineEventHandler = (fn: any) => fn
+    g.readBody = async (event: any) => event.body ?? {}
+    g.sendRedirect = sendRedirect
+    g.useAuthenticatedDirectus = () => ({
+        readNewsletterSubscriberByUnsubscribeToken,
+        unsubscribeNewsletterSubscriber,
+    })
+    return { readNewsletterSubscriberByUnsubscribeToken, unsubscribeNewsletterSubscriber, sendRedirect }
+})
+
+const invoke = (body: Record<string, unknown>) => (handler as any)({ body })
+
+beforeEach(() => {
+    readNewsletterSubscriberByUnsubscribeToken.mockReset()
+    unsubscribeNewsletterSubscriber.mockReset().mockResolvedValue(true)
+    sendRedirect.mockClear()
+})
+
+afterEach(() => {
+    vi.restoreAllMocks()
+})
+
+describe('POST /newsletter/unsubscribe (no-JS form)', () => {
+    // 303 specifically: the browser must follow up with a GET, so a reload of
+    // the result page cannot repeat the submission.
+    it('opts the subscriber out and redirects with the outcome', async () => {
+        readNewsletterSubscriberByUnsubscribeToken.mockResolvedValue({ id: 'sub_1', status: 'confirmed' })
+
+        await invoke({ token: 'good' })
+
+        expect(unsubscribeNewsletterSubscriber).toHaveBeenCalledWith('sub_1', 'good')
+        expect(sendRedirect).toHaveBeenCalledWith(expect.anything(), '/newsletter/unsubscribe?status=unsubscribed', 303)
+    })
+
+    it('reports an already-unsubscribed address without re-writing it', async () => {
+        readNewsletterSubscriberByUnsubscribeToken.mockResolvedValue({ id: 'sub_1', status: 'unsubscribed' })
+
+        await invoke({ token: 'good' })
+
+        expect(unsubscribeNewsletterSubscriber).not.toHaveBeenCalled()
+        expect(sendRedirect).toHaveBeenCalledWith(
+            expect.anything(),
+            '/newsletter/unsubscribe?status=already_unsubscribed',
+            303
+        )
+    })
+
+    it('reports an unknown token as invalid', async () => {
+        readNewsletterSubscriberByUnsubscribeToken.mockResolvedValue(null)
+
+        await invoke({ token: 'nope' })
+
+        expect(sendRedirect).toHaveBeenCalledWith(expect.anything(), '/newsletter/unsubscribe?status=invalid', 303)
+    })
+
+    it('reports a missing token as invalid, without touching Directus', async () => {
+        await invoke({})
+
+        expect(readNewsletterSubscriberByUnsubscribeToken).not.toHaveBeenCalled()
+        expect(sendRedirect).toHaveBeenCalledWith(expect.anything(), '/newsletter/unsubscribe?status=invalid', 303)
+    })
+
+    // A technical failure must not leave the visitor on a dead page: the 'error'
+    // view renders another submit button, which works without JS too.
+    it('redirects to the error state when Directus fails, rather than throwing', async () => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        readNewsletterSubscriberByUnsubscribeToken.mockRejectedValue(new Error('directus down'))
+
+        await invoke({ token: 'boom' })
+
+        expect(sendRedirect).toHaveBeenCalledWith(expect.anything(), '/newsletter/unsubscribe?status=error', 303)
+    })
+})

--- a/nuxt-app/test/newsletter-unsubscribe.route.test.ts
+++ b/nuxt-app/test/newsletter-unsubscribe.route.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import handler from '../server/api/newsletter/unsubscribe.post'
+
+// The handler's Nuxt/Nitro auto-imports must exist BEFORE the module is
+// imported (the `export default defineEventHandler(...)` runs at load time).
+// vitest hoists this vi.hoisted() block above all imports (including the
+// handler import above), so these globals are set when that module evaluates.
+const { readNewsletterSubscriberByUnsubscribeToken, unsubscribeNewsletterSubscriber } = vi.hoisted(() => {
+    const readNewsletterSubscriberByUnsubscribeToken = vi.fn()
+    const unsubscribeNewsletterSubscriber = vi.fn()
+    const g = globalThis as any
+    g.defineEventHandler = (fn: any) => fn
+    g.readBody = async (event: any) => event.body ?? {}
+    g.createError = (input: any) => Object.assign(new Error(input.message), input)
+    g.useAuthenticatedDirectus = () => ({
+        readNewsletterSubscriberByUnsubscribeToken,
+        unsubscribeNewsletterSubscriber,
+    })
+    return { readNewsletterSubscriberByUnsubscribeToken, unsubscribeNewsletterSubscriber }
+})
+
+// Invoke the real handler with a mock H3 event (readBody reads event.body).
+const invoke = (body: Record<string, unknown>) => (handler as any)({ body })
+
+beforeEach(() => {
+    readNewsletterSubscriberByUnsubscribeToken.mockReset()
+    // The guarded write reports whether a row actually changed; default to "won
+    // the race", so only the concurrency case below opts into `false`.
+    unsubscribeNewsletterSubscriber.mockReset().mockResolvedValue(true)
+})
+
+afterEach(() => {
+    vi.restoreAllMocks()
+})
+
+describe('POST /api/newsletter/unsubscribe', () => {
+    it('returns invalid for a missing token, without touching Directus', async () => {
+        const result = await invoke({})
+        expect(result).toEqual({ status: 'invalid' })
+        expect(readNewsletterSubscriberByUnsubscribeToken).not.toHaveBeenCalled()
+    })
+
+    it('returns invalid for an empty token', async () => {
+        const result = await invoke({ token: '' })
+        expect(result).toEqual({ status: 'invalid' })
+        expect(readNewsletterSubscriberByUnsubscribeToken).not.toHaveBeenCalled()
+    })
+
+    it('returns invalid for an unknown token', async () => {
+        readNewsletterSubscriberByUnsubscribeToken.mockResolvedValue(null)
+        const result = await invoke({ token: 'nope' })
+        expect(result).toEqual({ status: 'invalid' })
+        expect(unsubscribeNewsletterSubscriber).not.toHaveBeenCalled()
+    })
+
+    it('unsubscribes a confirmed subscriber', async () => {
+        readNewsletterSubscriberByUnsubscribeToken.mockResolvedValue({ id: 'sub_1', status: 'confirmed' })
+        const result = await invoke({ token: 'good' })
+        expect(result).toEqual({ status: 'unsubscribed' })
+        expect(unsubscribeNewsletterSubscriber).toHaveBeenCalledTimes(1)
+        // The token is passed along so the write can be guarded on it.
+        expect(unsubscribeNewsletterSubscriber).toHaveBeenCalledWith('sub_1', 'good')
+    })
+
+    it('unsubscribes a pending subscriber that never confirmed', async () => {
+        // Opting out has to work before confirmation too — it also stops the
+        // confirmation resends.
+        readNewsletterSubscriberByUnsubscribeToken.mockResolvedValue({ id: 'sub_1', status: 'pending' })
+        const result = await invoke({ token: 'good' })
+        expect(result).toEqual({ status: 'unsubscribed' })
+        expect(unsubscribeNewsletterSubscriber).toHaveBeenCalledTimes(1)
+    })
+
+    it('is idempotent: an already-unsubscribed subscriber is not re-written', async () => {
+        readNewsletterSubscriberByUnsubscribeToken.mockResolvedValue({
+            id: 'sub_1',
+            status: 'unsubscribed',
+            unsubscribed_at: '2026-01-01T00:00:00.000Z',
+        })
+        const result = await invoke({ token: 'good' })
+        expect(result).toEqual({ status: 'already_unsubscribed' })
+        // Keeps the original opt-out timestamp instead of pushing it forward.
+        expect(unsubscribeNewsletterSubscriber).not.toHaveBeenCalled()
+    })
+
+    it('reports already_unsubscribed when a concurrent request got there first', async () => {
+        readNewsletterSubscriberByUnsubscribeToken
+            .mockResolvedValueOnce({ id: 'sub_1', status: 'confirmed' })
+            .mockResolvedValueOnce({ id: 'sub_1', status: 'unsubscribed' })
+        unsubscribeNewsletterSubscriber.mockResolvedValue(false)
+
+        const result = await invoke({ token: 'good' })
+        expect(result).toEqual({ status: 'already_unsubscribed' })
+    })
+
+    it('surfaces an unexpected Directus failure as 500', async () => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        readNewsletterSubscriberByUnsubscribeToken.mockRejectedValue(new Error('directus down'))
+        await expect(invoke({ token: 'boom' })).rejects.toMatchObject({ statusCode: 500 })
+    })
+})


### PR DESCRIPTION
Adds the opt-out half of the newsletter flow. Follow-up to #219, which shipped signup + double-opt-in confirmation.

## What's in it

**Unsubscribe** — `POST /api/newsletter/unsubscribe` + `pages/newsletter/unsubscribe.vue`.

The link carries the permanent **`unsubscribe_token`**, not the confirm token: it never expires and stays valid after confirmation, because an unsubscribe link has to keep working for the life of the subscription.

| Situation | Result | Page state |
| --- | --- | --- |
| any status except `unsubscribed` | `status = unsubscribed`, `unsubscribed_at` | `unsubscribed` |
| already `unsubscribed` | no-op (idempotent) | `already_unsubscribed` |
| unknown token | no-op | `invalid` |
| Directus down / misconfigured (500) | no-op | `error` (retry) |

Opting out works from `pending` too — someone who never confirmed can still say no, and it also stops the confirmation resends. The write is guarded on the token and on not-already-unsubscribed (same pattern as the confirm writes), so `unsubscribed_at` keeps the timestamp of the *first* opt-out instead of being pushed forward by every re-click.

**Re-signup after opt-out** — adding unsubscribe made opting out a one-way door: the row still exists, so every later signup hit the duplicate branch and silently did nothing. A repeat signup for an `unsubscribed` address now reactivates it (back to `pending` + fresh `confirm_token`), which makes the CMS send a new confirmation mail — consent is re-obtained, never inherited from the old signup. Guarded on `status = unsubscribed` so a live subscription can't be reset, and failures are logged-and-swallowed because a 500 firing only for existing addresses would be an enumeration oracle.

**`unsubscribe_url` in the DOI template** — the CMS hook now passes it alongside `confirm_url`. This is the variable that was missing when the template used `{{url_unsubscribe}}`; the real name is `{{unsubscribe_url}}`. Optional in the DOI mail itself (nothing is subscribed yet), but the token is permanent, so the same link can be reused verbatim in newsletter issues, where an unsubscribe link is mandatory.

## Shared extraction rather than a second page

`unsubscribe.vue` is not a copy of `confirm.vue`. The shared parts came out first:

- **`composables/useNewsletterTokenAction.ts`** — the flow: read `?token=`, post it **client-side only** (`onMounted`, never during SSR — that is what keeps email scanners and prefetchers from confirming or unsubscribing on the recipient's behalf), map the result onto a status, handle the `?preview=` override and retry.
- **`components/NewsletterStatusPanel.vue`** — the result page: spotlights, status icon, eyebrow, headline, copy, CTA and the non-prod state switcher.

`confirm.vue` drops from 221 to ~85 lines; both pages are now just a copy map. The consent property lives in the composable, so it is implemented once instead of twice.

## Verification

- Nuxt vitest **37/37** (9 new), CMS jest **14/14**, ESLint + Prettier clean, no typecheck errors in the touched files, extension bundle builds.
- Against a dev server: all five unsubscribe preview states render, status icon exactly centred, preview switcher and retry button both work (retry round-trips to the endpoint and flips the view), and `?token=` SSR renders only the loading state with **no** server-side API call — confirm still does all of the same after the refactor.
- **Not verified locally:** anything that actually talks to Directus. There is no `NUXT_DIRECTUS_API_TOKEN` in the local `.env`, so a real token walk through unsubscribe needs the preview deployment.

## Deploy dependencies (not shipped by Vercel)

- **Redeploy the Directus extension bundle** — required for `unsubscribe_url` to reach the template.
- Add `{{unsubscribe_url}}` to the `newsletter_double_opt_in` template if the mail should carry the opt-out link.
- The API token's role needs update permission on `newsletter_subscribers` for the unsubscribe and reactivation writes.

## Notes for review

- `invalid` links point at `/kontakt` rather than the homepage — a dead unsubscribe link is the one case where someone actively needs to reach us.
- The residual read-to-write window from #219 applies to the new guarded write as well: a filtered `updateItems` is not an atomic compare-and-swap in Directus. Documented at both call sites and on #215.
- No `List-Unsubscribe` / RFC 8058 one-click headers here — that is a mail-header concern for whatever sends the actual issues, and would want its own no-confirmation POST endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G87EXbthS28Q7GCbTWqad7
