### PR TITLE
Make loading-screen state per-request; and why the testimonial-seed fix was reverted

### DIFF
--- a/nuxt-app/composables/useLoadingScreen.ts
+++ b/nuxt-app/composables/useLoadingScreen.ts
@@ -15,7 +15,7 @@ export function useLoadingScreen(...dataList: Ref<unknown>[]) {
     const isLoading = useState<boolean>('loading-screen', () => false)
 
     // Called with no arguments this writes `false` rather than reading, which is how
-    // `LoadingScreen.vue` clears the overlay. Keep that: 8 of 34 pages never call this composable, so
+    // `LoadingScreen.vue` clears the overlay. Not all pages use/call this composable, so
     // without the reset, navigating to one of them from a page that was still loading would leave a
     // full-screen overlay stuck. Splitting read from write needs a route-change reset first.
     isLoading.value = dataList.some((data) => !data.value)

--- a/nuxt-app/composables/useLoadingScreen.ts
+++ b/nuxt-app/composables/useLoadingScreen.ts
@@ -14,7 +14,10 @@ export function useLoadingScreen(...dataList: Ref<unknown>[]) {
     // visitor's page renders. `useState` is per-request on the server.
     const isLoading = useState<boolean>('loading-screen', () => false)
 
-    // Set initial state
+    // Called with no arguments this writes `false` rather than reading, which is how
+    // `LoadingScreen.vue` clears the overlay. Keep that: 8 of 34 pages never call this composable, so
+    // without the reset, navigating to one of them from a page that was still loading would leave a
+    // full-screen overlay stuck. Splitting read from write needs a route-change reset first.
     isLoading.value = dataList.some((data) => !data.value)
 
     // Change state on update

--- a/nuxt-app/composables/useLoadingScreen.ts
+++ b/nuxt-app/composables/useLoadingScreen.ts
@@ -1,8 +1,5 @@
 import type { Ref } from 'vue'
-import { reactive, ref, watch } from 'vue'
-
-// Global is loading state
-const isLoading = ref(false)
+import { reactive, watch } from 'vue'
 
 /**
  * Composable to set and get the global state of the loading screen.
@@ -12,6 +9,11 @@ const isLoading = ref(false)
  * @returns The state of the loading screen.
  */
 export function useLoadingScreen(...dataList: Ref<unknown>[]) {
+    // `useState`, not a module-scope `ref`: a module-scope ref is created once per server worker and
+    // shared by every concurrent request, so one visitor's navigation can change what another
+    // visitor's page renders. `useState` is per-request on the server.
+    const isLoading = useState<boolean>('loading-screen', () => false)
+
     // Set initial state
     isLoading.value = dataList.some((data) => !data.value)
 

--- a/nuxt-app/test/useLoadingScreen.test.ts
+++ b/nuxt-app/test/useLoadingScreen.test.ts
@@ -5,7 +5,7 @@ import { ref, type Ref } from 'vue'
 // version with the two properties that matter: it returns a Vue `ref` (so `reactive()` unwraps it
 // exactly as in production), and there is one store per "request", so a value created during a
 // request is reused within it and gone in the next.
-let store: Map<string, Ref<unknown>>
+let store = new Map<string, Ref<unknown>>()
 const newRequest = () => {
     store = new Map()
 }

--- a/nuxt-app/test/useLoadingScreen.test.ts
+++ b/nuxt-app/test/useLoadingScreen.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { ref, type Ref } from 'vue'
+
+// `useLoadingScreen` reads Nuxt's `useState`, which is an auto-import at runtime. Stand in a minimal
+// version with the two properties that matter: it returns a Vue `ref` (so `reactive()` unwraps it
+// exactly as in production), and there is one store per "request", so a value created during a
+// request is reused within it and gone in the next.
+let store: Map<string, Ref<unknown>>
+const newRequest = () => {
+    store = new Map()
+}
+
+beforeEach(() => {
+    newRequest()
+    ;(globalThis as Record<string, unknown>).useState = <T>(key: string, init: () => T) => {
+        if (!store.has(key)) {
+            store.set(key, ref(init()) as Ref<unknown>)
+        }
+        return store.get(key) as Ref<T>
+    }
+})
+
+afterEach(() => {
+    delete (globalThis as Record<string, unknown>).useState
+})
+
+describe('useLoadingScreen', () => {
+    it('does not carry state from one request into the next', async () => {
+        // `isLoading` used to be a module-scope `ref`, created once per server worker and shared by
+        // every concurrent request, so one visitor's pending navigation could show another visitor a
+        // loading screen — and make the server's HTML disagree with that visitor's first client render.
+        const { useLoadingScreen } = await import('../composables/useLoadingScreen')
+
+        const pending = ref<unknown>(null)
+        expect(useLoadingScreen(pending).isLoading).toBe(true)
+
+        newRequest()
+        const loaded = ref<unknown>({ data: 'ready' })
+        expect(useLoadingScreen(loaded).isLoading).toBe(false)
+    })
+
+    it('shares one flag between all callers within a request', async () => {
+        // The page sets the flag by passing its data; `LoadingScreen.vue` calls with no arguments.
+        // Both must observe the same state or the loading screen cannot work at all.
+        //
+        // Note the quirk this pins down: a no-argument call *writes* `false`, because
+        // `[].some(...)` is false. It reads like a getter and is not one. The order in `app.vue`
+        // (LoadingScreen before `<nuxt-page />`) is what stops that clobbering the page's value.
+        const { useLoadingScreen } = await import('../composables/useLoadingScreen')
+
+        const pending = ref<unknown>(null)
+        const fromPage = useLoadingScreen(pending)
+        expect(fromPage.isLoading).toBe(true)
+
+        useLoadingScreen()
+
+        expect(fromPage.isLoading).toBe(false)
+    })
+
+    it('tracks its data list within a request', async () => {
+        const { useLoadingScreen } = await import('../composables/useLoadingScreen')
+
+        const data = ref<unknown>(null)
+        const state = useLoadingScreen(data)
+        expect(state.isLoading).toBe(true)
+
+        data.value = { data: 'ready' }
+        await new Promise((resolve) => setTimeout(resolve, 0))
+        expect(state.isLoading).toBe(false)
+    })
+})


### PR DESCRIPTION
You asked for both fixes. **One shipped, one turned out not to be a bug — and I reverted it rather than ship a change that fixes nothing.**

Branched off `main` rather than the shared branch so it doesn't tangle with #237, which is still open.

## Shipped: `useLoadingScreen` was module-scope state

```diff
-// Global is loading state
-const isLoading = ref(false)
-
 export function useLoadingScreen(...dataList: Ref<unknown>[]) {
+    const isLoading = useState<boolean>('loading-screen', () => false)
```

A module-scope `ref` is created **once per server worker and shared by every concurrent request** — the footgun Nuxt documents explicitly. The mechanism is real here: `useAsyncData` awaits during SSR, so two requests interleave, and request A can resume and render using request B's flag.

`useState` is per-request on the server and serialised into the payload. Confirmed present as `"loading-screen"` in the payload after the change.

**What I did not do: claim this fixes the podcast-page hydration mismatch.** `isLoading` is `false` on both sides in normal operation, and I did **not** reproduce a live race — hammering six pages concurrently, three rounds, never rendered the overlay. That shows no regression, not a demonstrated fix. This stands on the documented anti-pattern, not on a reproduction, and I'd rather say so than imply I caught it in the act.

Behaviour within a request is unchanged, pinned by three tests — including the quirk worth knowing about: **calling `useLoadingScreen()` with no arguments *writes* `false`** rather than reading, because `[].some(...)` is false. It reads like a getter and isn't one. The order in `app.vue` (`LoadingScreen` before `<nuxt-page />`) is the only thing stopping that from clobbering the page's value.

## Reverted: `useWeightedRandomSelection` is not a hydration-mismatch source

I had told you the hourly seed was "a genuine latent instance of this bug class". **That was wrong.** The evidence:

I wrote the fix (seed pinned in `useState`), then built a browser test that reproduces the real trigger — `addInitScript` shifting the client's clock 61 minutes before any page JS runs, so the client's first render lands in the next hourly bucket:

| build | `/meetup` | `/konferenz` | `/` |
| --- | --- | --- | --- |
| with the seed fix | 0 warnings | 0 | 0 |
| **negative control (old recomputing seed)** | **0 warnings** | **0** | **0** |

The negative control passing means the test proves nothing — so I looked for why, instead of shipping it:

```vue
<ClientOnly>
  <GenericLazyList class="flex" :items="randomizedTestimonials" …>
```

`TestimonialSlider.vue:10` wraps the entire list in **`<ClientOnly>`**. Testimonials are never server-rendered — confirmed against production, where the SSR HTML contains no testimonial text at all, only the component's stylesheet link. There is nothing for hydration to compare, so the seed cannot cause a mismatch however far the clocks diverge.

The change would also have made things slightly worse: pinning the seed in the payload ties rotation to *when the page was cached* rather than when it is viewed, and adds a payload entry — for no benefit. So it is reverted.

(13 testimonials exist against a `maxCount` of 5, so the weighted selection really does run. The path is reachable; it just isn't part of SSR.)

## The podcast-page mismatch is still unexplained

Both of my leads are now ruled out. The open item stands, and everything ruled out so far is recorded in #237's plan entry so nobody repeats it.

## Verification

| gate | result |
| --- | --- |
| `lint` | 0 errors, 134 warnings (unchanged) |
| `test` | **55/55** (52 + 3 new) |
| ratchet | 263 (unchanged) |
| `build` | exit 0, 31.3 MB (unchanged) |
| `prettier --check` | clean on both changed files |

**Plan document deliberately untouched here.** The hydration write-up lives in #237, which is still open; editing the same paragraphs from two branches would guarantee a conflict. I'll amend the plan — recording the `ClientOnly` finding and this fix — in a follow-up once #237 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkKMceYAzAYLrSyC42FWTf