### PR TITLE
Fix podcast player ignoring the start timestamp

### DIFF
--- a/nuxt-app/components/PodcastTranscript.vue
+++ b/nuxt-app/components/PodcastTranscript.vue
@@ -61,9 +61,13 @@ export default defineComponent({
 
     function playPodcastAtTimestamp(timestamp: number) {
       if (podcastPlayer.podcast?.id !== props.podcast.id) {
-        podcastPlayer.setPodcast(props.podcast);
+        // Loading a new episode: hand the offset to `setPodcast`, which applies
+        // it once metadata is available. Seeking right after the src is set
+        // would be reset to 0 by the browser.
+        podcastPlayer.setPodcast(props.podcast, { startAt: timestamp });
+      } else {
+        podcastPlayer.setCurrentTime(timestamp);
       }
-      podcastPlayer.setCurrentTime(timestamp);
       podcastPlayer.play();
     }
 

--- a/nuxt-app/composables/usePodcastPlayer.ts
+++ b/nuxt-app/composables/usePodcastPlayer.ts
@@ -1,4 +1,4 @@
-import { onMounted, reactive, ref, toRefs, watch } from 'vue'
+import { onMounted, reactive, ref, shallowRef, toRefs, watch } from 'vue'
 import { PAUSE_PODCAST_EVENT_ID, PLAY_PODCAST_EVENT_ID } from '../config'
 import { trackGoal } from '../helpers'
 import type { PodcastItem } from '../types'
@@ -14,7 +14,12 @@ export type PodcastPlayerSourceFactory = (callbacks: SourceCallbacks) => MediaSo
 
 const podcast = ref<PodcastBasics>()
 const audioElement = ref<HTMLAudioElement>()
-const activeSource = ref<MediaSource | null>(null)
+// shallowRef, not ref: a deep ref stores objects as a reactive proxy, so
+// `activeSource.value === source` would never hold for the raw source we just
+// assigned — silently breaking the "did the user switch episodes while the
+// audio element was still loading?" guards below. The source is a bag of
+// methods with no state of its own, so there is nothing to make reactive.
+const activeSource = shallowRef<MediaSource | null>(null)
 const audioState = reactive({
     volume: 1,
     currentTime: 0,
@@ -225,6 +230,10 @@ export function usePodcastPlayer() {
         source.setVolume(audioState.volume)
 
         const applySeek = () => {
+            // Bail if something re-bound the bar (another episode, or the video
+            // player re-attaching) before metadata loaded, so we don't seek or
+            // report a position that belongs to the previous source.
+            if (activeSource.value !== source) return
             try {
                 audio.currentTime = options.seekTime
             } catch {
@@ -240,7 +249,10 @@ export function usePodcastPlayer() {
         }
 
         if (options.autoplay) {
-            const startPlayback = () => source.play()
+            const startPlayback = () => {
+                if (activeSource.value !== source) return
+                source.play()
+            }
             if (audio.readyState >= 3 /* HAVE_FUTURE_DATA */) {
                 startPlayback()
             } else {

--- a/nuxt-app/test/podcastPlayerStartAt.test.ts
+++ b/nuxt-app/test/podcastPlayerStartAt.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRenderer, defineComponent, h } from 'vue'
+import type { usePodcastPlayer } from '../composables/usePodcastPlayer'
+
+type UsePodcastPlayer = typeof usePodcastPlayer
+type PodcastPlayer = ReturnType<UsePodcastPlayer>
+type PodcastArg = Parameters<PodcastPlayer['setPodcast']>[0]
+
+// The composable tracks Fathom goals on play/pause; stub the helper barrel so
+// importing it doesn't pull in Nuxt-only modules.
+vi.mock('../helpers', () => ({ trackGoal: vi.fn() }))
+
+/**
+ * Minimal stand-in for the global HTMLAudioElement the player creates. Mirrors
+ * the parts of the media element the composable touches, including the browser
+ * behaviour that matters here: assigning `src` resets `readyState`/`currentTime`,
+ * so a seek only sticks once metadata has arrived.
+ */
+class FakeAudio extends EventTarget {
+    currentTime = 0
+    duration = NaN
+    volume = 1
+    readyState = 0
+    paused = true
+    #src = ''
+
+    get src() {
+        return this.#src
+    }
+
+    set src(value: string) {
+        this.#src = value
+        this.readyState = 0
+        this.currentTime = 0
+        this.duration = NaN
+    }
+
+    play() {
+        this.paused = false
+        this.dispatchEvent(new Event('play'))
+        return Promise.resolve()
+    }
+
+    pause() {
+        this.paused = true
+        this.dispatchEvent(new Event('pause'))
+    }
+
+    /** Simulate the browser finishing the metadata fetch for the current src. */
+    loadMetadata(duration = 3600) {
+        this.readyState = 1
+        this.duration = duration
+        this.dispatchEvent(new Event('loadedmetadata'))
+    }
+}
+
+/**
+ * The composable creates its audio element in `onMounted`, so it needs a real
+ * component instance. Mount one through a no-op renderer: that gives us the
+ * mounted lifecycle without needing a DOM, keeping these tests in the suite's
+ * plain-node environment.
+ */
+function mountWithPlayer(usePlayer: UsePodcastPlayer) {
+    let player!: PodcastPlayer
+    const noop = () => {}
+    const { createApp } = createRenderer({
+        createElement: () => ({}) as never,
+        createText: () => ({}) as never,
+        setElementText: noop,
+        insert: noop,
+        remove: noop,
+        patchProp: noop,
+        parentNode: () => null,
+        nextSibling: () => null,
+        setText: noop,
+    })
+    createApp(
+        defineComponent({
+            setup() {
+                player = usePlayer()
+                return () => h('div')
+            },
+        })
+    ).mount({} as never)
+    return player
+}
+
+const EPISODE = {
+    id: 1,
+    slug: 'deep-dive-142',
+    type: 'deep_dive',
+    number: '142',
+    title: 'Test-Episode',
+    audio_url: 'https://example.com/142.mp3',
+} as PodcastArg
+
+const OTHER_EPISODE = { ...EPISODE, id: 2, audio_url: 'https://example.com/143.mp3' }
+
+let audio: FakeAudio
+let player: PodcastPlayer
+
+beforeEach(async () => {
+    audio = new FakeAudio()
+    vi.stubGlobal('document', { createElement: () => audio })
+    // The composable holds module-level state (one player per app), so reset the
+    // module registry between tests to get a fresh player each time.
+    vi.resetModules()
+    const { usePodcastPlayer } = await import('../composables/usePodcastPlayer')
+    player = mountWithPlayer(usePodcastPlayer)
+})
+
+describe('usePodcastPlayer startAt', () => {
+    it('seeks to the offset once metadata arrives (news reference play button)', () => {
+        player.setPodcast(EPISODE, { startAt: 600 })
+        player.play()
+
+        // Nothing to seek yet — the browser has not loaded metadata.
+        expect(audio.currentTime).toBe(0)
+
+        audio.loadMetadata()
+
+        expect(audio.currentTime).toBe(600)
+        expect(player.currentTime).toBe(600)
+    })
+
+    it('applies the offset when the already-loaded episode is re-loaded with one', () => {
+        player.setPodcast(EPISODE)
+        audio.loadMetadata()
+
+        player.setPodcast(EPISODE, { startAt: 90 })
+        // `setPodcast` always re-assigns src, which resets readyState — so even
+        // for the same episode the seek waits for metadata again.
+        audio.loadMetadata()
+
+        expect(audio.currentTime).toBe(90)
+    })
+
+    it('does not seek when no offset is given', () => {
+        player.setPodcast(EPISODE)
+        audio.loadMetadata()
+
+        expect(audio.currentTime).toBe(0)
+    })
+
+    it('drops a pending seek when another episode is loaded before metadata', () => {
+        player.setPodcast(EPISODE, { startAt: 600 })
+        player.setPodcast(OTHER_EPISODE)
+
+        audio.loadMetadata()
+
+        // The first episode's offset must not leak into the newly loaded one.
+        expect(audio.currentTime).toBe(0)
+        expect(player.podcast?.id).toBe(OTHER_EPISODE.id)
+    })
+})

--- a/nuxt-app/test/podcastPlayerStartAt.test.ts
+++ b/nuxt-app/test/podcastPlayerStartAt.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createRenderer, defineComponent, h } from 'vue'
 import type { usePodcastPlayer } from '../composables/usePodcastPlayer'
 
@@ -107,6 +107,13 @@ beforeEach(async () => {
     vi.resetModules()
     const { usePodcastPlayer } = await import('../composables/usePodcastPlayer')
     player = mountWithPlayer(usePodcastPlayer)
+})
+
+afterEach(() => {
+    // These tests run in the suite's `node` environment, where there is no
+    // `document`. Drop the stub again so we don't leave a browser-looking global
+    // behind for anything that checks `typeof document`.
+    vi.unstubAllGlobals()
 })
 
 describe('usePodcastPlayer startAt', () => {


### PR DESCRIPTION
## Problem

Hitting play on the podcast reference in a news item (`NewsPodcastReference.vue`) starts the episode from the beginning instead of the referenced timestamp. Regression from ce73fa2.

## Cause

`setPodcast`'s `startAt` seek is applied on `loadedmetadata` (setting `currentTime` before metadata is loaded gets reset to 0 by the browser) and guarded so a quick episode switch can't seek the wrong source:

```ts
if (activeSource.value !== source) return
```

`activeSource` was a deep `ref`. Vue runs objects assigned to a deep ref through `toReactive()`, so `activeSource.value` hands back a **reactive Proxy** — never the raw `source` that was just assigned. The guard was therefore always true and swallowed every seek. Verified against the repo's Vue:

```
ref identity preserved: false
shallowRef identity preserved: true
```

Only the audio-element + `startAt` path was affected, which is why this looked news-specific: the `sourceFactory` branch (YouTube) seeks the raw object directly, and `switchToAudioElement` had no guard at all.

## Changes

- **`usePodcastPlayer.ts`** — `activeSource` becomes a `shallowRef`. Identity is preserved, and the source is a bag of methods with no state of its own, so deep reactivity bought nothing.
- **`usePodcastPlayer.ts`** — apply the same guard in `switchToAudioElement`, where a pending seek (and the autoplay `canplay` handler) could act on a source that had already been replaced. Latent, pre-existing.
- **`PodcastTranscript.vue`** — use `startAt` when clicking a word loads a *different* episode, instead of `setPodcast` + immediate `setCurrentTime`, which hit the same reset-to-0 race. Seeking within the already-loaded episode still uses `setCurrentTime`.
- **`test/podcastPlayerStartAt.test.ts`** — new regression test driving the real composable against a fake audio element that models the `src` → `readyState`/`currentTime` reset. Stays in the suite's plain-node environment (no new dev dependencies) by mounting through a no-op renderer.

`PodcastBanner.vue` also calls `setPodcast` but never seeks, so it needed no change.

## Verification

- The two seek assertions fail on the pre-fix code with exactly the reported symptom (`expected +0 to be 600`) and pass with it.
- Full suite: 31 passed.
- eslint clean on the changed TS/test files. Formatting left alone in the two touched files — both were already prettier-non-compliant on `main`, so reformatting would have buried the fix in churn.

Worth a manual smoke test of the news reference play button, the transcript word-click, and the video → audio-bar handoff before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177u9R7dV8baNUL458gDmfz