### PR TITLE
Phase 5 (4/7): Zod 3 → 4, dropping h3-zod

### DIFF
--- a/docs/dependency-upgrade-plan.md
+++ b/docs/dependency-upgrade-plan.md
@@ -719,6 +719,10 @@ time-unconstrained, but Stripe touches the payment path and may want a second pa
 colleague, so it should not be the thing blocking the rest. Remaining order: `@directus/sdk`,
 `isomorphic-dompurify`, then `stripe`.
 
+When the last of those lands, do the
+[comment audit](#comment-audit-across-the-upgrade-series--do-this-when-phase-5-completes) before
+starting Phase 6.
+
 ### `nodemailer` 8.0.11 → 9.0.3
 
 **The audit backlog is now empty:** `found 0 vulnerabilities`, down from 49 distinct root advisories
@@ -1250,6 +1254,53 @@ browser-support decision nobody made.
   to do now; worth remembering when Nuxt 5 appears, since Nuxt 3's EOL is the precedent for how
   quickly that becomes urgent.
 
+### Comment audit across the upgrade series — do this when Phase 5 completes
+
+**Scheduled deliberately: after Phase 5, before Phase 6.** Agreed with the maintainer 2026-08-03,
+prompted by a review comment on #233 that flagged a code comment as pull-request rationale. It was
+right, and the same habit runs through the whole series, so this is a series-wide pass rather than a
+one-file fix.
+
+**The test a comment has to pass:** *would someone who has never heard of the pull request still need
+this sentence?*
+
+That splits cleanly:
+
+| verdict | what it looks like | where it belongs |
+| --- | --- | --- |
+| **Keep** | A standing constraint someone would otherwise violate — "this looks removable but is not, because X" | In the file. The failure mode is a future reader deleting it, so it has to be where they are. |
+| **Cut** | Changelog — "X replaced Y", "package Z was unmaintained", "verified identical to before" | The PR and commit message. Written for an audience that reads the file once and never returns. |
+| **Cut** | Measurement narrative — "6 workers produced 6 failures", "1.3–1.6s versus 2.8–8.7s", "my first attempt was wrong" | **This document.** It is genuinely worth keeping; it is just not worth keeping *there*. |
+
+**The honest diagnosis**, in the maintainer's framing: these comments were treating code as a place to
+prove the work was done, which is the wrong audience.
+
+**Explicit non-goal: this is not "fewer comments everywhere".** Some of the longest blocks are
+load-bearing *precisely because* they sit on unusual-looking config that a tidy-minded reader would
+delete. Those keep **a one-line reason plus a removal condition** in the file, with the full reasoning
+moved here:
+
+- `nitro.externals.inline: ['pinia']` — delete it and production 500s on every route, but only under
+  `NODE_ENV=production`, so nothing in the PR gate catches it.
+- `vite.build.cssMinify: 'esbuild'` — delete it and lightningcss silently narrows browser support to
+  Safari 16.4+.
+- `tailwind.config.js` `container.screens` listing only `2xl` — re-add the `100%` entries and the
+  build fails on invalid CSS.
+
+Measured scope as of 2026-08-03 — **255 lines** in blocks of three or more comment lines:
+
+| file | blocks | lines | largest |
+| --- | --- | --- | --- |
+| `nuxt.config.ts` | 10 | **99** | 42 |
+| `eslint.config.mjs` | 5 | 45 | 14 |
+| `playwright.config.ts` | 3 | 37 | 18 |
+| `scripts/typecheck-ratchet.mjs` | 4 | 34 | 16 |
+| `tests-smoke/routes.smoke.ts` | 5 | 26 | 8 |
+| `tailwind.config.js` | 2 | 14 | 11 |
+
+Do it as **its own PR**. It touches files from five merged phases, and folding it into a dependency
+upgrade would mean a reviewer cannot tell the upgrade from the prose edit.
+
 ### Waiting on upstream: the Pinia 4 export map
 
 **Status as of 2026-08-03: not fixed, and no upstream issue exists.** `pinia@4.0.2` is the newest
@@ -1428,3 +1479,4 @@ Tracked so nobody has to rediscover them. None are urgent on their own.
 | 2026-08-03 | `stripe` moved to the **end** of Phase 5 at the maintainer's request. It touches the payment path and may want a colleague's review, so it should not block the items that are genuinely time-unconstrained. |
 | 2026-08-03 | Zod 4 taken with `h3-zod` removed rather than replaced. `h3-zod` existed for one call site, was last published January 2024, pinned `zod ^3`, and peers `h3 ^1` while Nuxt 4 resolves `h3 2.x`. The six sibling routes already used `safeParse` + `createError`, so the replacement is the existing house pattern, not a new one. |
 | 2026-08-03 | Zod 4's reworded **default** messages accepted as-is. Custom German messages are unchanged; the defaults were English before and after, so this is a wording change rather than a regression. Adopting `z.locales.de()` is logged separately because it rewrites many user-facing strings. |
+| 2026-08-03 | Code comments across the series to be audited in their own PR once Phase 5 completes, against one test: *would someone who has never heard of the pull request still need this sentence?* Changelog and measurement narrative move to this document; standing constraints keep a one-line reason and a removal condition in the file. Not a push for fewer comments — the longest blocks sit on config a tidy-minded reader would delete. |

--- a/docs/dependency-upgrade-plan.md
+++ b/docs/dependency-upgrade-plan.md
@@ -35,7 +35,7 @@ each phase leaves the app in a shippable state and can be reverted on its own.
 | — | TypeScript 5.9 → 6.0.3 (interstitial, own PR) | ✅ Done (2026-07-31) |
 | 3 | `@nuxt/image-edge` → `@nuxt/image@2` | ✅ Done (2026-07-31) |
 | 4 | **Nuxt 3 → Nuxt 4** | ✅ Done (2026-08-03) |
-| 5 | Ecosystem majors (Pinia, ESLint, Zod, Directus SDK, Stripe, DOMPurify) | 🔄 In progress — 3 of 7 (`nodemailer`, Pinia, ESLint; **audit at zero**) |
+| 5 | Ecosystem majors (Pinia, ESLint, Zod, Directus SDK, Stripe, DOMPurify) | 🔄 In progress — 4 of 7 (`nodemailer`, Pinia, ESLint, Zod; **audit at zero**) |
 | 6 | Deferred: Tailwind 4, Node 24 | ⬜ Deliberately deferred |
 | — | [After the plan — follow-up backlog](#after-the-plan--follow-up-backlog) | 📋 Consolidated, unscheduled |
 
@@ -681,9 +681,7 @@ order, or in parallel by different people.
       `@nuxt/eslint-config@1.16.0` *depends* on `@eslint/js ^10.0.1`, so 10 is its primary target,
       and `@nuxt/eslint`, `@typescript-eslint` 8.65 and `eslint-plugin-vue` 10.10 all peer
       `^9 || ^10`. Choosing 9 would now be the *less* aligned option. Details below.
-- [ ] **Zod 3.25.76 → 4.x** and **drop `h3-zod`**. `h3-zod` is unmaintained (last publish January
-      2024) and expects Zod 3, so it blocks the upgrade. Only **1 usage** — replace with direct
-      `zod` parsing. Zod is imported in 4 files total.
+- [x] **Zod 3.25.76 → 4.4.3** and **dropped `h3-zod`** — ✅ done 2026-08-03. Details below.
 - [ ] **`@directus/sdk` 21.3.0 → 24.0.0.** Largest blast radius of this phase — 4 files, but one
       of them is the 884-line `useDirectus.ts`. Check the v22/23/24 changelogs for query-builder
       and type-inference changes. Requires Node `>=22` — satisfied.
@@ -704,17 +702,22 @@ order, or in parallel by different people.
       current**: Phase 2 moved `dompurify` 3.4.2 → 3.4.12 transitively and those advisories are
       gone, so this is now a staleness item rather than a security one. Reprioritise accordingly.
 
-### Progress: 3 of 7 done
+### Progress: 4 of 7 done
 
 | item | status |
 | --- | --- |
 | `nodemailer` → 9.0.3 | ✅ done 2026-08-03 — audit reached zero |
 | Pinia → 4.0.2 | ✅ done 2026-08-03 — needed a nitro workaround |
 | ESLint → **10** + flat config | ✅ done 2026-08-03 — see the version note below |
-| Zod → 4, drop `h3-zod` | ⬜ |
+| Zod → 4, drop `h3-zod` | ✅ done 2026-08-03 |
 | `@directus/sdk` → 24 | ⬜ blocked on verifying against Directus 11.x |
-| `stripe` → 22.4.0 | ⬜ |
+| `stripe` → 22.4.0 | ⬜ **deliberately last** — see sequencing note |
 | `isomorphic-dompurify` → 3.x | ⬜ no longer security-driven, see above |
+
+**Sequencing: `stripe` goes last.** Requested 2026-08-03. Everything else in this phase is
+time-unconstrained, but Stripe touches the payment path and may want a second pair of eyes from a
+colleague, so it should not be the thing blocking the rest. Remaining order: `@directus/sdk`,
+`isomorphic-dompurify`, then `stripe`.
 
 ### `nodemailer` 8.0.11 → 9.0.3
 
@@ -996,6 +999,80 @@ preview where images are cached.
 | smoke | 18/18 | 18/18 (x4) |
 | `npm audit` | 0 | 0 |
 
+### Zod 3.25.76 → 4.4.3, and `h3-zod` dropped
+
+`h3-zod` existed for **one call site** and pinned `zod ^3`, so a package last published in
+**January 2024** was holding back a major. It also peers `h3 ^1.6.0` while Nuxt 4 resolves `h3 2.x`
+for the server — already a mismatch before Zod entered the picture.
+
+That one site, `server/api/checkin/scan.post.ts`, now validates the way **its six sibling routes
+already did** — `Schema.safeParse(await readBody(event))` plus `createError({ statusCode: 400 })`. So
+this removes a dependency *and* the odd one out. Checked the client first: `pages/admin/checkin.vue`
+reads `err?.data?.message || err?.message`, which the repo pattern populates, whereas `h3-zod` put the
+whole `ZodError` in `data`.
+
+#### Validation behaviour is unchanged — measured, not assumed
+
+Zod 4 rewrote its string-format validators, and this app validates emails on the newsletter and
+contact paths, so "does it compile" was not the question. The real schemas were run against a fixed
+set of **50 inputs** on Zod 3, then again on Zod 4, and the accept/reject outcomes diffed:
+
+> **identical** — every email (including `plus+tag@`, IDN `münchen.de`, quoted local parts,
+> double-dots, `ip@[127.0.0.1]`), every URL, every UUID, plus `z.preprocess` and `.refine`.
+
+#### Five type errors, both causes real
+
+The ratchet caught 263 → 268. Both underlying changes are genuine, and both were fixed rather than
+absorbed into the baseline:
+
+- **`issue.path` is now `PropertyKey[]`** (was `(string | number)[]`), so `` `${key}` `` on a path
+  segment became `TS2731` in four routes. Zod is flagging a real hazard: converting a symbol in a
+  template literal throws at runtime. Now `String(...)`. Our schemas have no symbol keys, so this was
+  never reachable in practice — but the type is honest and the fix is free.
+- **`errorMap` was replaced by `error`** on `z.enum`, one site. Confirmed empirically that `error:`,
+  `error: () => …` and the deprecated `message:` all yield the identical string; took `error:` as the
+  current form.
+
+#### Default messages changed wording — worth knowing
+
+Custom German messages are preserved exactly. But Zod's *defaults* were reworded, and those reach
+users on fields that carry no custom message:
+
+| case | Zod 3 | Zod 4 |
+| --- | --- | --- |
+| missing required string | `Required` | `Invalid input: expected string, received undefined` |
+| `.min(1)` on `''` | `String must contain at least 1 character(s)` | `Too small: expected string to have >=1 characters` |
+| bad email | `Invalid email` | `Invalid email address` |
+| bad URL | `Invalid url` | `Invalid URL` |
+| bad enum | `Invalid enum value. Expected 'a' \| 'b', received 'z'` | `Invalid option: expected one of "a"\|"b"` |
+
+Both sets are English on a German-language site — a pre-existing wart, not a regression. Zod 4 does
+now ship locales, and `z.config(z.locales.de())` was verified to produce
+`Ungültige Eingabe: erwartet string, erhalten undefined`. That is a genuine improvement the upgrade
+unlocks, logged as a follow-up rather than taken here, since it rewrites many user-facing strings and
+deserves its own review.
+
+#### Verification
+
+Endpoints exercised against the built server, not just unit-tested: `POST /api/vote` with `{}`
+returns **400** (Zod ran), and the rewritten `POST /api/checkin/scan` returns **401** (auth correctly
+precedes validation).
+
+| gate | before | after |
+| --- | --- | --- |
+| `lint` | 0 errors, 134 warnings | 0 errors, 134 warnings |
+| `test` | 52/52 | 52/52 |
+| ratchet | 263 | 263 (268 before the two fixes) |
+| `build` | exit 0, 30.9 MB | exit 0, 31.3 MB |
+| smoke | 18/18 | 18/18 (x3) |
+| `npm audit` | 0 | 0 |
+
+Two smoke runs failed mid-verification and **neither was this change**. One was the podcast page under
+contention; the other was `/feed/news.xml` returning 500 because the **CMS returned 503** — "App
+Platform failed to forward this request". Corroborated independently: a plain health check against
+`admin.programmier.bar` returned `HTTP 000` in the same window. The feed route surfaces a CMS outage as
+a 500, which is exactly why smoke does not gate pull requests.
+
 ---
 
 ## Phase 6 — Deliberately deferred
@@ -1117,6 +1194,12 @@ browser-support decision nobody made.
 
 ### 5. Small, verified, uncontroversial
 
+- [ ] **Give Zod German default messages.** Every field with a custom message is already German, but
+      fields without one fall back to Zod's English defaults on a German-language site — a pre-existing
+      wart, though Zod 4 reworded them (`Required` → `Invalid input: expected string, received
+      undefined`). Zod 4 ships locales, and `z.config(z.locales.de())` was verified to produce
+      `Ungültige Eingabe: erwartet string, erhalten undefined`. One line, but it rewrites many
+      user-facing strings, so it wants its own review rather than riding along with an upgrade.
 - [ ] ⚠️ **`components/ConferenceTickets.vue` appears to be entirely unused.** Nothing renders it,
       and none of its three props is read inside it — `ticketsOnSale` is neither passed by any caller
       nor referenced in the component. Found while fixing a lint error in it. Either wire it up or
@@ -1260,7 +1343,7 @@ Tracked so nobody has to rediscover them. None are urgent on their own.
 | Package | Last publish | Note |
 | --- | --- | --- |
 | `@nuxt/image-edge` | Feb 2024 (nightly) | Phase 3 removes it |
-| `h3-zod` | Jan 2024 | Phase 5 removes it |
+| `h3-zod` | Jan 2024 | ✅ removed in Phase 5 (Zod 4) |
 | `eslint-plugin-nuxt` | Aug 2023 | ✅ removed in Phase 5 (ESLint 10) |
 | `@ubclaunchpad/vue-fathom` | Apr 2022 | 1 usage. Fathom's own snippet is a few lines — consider inlining and dropping the dependency. |
 | `smoothscroll-polyfill` | Aug 2022 | ✅ removed in Phase 1 |
@@ -1342,3 +1425,6 @@ Tracked so nobody has to rediscover them. None are urgent on their own.
 | 2026-08-03 | ESLint taken to **10**, not the 9 this phase originally specified. That note predated `@nuxt/eslint-config@1.16.0`, which *depends* on `@eslint/js ^10.0.1` — 10 is its primary target, and `@typescript-eslint` 8.65 and `eslint-plugin-vue` 10.10 both peer `^9 || ^10`. Picking 9 would now be the less aligned choice. TypeScript 6.0.3 sits inside `@typescript-eslint`'s `>=4.8.4 <6.1.0`. |
 | 2026-08-03 | `no-explicit-any` (103) and `no-unused-vars` (15) demoted to warnings in `eslint.config.mjs` rather than fixed or disabled. `@nuxt/eslint-config@1` is much stricter than `0.2`, and enabling it as-is turned 0 errors into 121. Fixing 103 `any`s is a typing project belonging with the vue-tsc burn-down, not a lint upgrade; demoting keeps the signal while preserving Phase 0's gate-on-errors choice. The three singleton errors were fixed rather than suppressed. |
 | 2026-08-03 | Smoke `expect.timeout` raised 15s → 30s, sized from measurement: the heaviest page reports visible text in 1.3–1.6s alone but 2.8–8.7s with six loading concurrently, and never failed to render in 12 concurrent loads. A first hypothesis (polling `innerText` forces expensive layout) was measured and disproved at 1.2ms. Raising the budget masks nothing — a page that never renders still fails. |
+| 2026-08-03 | `stripe` moved to the **end** of Phase 5 at the maintainer's request. It touches the payment path and may want a colleague's review, so it should not block the items that are genuinely time-unconstrained. |
+| 2026-08-03 | Zod 4 taken with `h3-zod` removed rather than replaced. `h3-zod` existed for one call site, was last published January 2024, pinned `zod ^3`, and peers `h3 ^1` while Nuxt 4 resolves `h3 2.x`. The six sibling routes already used `safeParse` + `createError`, so the replacement is the existing house pattern, not a new one. |
+| 2026-08-03 | Zod 4's reworded **default** messages accepted as-is. Custom German messages are unchanged; the defaults were English before and after, so this is a wording change rather than a regression. Adopting `z.locales.de()` is logged separately because it rewrites many user-facing strings. |

--- a/nuxt-app/package-lock.json
+++ b/nuxt-app/package-lock.json
@@ -15,7 +15,6 @@
                 "@pinia/nuxt": "^1.0.1",
                 "@types/google.maps": "^3.55.3",
                 "@ubclaunchpad/vue-fathom": "^2.0.0",
-                "h3-zod": "^0.5.3",
                 "html5-qrcode": "^2.3.8",
                 "isomorphic-dompurify": "~2.20.0",
                 "nodemailer": "^9.0.3",
@@ -26,7 +25,7 @@
                 "vite-svg-loader": "^5.1.0",
                 "vue-json-pretty": "^2.5.0",
                 "web-haptics": "^0.0.6",
-                "zod": "^3.22.4"
+                "zod": "^4.4.3"
             },
             "devDependencies": {
                 "@ianvs/prettier-plugin-sort-imports": "^4.1.1",
@@ -2643,16 +2642,6 @@
             },
             "peerDependencies": {
                 "zod": "^4.0.0"
-            }
-        },
-        "node_modules/@json-render/core/node_modules/zod": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-            "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/colinhacks"
             }
         },
         "node_modules/@koa/router": {
@@ -6531,16 +6520,6 @@
             },
             "engines": {
                 "node": ">=20.16.0"
-            }
-        },
-        "node_modules/@vitejs/devtools-kit/node_modules/zod": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-            "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/colinhacks"
             }
         },
         "node_modules/@vitejs/plugin-vue": {
@@ -10539,16 +10518,6 @@
                 "radix3": "^1.1.2",
                 "ufo": "^1.6.3",
                 "uncrypto": "^0.1.3"
-            }
-        },
-        "node_modules/h3-zod": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/h3-zod/-/h3-zod-0.5.3.tgz",
-            "integrity": "sha512-wqlRd/d5d9sNYxmNglnL63J4v5HiZZrcXdLIiU2cBsy5gTwxrSH1AqtNrVkuUleshgNOAQldbuO06phdUIxuKA==",
-            "license": "MIT",
-            "peerDependencies": {
-                "h3": "^1.6.0",
-                "zod": "^3.21.0"
             }
         },
         "node_modules/has-flag": {
@@ -18593,9 +18562,9 @@
             }
         },
         "node_modules/zod": {
-            "version": "3.25.76",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+            "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"

--- a/nuxt-app/package.json
+++ b/nuxt-app/package.json
@@ -28,7 +28,6 @@
         "@pinia/nuxt": "^1.0.1",
         "@types/google.maps": "^3.55.3",
         "@ubclaunchpad/vue-fathom": "^2.0.0",
-        "h3-zod": "^0.5.3",
         "html5-qrcode": "^2.3.8",
         "isomorphic-dompurify": "~2.20.0",
         "nodemailer": "^9.0.3",
@@ -39,7 +38,7 @@
         "vite-svg-loader": "^5.1.0",
         "vue-json-pretty": "^2.5.0",
         "web-haptics": "^0.0.6",
-        "zod": "^3.22.4"
+        "zod": "^4.4.3"
     },
     "devDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "^4.1.1",

--- a/nuxt-app/server/api/checkin/scan.post.ts
+++ b/nuxt-app/server/api/checkin/scan.post.ts
@@ -3,10 +3,6 @@ import { CheckinScanSchema } from '~/server/utils/schema'
 export default defineEventHandler(async (event) => {
     await requireDirectusUser(event)
 
-    // Validated the same way as every other route here, rather than via `h3-zod`'s
-    // `useValidatedBody`. That package was last published in January 2024, pins `zod ^3`, and so
-    // blocked Zod 4 for the sake of one call site — this one. The six sibling routes already used
-    // `safeParse` + `createError`, so dropping it also removes the odd one out.
     const parseResult = CheckinScanSchema.safeParse(await readBody(event))
     if (!parseResult.success) {
         throw createError({

--- a/nuxt-app/server/api/checkin/scan.post.ts
+++ b/nuxt-app/server/api/checkin/scan.post.ts
@@ -1,10 +1,20 @@
-import { useValidatedBody } from 'h3-zod'
 import { CheckinScanSchema } from '~/server/utils/schema'
 
 export default defineEventHandler(async (event) => {
     await requireDirectusUser(event)
 
-    const { ticketCode } = await useValidatedBody(event, CheckinScanSchema)
+    // Validated the same way as every other route here, rather than via `h3-zod`'s
+    // `useValidatedBody`. That package was last published in January 2024, pins `zod ^3`, and so
+    // blocked Zod 4 for the sake of one call site — this one. The six sibling routes already used
+    // `safeParse` + `createError`, so dropping it also removes the odd one out.
+    const parseResult = CheckinScanSchema.safeParse(await readBody(event))
+    if (!parseResult.success) {
+        throw createError({
+            statusCode: 400,
+            message: parseResult.error.issues[0]?.message ?? 'Ungültiger Ticket-Code',
+        })
+    }
+    const { ticketCode } = parseResult.data
 
     const directus = useAuthenticatedDirectus()
 

--- a/nuxt-app/server/api/email.post.ts
+++ b/nuxt-app/server/api/email.post.ts
@@ -15,7 +15,7 @@ export default defineEventHandler(async (event) => {
     const parseResult = EmailSchema.safeParse(rawBody)
     if (!parseResult.success) {
         const issue = parseResult.error.issues[0]
-        const key = issue?.path?.[0] ?? 'input'
+        const key = String(issue?.path?.[0] ?? 'input')
         const message = issue?.message ?? 'Validation error'
         throw createError({ statusCode: 400, message: `${key}: ${message}` })
     }

--- a/nuxt-app/server/api/speaker-portal/submit.post.ts
+++ b/nuxt-app/server/api/speaker-portal/submit.post.ts
@@ -53,7 +53,7 @@ export default defineEventHandler(async (event) => {
     // Validate form data with Zod
     const parseResult = SpeakerSubmissionSchema.safeParse(rawData)
     if (!parseResult.success) {
-        const firstError = parseResult.error.errors[0]
+        const firstError = parseResult.error.issues[0]
         throw createError({
             statusCode: 400,
             message: firstError?.message || 'Ungültige Formulardaten',

--- a/nuxt-app/server/api/ticket-portal/submit.post.ts
+++ b/nuxt-app/server/api/ticket-portal/submit.post.ts
@@ -20,7 +20,7 @@ export default defineEventHandler(async (event) => {
     // Validate form data with Zod
     const parseResult = TicketProfileSchema.safeParse(body.data)
     if (!parseResult.success) {
-        const firstError = parseResult.error.errors[0]
+        const firstError = parseResult.error.issues[0]
         throw createError({
             statusCode: 400,
             message: firstError?.message || 'Ungültige Formulardaten',

--- a/nuxt-app/server/api/tickets/create-checkout.post.ts
+++ b/nuxt-app/server/api/tickets/create-checkout.post.ts
@@ -154,7 +154,7 @@ export default defineEventHandler(async (event) => {
     const parseResult = CreateCheckoutSchema.safeParse(rawBody)
     if (!parseResult.success) {
         const issue = parseResult.error.issues[0]
-        const key = issue?.path?.[0] ?? 'input'
+        const key = String(issue?.path?.[0] ?? 'input')
         const message = issue?.message ?? 'Validierungsfehler'
         throw createError({ statusCode: 400, message: `${key}: ${message}` })
     }

--- a/nuxt-app/server/api/tickets/validate-discount.post.ts
+++ b/nuxt-app/server/api/tickets/validate-discount.post.ts
@@ -7,7 +7,7 @@ export default defineEventHandler(async (event) => {
     const parseResult = ValidateDiscountSchema.safeParse(rawBody)
     if (!parseResult.success) {
         const issue = parseResult.error.issues[0]
-        const key = issue?.path?.[0] ?? 'input'
+        const key = String(issue?.path?.[0] ?? 'input')
         const message = issue?.message ?? 'Validierungsfehler'
         throw createError({ statusCode: 400, message: `${key}: ${message}` })
     }

--- a/nuxt-app/server/api/vote.post.ts
+++ b/nuxt-app/server/api/vote.post.ts
@@ -11,7 +11,7 @@ export default defineEventHandler(async (event) => {
     const parseResult = VoteSchema.safeParse(rawBody)
     if (!parseResult.success) {
         const issue = parseResult.error.issues[0]
-        const key = issue?.path?.[0] ?? 'input'
+        const key = String(issue?.path?.[0] ?? 'input')
         const message = issue?.message ?? 'Validation error'
         throw createError({ statusCode: 400, message: `${key}: ${message}` })
     }

--- a/nuxt-app/server/utils/schema.ts
+++ b/nuxt-app/server/utils/schema.ts
@@ -125,8 +125,6 @@ export const CompanyBillingSchema = z.object({
 export const CreateCheckoutSchema = z
     .object({
         conferenceId: z.string().uuid('Ungültige Konferenz-ID.'),
-        // `error`, not `errorMap` — Zod 4 replaced the latter. Verified to produce the identical
-        // message, and `message:` is itself deprecated in Zod 4, so this is the current form.
         purchaseType: z.enum(['personal', 'company'], {
             error: 'Bitte wähle zwischen Privat oder Firma.',
         }),

--- a/nuxt-app/server/utils/schema.ts
+++ b/nuxt-app/server/utils/schema.ts
@@ -125,8 +125,10 @@ export const CompanyBillingSchema = z.object({
 export const CreateCheckoutSchema = z
     .object({
         conferenceId: z.string().uuid('Ungültige Konferenz-ID.'),
+        // `error`, not `errorMap` — Zod 4 replaced the latter. Verified to produce the identical
+        // message, and `message:` is itself deprecated in Zod 4, so this is the current form.
         purchaseType: z.enum(['personal', 'company'], {
-            errorMap: () => ({ message: 'Bitte wähle zwischen Privat oder Firma.' }),
+            error: 'Bitte wähle zwischen Privat oder Firma.',
         }),
         purchaser: PurchaserSchema,
         company: CompanyBillingSchema.optional(),


### PR DESCRIPTION
`zod 3.25.76 → 4.4.3`, and **`h3-zod` removed**.

`h3-zod` existed for exactly **one call site** and pinned `zod ^3`, so a package last published in **January 2024** was holding back a major. It also peers `h3 ^1.6.0` while Nuxt 4 resolves `h3 2.x` for the server — already a mismatch before Zod entered the picture.

That one site, `server/api/checkin/scan.post.ts`, now validates the way **its six sibling routes already did**: `Schema.safeParse(await readBody(event))` + `createError({ statusCode: 400 })`. So this removes a dependency *and* the odd one out. I checked the consumer first: `pages/admin/checkin.vue` reads `err?.data?.message || err?.message`, which the house pattern populates, whereas `h3-zod` put the whole `ZodError` in `data`.

## Validation behaviour is unchanged — measured, not assumed

Zod 4 rewrote its string-format validators, and this app validates emails on the newsletter and contact paths, so *"does it compile"* wasn't the question. I ran the **real schemas** against a fixed set of **50 inputs** on Zod 3, then again on Zod 4, and diffed the accept/reject outcomes:

> **identical** — plus-tags, IDN domains (`münchen.de`), quoted local parts, double dots, `ip@[127.0.0.1]`, every URL and UUID case, plus `z.preprocess` and `.refine`.

## Five type errors — both causes real, both fixed

The ratchet caught 263 → 268. Neither was absorbed into the baseline:

- **`issue.path` is now `PropertyKey[]`** (was `(string | number)[]`), so `` `${key}` `` on a path segment became `TS2731` in four routes. Zod is flagging a genuine hazard — converting a symbol in a template literal *throws at runtime*. Now `String(...)`. Our schemas have no symbol keys so it was never reachable, but the type is honest and the fix is free.
- **`errorMap` → `error`** on `z.enum`, one site. Confirmed empirically that `error:`, `error: () => …` and the deprecated `message:` all yield the identical string; took `error:` as the current form.

> Worth noting: the two `.errors` hits in `scan.post.ts` are **Directus SDK** errors, not ZodErrors, so they're untouched. The real `ZodError.errors` removals were in `ticket-portal/submit.post.ts` and `speaker-portal/submit.post.ts`, now `.issues`.

## Default messages changed wording

Custom German messages are preserved exactly. Zod's *defaults* were reworded though, and those reach users on fields carrying no custom message:

| case | Zod 3 | Zod 4 |
| --- | --- | --- |
| missing required string | `Required` | `Invalid input: expected string, received undefined` |
| `.min(1)` on `''` | `String must contain at least 1 character(s)` | `Too small: expected string to have >=1 characters` |
| bad email | `Invalid email` | `Invalid email address` |
| bad URL | `Invalid url` | `Invalid URL` |
| bad enum | `Invalid enum value. Expected 'a' \| 'b', received 'z'` | `Invalid option: expected one of "a"\|"b"` |

Both sets are English on a German-language site, so this is a **wording change, not a regression**. Zod 4 now ships locales — I verified `z.config(z.locales.de())` produces `Ungültige Eingabe: erwartet string, erhalten undefined`. That's a real improvement the upgrade unlocks, **logged as a follow-up** rather than taken here, since it rewrites many user-facing strings and deserves its own review.

## Verification

Endpoints exercised against the **built server**, not just unit-tested:

- `POST /api/vote` with `{}` → **400** (Zod ran)
- rewritten `POST /api/checkin/scan` → **401**, confirming auth still precedes validation

| gate | before | after |
| --- | --- | --- |
| `lint` | 0 errors, 134 warnings | 0 errors, 134 warnings |
| `test` | 52/52 | 52/52 |
| ratchet | 263 | 263 (268 before the two fixes) |
| `build` | exit 0, 30.9 MB | exit 0, 31.3 MB |
| smoke | 18/18 | 18/18 (×3) |
| `npm audit` | 0 | 0 |

**Two smoke runs failed mid-verification and neither was this change.** One was the podcast page under contention. The other was `/feed/news.xml` returning 500 because the **CMS returned 503** — *"App Platform failed to forward this request"*. Corroborated independently: a plain health check against `admin.programmier.bar` returned `HTTP 000` in the same window. The feed route surfaces a CMS outage as a 500, which is exactly why smoke doesn't gate PRs.

## Sequencing change

**`stripe` moves to the end of Phase 5**, as requested — it touches the payment path and may want a colleague's review, so it shouldn't block the genuinely time-unconstrained items. Recorded in the plan.

| remaining | note |
| --- | --- |
| `@directus/sdk` → 24 | must be verified against Directus **11.x**, frozen by the licence block |
| `isomorphic-dompurify` → 3.x | no longer security-driven |
| `stripe` → 22.4.0 | **last** — payment path, 7 files |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkKMceYAzAYLrSyC42FWTf